### PR TITLE
Add magnetic size options

### DIFF
--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -34,6 +34,7 @@ const ACheckbox = forwardRef(
       disabled = false,
       hint,
       indeterminate = false,
+      size = "default",
       onClick,
       required,
       rules,
@@ -135,7 +136,9 @@ const ACheckbox = forwardRef(
 
     const boxProps = {
       "aria-hidden": "true",
-      className: "a-checkbox__box"
+      className: `a-checkbox__box${
+        size && (size === "medium" || size === "small") ? ` a-${size}-box` : ""
+      }`
     };
 
     if (!disabled && !["danger", "warning"].includes(workingValidationState)) {
@@ -178,7 +181,7 @@ const ACheckbox = forwardRef(
             }
           />
           <span {...boxProps}>
-            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15">
               <path d={currentPath} />
             </svg>
           </span>
@@ -249,7 +252,12 @@ ACheckbox.propTypes = {
   /**
    * Toggles wrapping of long text in the label.
    */
-  wrap: PropTypes.bool
+  wrap: PropTypes.bool,
+  /**
+   * Size options ["default","medium","small"]
+   * Default size is 15px, Magnetic Medium = 20px, Magnetic Small = 16px
+   */
+  size: PropTypes.oneOf(["default", "small", "medium"])
 };
 
 ACheckbox.displayName = "ACheckbox";

--- a/framework/components/ACheckbox/ACheckbox.mdx
+++ b/framework/components/ACheckbox/ACheckbox.mdx
@@ -191,6 +191,17 @@ The `ACheckbox` component inherits passed props.
 `}
 />
 
+## Size options
+
+<Playground
+  code={`<div className="d-flex flex-column">
+  <ACheckbox >Default - legacy (15px)</ACheckbox>
+  <ACheckbox size={"small"}>Magnetic Small (16px)</ACheckbox>
+  <ACheckbox size={"medium"}>Magnetic Medium (20px)</ACheckbox>
+</div>
+`}
+/>
+
 ## Accessibility Notes
 
 By default, `ACheckbox` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [checkbox](https://www.w3.org/TR/wai-aria/#checkbox).

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -2,6 +2,8 @@
 
 $checkbox-box-border-radius: $border-radius--md;
 $checkbox-box-side-length: rem(0.9375);
+$checkbox-box-side-length-magna-medium: rem(1.25);
+$checkbox-box-side-length-magna-small: rem(1);
 $checkbox-icon-size: $font-size--xxs;
 $checkbox-icon-padding-left: $base-padding-xsmall;
 $checkbox-label-padding-left: $base-padding-small;
@@ -145,6 +147,24 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
 
     &:hover:after {
       opacity: 0.6;
+    }
+  }
+
+  &__box.a-medium-box {
+    height: $checkbox-box-side-length-magna-medium;
+    width: $checkbox-box-side-length-magna-medium;
+    &:after {
+      height: $checkbox-box-side-length-magna-medium;
+      width: $checkbox-box-side-length-magna-medium;
+    }
+  }
+
+  &__box.a-small-box {
+    height: $checkbox-box-side-length-magna-small;
+    width: $checkbox-box-side-length-magna-small;
+    &:after {
+      height: $checkbox-box-side-length-magna-small;
+      width: $checkbox-box-side-length-magna-small;
     }
   }
 


### PR DESCRIPTION
**What is the current behavior?** <!--(You can also link to an open issue here)-->
Only supports legacy size = 15px


**What is the new behavior (if this is a feature change)?**
Supports default = 15px, small = 16px, medium = 20px


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->
no


**Other information**:
<img width="236" alt="Screen Shot 2022-12-16 at 5 32 56 PM" src="https://user-images.githubusercontent.com/46496881/208207964-624f608b-11f6-42e8-9f4e-359bd035e08e.png">


