### PR TITLE
fix: add missing react imports

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -1,4 +1,4 @@
-import {forwardRef} from "react";
+import React, {forwardRef} from "react";
 import PropTypes from "prop-types";
 
 import AModal from "../AModal/AModal";

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -1,4 +1,4 @@
-import {forwardRef, useContext, useEffect, useRef} from "react";
+import React, {forwardRef, useContext, useEffect, useRef} from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 

--- a/framework/components/APageOverlay/APageOverlay.js
+++ b/framework/components/APageOverlay/APageOverlay.js
@@ -1,4 +1,4 @@
-import {forwardRef} from "react";
+import React, {forwardRef} from "react";
 
 import "./APageOverlay.scss";
 

--- a/framework/components/APageOverlay/APageOverlay.mdx
+++ b/framework/components/APageOverlay/APageOverlay.mdx
@@ -1,5 +1,5 @@
 ---
-name: APageOverlay
+name: Page Overlay
 route: /components/page-overlay
 components: APageOverlay
 ---


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
A fix for using components from Magna React that do not explicitly import `react`.


**What is the current behavior?** <!--(You can also link to an open issue here)-->
When importing `ADrawer`, `AModal`, or `APageOverlay` into an application, a runtime error occurs: `React is not defined`

**What is the new behavior (if this is a feature change)?**

Adds missing React import to affected components.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:


