### PR TITLE
fix: add prop for custom class to ADrawerContent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,8 @@
 - [ ] The ESLint plugin has been updated if a new component is added
 - [ ] Test have been added or modified, if appropriate
 - [ ] Has been verified locally
-
+- [ ] The component should accept a class name as a prop, if appropriate
+- [ ] The component should accept a forward ref, if appropriate
 
 **What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
 <!--

--- a/framework/components/ADrawer/ADrawerContent.js
+++ b/framework/components/ADrawer/ADrawerContent.js
@@ -1,10 +1,20 @@
-import React from "react";
+import React, {forwardRef} from "react";
 
 import "./ADrawerContent.scss";
 
-const ADrawerContent = ({children}) => {
-  return <div className="a-drawer__content">{children}</div>;
-};
+const ADrawerContent = forwardRef(
+  ({children, className: propsClassName, ...rest}, ref) => {
+    let className = "a-drawer__content";
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+    return (
+      <div ref={ref} className={className} {...rest}>
+        {children}
+      </div>
+    );
+  }
+);
 
 ADrawerContent.displayName = "ADrawerContent";
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally
- [ ] The component should accept a class name as a prop, if appropriate
- [ ] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
Allows a user to pass a custom class to the `ADrawerContent` component.


**What is the current behavior?** <!--(You can also link to an open issue here)-->

* The `ADrawerContent` component does not accept a class name as a prop.
* The `ADrawerContent` component does not accept a forward ref.


**What is the new behavior (if this is a feature change)?**

* The `ADrawerContent` component accepts a class name as a prop.
* The `ADrawerContent` component accepts a forward ref.


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:
Thought it would be a good idea to add these two type of common props to the pull request template in case somebody forgets about it while developing.

