### PR TITLE
Add basic truncation to table header cells

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -4,6 +4,7 @@ import React, {forwardRef, useMemo, useRef, useCallback, useState} from "react";
 import AInView from "../AInView";
 import AIcon from "../AIcon";
 import ASimpleTable from "../ASimpleTable";
+import ATooltip from "../ATooltip";
 import "./ADataTable.scss";
 
 /**
@@ -34,14 +35,33 @@ const ADataTableWrapper = React.forwardRef(
 );
 ADataTableWrapper.displayName = "ADataTableWrapper";
 
-const TableHeader = React.forwardRef(({className, ...rest}, ref) => (
-  <th
-    ref={ref}
-    role="columnheader"
-    className={`a-data-table__header${className ? ` ${className}` : ""}`}
-    {...rest}
-  />
-));
+const TableHeader = React.forwardRef(({className, wrap, ...rest}, ref) => {
+  if (wrap) {
+    const {style, children} = rest;
+
+    return (
+      <th
+        ref={ref}
+        role="columnheader"
+        className={`a-data-table__header${className ? ` ${className}` : ""}`}
+        {...rest}
+      >
+        <div className="a-data-table__headerWrap" style={style}>
+          {children}
+        </div>
+      </th>
+    );
+  }
+
+  return (
+    <th
+      ref={ref}
+      role="columnheader"
+      className={`a-data-table__header${className ? ` ${className}` : ""}`}
+      {...rest}
+    />
+  );
+});
 TableHeader.displayName = "TableHeader";
 
 const TableRow = React.forwardRef(
@@ -177,7 +197,9 @@ const ADataTable = forwardRef(
                         .trim(),
                       role: "columnheader",
                       scope: "col",
-                      "aria-label": x.name
+                      "aria-label": x.name,
+                      style: x.style,
+                      wrap: x.wrap
                     };
 
                     const sortableBtnProps = {};

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -381,6 +381,57 @@ In this example, the associated more details drawer that is opened is used to de
 `}
 />
 
+### Truncated Header Text
+
+_This requires setting a width on the header cell, and does not account for responsive layouts_
+
+<Playground
+  code={`() => {
+  const [sort, setSort] = useState();
+  const headers = [
+     {
+      name: "Sortable Truncated header text",
+      key: "a",
+      align: "start",
+      className: "text-capitalize",
+      sortable: true,
+      style: {
+        width: "60px"
+      }
+    },
+    {
+      name: "Truncated header text",
+      key: "b",
+      align: "end",
+      className: "text-capitalize",
+      wrap: true,
+      style: {
+        width: "60px"
+      }
+    }
+  ];
+  const items = [
+
+    {
+      a: 10.5,
+      b: 100
+    }
+
+];
+return (
+
+<ADataTable
+  striped
+  tight
+  headers={headers}
+  items={items}
+  className="mx-auto"
+  style={{maxWidth: 500}}
+  sort={sort}
+  onSort={(s) => setSort(s)}
+/>
+); } `} />
+
 ## Expandable Rows
 
 <Playground

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -53,12 +53,22 @@ $hidden-table-col-width: 45px;
         margin: 0;
         background: transparent;
         cursor: pointer;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: inherit;
       }
       &.a-icon {
         vertical-align: middle;
         width: 18px;
       }
     }
+  }
+
+  &__headerWrap {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .text-start {


### PR DESCRIPTION
Resolves #81 

This PR allows for passing style to the table header cell. Using this the header text will truncate if needed.

Given the nature of `<table>` and css, this does not make the table automatically truncate and size columns for responsive layouts. Other table implementations will need to be used for responsive design.

It is recommended to allow a table to horizontal scroll rather than truncate columns header text.