### PR TITLE
Rework table header for auto truncation

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -456,7 +456,11 @@ ADataTable.propTypes = {
   /**
    * Toggles the `tight` display variant. Smaller row heights.
    */
-  tight: PropTypes.bool
+  tight: PropTypes.bool,
+  /**
+   * Automatically truncate header text with ellipses when applicable
+   */
+  truncateHeaders: PropTypes.bool
 };
 
 ADataTable.displayName = "ADataTable";

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -35,24 +35,7 @@ const ADataTableWrapper = React.forwardRef(
 );
 ADataTableWrapper.displayName = "ADataTableWrapper";
 
-const TableHeader = React.forwardRef(({className, wrap, ...rest}, ref) => {
-  if (wrap) {
-    const {style, children} = rest;
-
-    return (
-      <th
-        ref={ref}
-        role="columnheader"
-        className={`a-data-table__header${className ? ` ${className}` : ""}`}
-        {...rest}
-      >
-        <div className="a-data-table__headerWrap" style={style}>
-          {children}
-        </div>
-      </th>
-    );
-  }
-
+const TableHeader = React.forwardRef(({className, ...rest}, ref) => {
   return (
     <th
       ref={ref}
@@ -118,6 +101,7 @@ const ADataTable = forwardRef(
       onScrollToEnd,
       sort,
       selectedItems,
+      truncateHeaders,
       ...rest
     },
     ref
@@ -131,6 +115,9 @@ const ADataTable = forwardRef(
     let className = "a-data-table";
     if (ExpandableComponent) {
       className += " a-data-table--expandable";
+    }
+    if (truncateHeaders) {
+      className += " a-data-table--truncate-headers";
     }
     if (propsClassName) {
       className += ` ${propsClassName}`;
@@ -245,37 +232,46 @@ const ADataTable = forwardRef(
                           {...headerProps}
                           key={`a-data-table_header_${i}`}
                         >
-                          {x.name}
+                          <span className="a-data-table__header__label">
+                            {x.name}
+                          </span>
                         </TableHeader>
                       );
                     }
+
+                    let sortIcon = x.sortable && (
+                      <AIcon
+                        iconSet="magna"
+                        left={x.align === "end"}
+                        right={x.align !== "end"}
+                        className={`a-data-table__header__sort ${
+                          sort && x.key === sort.key
+                            ? "a-data-table__header__sort--active"
+                            : ""
+                        }`}
+                        onClick={sortableBtnProps.onClick}
+                      >
+                        {getSortIconName(x, sort)}
+                      </AIcon>
+                    );
 
                     return (
                       <TableHeader
                         {...headerProps}
                         key={`a-data-table_header_${i}`}
                       >
-                        <button
-                          {...sortableBtnProps}
-                          className="a-data-table__header__sort__button"
-                        >
-                          {x.align !== "end" ? x.name : ""}
-                          {x.sortable && (
-                            <AIcon
-                              iconSet="magna"
-                              left={x.align === "end"}
-                              right={x.align !== "end"}
-                              className={`a-data-table__header__sort ${
-                                sort && x.key === sort.key
-                                  ? "a-data-table__header__sort--active"
-                                  : ""
-                              }`}
-                            >
-                              {getSortIconName(x, sort)}
-                            </AIcon>
-                          )}
-                          {x.align === "end" ? x.name : ""}
-                        </button>
+                        <div className="a-data-table__header__sort-wrap">
+                          {x.align == "end" && sortIcon}
+                          <button
+                            {...sortableBtnProps}
+                            className="a-data-table__header__sort__button"
+                          >
+                            <span className="a-data-table__header__label">
+                              {x.name}
+                            </span>
+                          </button>
+                          {x.align !== "end" && sortIcon}
+                        </div>
                       </TableHeader>
                     );
                   })}

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -86,6 +86,7 @@ import {ADataTable} from "@cisco-sbg-ui/magna-react";
       style={{maxWidth: 500}}
       sort={sort}
       onSort={(s) => setSort(s)}
+      truncateHeaders
     />
   );
 }
@@ -380,57 +381,6 @@ In this example, the associated more details drawer that is opened is used to de
 }
 `}
 />
-
-### Truncated Header Text
-
-_This requires setting a width on the header cell, and does not account for responsive layouts_
-
-<Playground
-  code={`() => {
-  const [sort, setSort] = useState();
-  const headers = [
-     {
-      name: "Sortable Truncated header text",
-      key: "a",
-      align: "start",
-      className: "text-capitalize",
-      sortable: true,
-      style: {
-        width: "60px"
-      }
-    },
-    {
-      name: "Truncated header text",
-      key: "b",
-      align: "end",
-      className: "text-capitalize",
-      wrap: true,
-      style: {
-        width: "60px"
-      }
-    }
-  ];
-  const items = [
-
-    {
-      a: 10.5,
-      b: 100
-    }
-
-];
-return (
-
-<ADataTable
-  striped
-  tight
-  headers={headers}
-  items={items}
-  className="mx-auto"
-  style={{maxWidth: 500}}
-  sort={sort}
-  onSort={(s) => setSort(s)}
-/>
-); } `} />
 
 ## Expandable Rows
 

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -177,29 +177,27 @@ $hidden-table-col-width: 45px;
   }
 
   &--truncate-headers {
-    thead .a-data-table__row {
-      .a-data-table__header {
-        max-width: 1px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+    .a-data-table__header {
+      max-width: 1px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
-        &__sort {
-          &__button {
-            display: inline-flex;
-            overflow: hidden;
-          }
-        }
-
-        &__sort-wrap {
-          display: flex;
-        }
-
-        &__label {
-          text-overflow: ellipsis;
-          white-space: nowrap;
+      &__sort {
+        &__button {
+          display: inline-flex;
           overflow: hidden;
         }
+      }
+
+      &__sort-wrap {
+        display: flex;
+      }
+
+      &__label {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
     }
   }

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -179,9 +179,6 @@ $hidden-table-col-width: 45px;
   &--truncate-headers {
     .a-data-table__header {
       max-width: 1px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
 
       &__sort {
         &__button {

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -43,7 +43,7 @@ $hidden-table-col-width: 45px;
   &__header {
     &__sort {
       &__button {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         outline: none;
         font-family: inherit !important;
@@ -55,22 +55,13 @@ $hidden-table-col-width: 45px;
         margin: 0;
         background: transparent;
         cursor: pointer;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        width: inherit;
       }
       &.a-icon {
         vertical-align: middle;
         width: 20px;
+        cursor: pointer;
       }
     }
-  }
-
-  &__headerWrap {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .text-start {
@@ -180,6 +171,34 @@ $hidden-table-col-width: 45px;
             opacity: 0;
             border: unset;
           }
+        }
+      }
+    }
+  }
+
+  &--truncate-headers {
+    thead .a-data-table__row {
+      .a-data-table__header {
+        max-width: 1px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &__sort {
+          &__button {
+            display: inline-flex;
+            overflow: hidden;
+          }
+        }
+
+        &__sort-wrap {
+          display: flex;
+        }
+
+        &__label {
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          overflow: hidden;
         }
       }
     }


### PR DESCRIPTION
This changes up the DOM structure to support auto truncation with text-overflow ellipsis. 

Note that this is potentially a breaking change with existing header css. Any existing overrides to this effect can hopefully be removed.

Use the `truncateHeaders` prop on `ADataTable` to set auto truncation. Basic example on demo is updated to use this prop


![Screenshot 2023-01-17 at 1 47 01 PM](https://user-images.githubusercontent.com/23561587/212997236-3c3fe1a0-56f6-415b-a345-de8cfc97c09c.png)
![Screenshot 2023-01-17 at 1 47 10 PM](https://user-images.githubusercontent.com/23561587/212997240-e6a7840d-b4c1-49d7-b773-b3fed19f9b16.png)



