### PR TITLE
#111 - add size variants for AModal

### DIFF
--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -28,6 +28,7 @@ const AModal = forwardRef(
       medium,
       large,
       xlarge,
+      onClickOutside,
       ...rest
     },
     ref
@@ -64,7 +65,7 @@ const AModal = forwardRef(
 
     if (withOverlay) {
       return ReactDOM.createPortal(
-        <APageOverlay className={visibilityClass}>
+        <APageOverlay className={visibilityClass} onClick={onClickOutside}>
           <Component
             role="dialog"
             aria-modal="true"
@@ -174,7 +175,12 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   /**
    * Sets the modal width to extra large.
    */
-  xlarge: PropTypes.bool
+  xlarge: PropTypes.bool,
+
+  /**
+   * If not using the `usePopupQuickExit` hook, pass in a function to handle clicking outside of the modal event. `withOverlay` prop must be set to true.
+   */
+  onClickOutside: PropTypes.func
 };
 
 AModal.displayName = "AModal";

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -24,6 +24,10 @@ const AModal = forwardRef(
       withOverlay = true,
       trapFocus = true,
       isOpen,
+      small,
+      medium,
+      large,
+      xlarge,
       ...rest
     },
     ref
@@ -46,6 +50,16 @@ const AModal = forwardRef(
     let contentClassName = `a-modal-container ${visibilityClass}`;
     if (propsClassName) {
       contentClassName += ` ${propsClassName}`;
+    }
+
+    if (small) {
+      contentClassName += " a-modal-container--small";
+    } else if (medium) {
+      contentClassName += " a-modal-container--medium";
+    } else if (large) {
+      contentClassName += " a-modal-container--large";
+    } else if (xlarge) {
+      contentClassName += " a-modal-container--xlarge";
     }
 
     if (withOverlay) {
@@ -85,11 +99,11 @@ AModal.propTypes = {
     // No a11y prop supplied at all
     if (!props["aria-labelledby"] && !props[propName]) {
       const msg = `You did not provide an accessible title to \`${componentName}\`.
-      
+
 You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${componentName}\`. In the case of \`aria-label\`, pass a string describing your modal's content. In the case of \`aria-labelledby\`, pass an ID of a child element that should serve as the title for your modal's content.
-      
+
   - For examples, reference the Magna-React documentation (https://magna-react.vercel.app/components/modal#usage).
-      
+
   - For more information about aria labelling, reference WAI-ARIA (https://w3c.github.io/aria/#aria-label).
 `;
       return new Error(msg);
@@ -140,7 +154,27 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   /**
    * Determines if the modal is opened or closed.
    */
-  isOpen: PropTypes.bool
+  isOpen: PropTypes.bool,
+
+  /**
+   * Sets the modal width to small.
+   */
+  small: PropTypes.bool,
+
+  /**
+   * Sets the modal width to medium.
+   */
+  medium: PropTypes.bool,
+
+  /**
+   * Sets the modal width to large.
+   */
+  large: PropTypes.bool,
+
+  /**
+   * Sets the modal width to extra large.
+   */
+  xlarge: PropTypes.bool
 };
 
 AModal.displayName = "AModal";

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -342,6 +342,49 @@ _This assumes a single direct child, such as `APanel`, as the modal content._
 `}
 />
 
+### With onClickOutside
+
+_`withOverlay` must be true for the `onClickOutside` prop to take effect._
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+    const [open, setOpen] = useState(false);
+    const [size, setSize] = useState("small");
+
+    return (
+      <div>
+        <AButton
+            onClick={() => {setOpen(true)}}>
+            Open Modal
+        </AButton>
+        <AModal
+            aria-labelledby='modal-title'
+            isOpen={open}
+            onClickOutside={() => {setOpen(false)}}
+            {...{[size]: true}}>
+            <APanel type="dialog">
+            <APanelHeader>
+              <APanelTitle id='modal-title'>Modal Demo</APanelTitle>
+              <AButton onClick={() => setOpen(false)} tertiaryAlt icon>
+                <AIcon>close</AIcon>
+              </AButton>
+            </APanelHeader>
+            <APanelBody>
+              Modal content goes here.
+            </APanelBody>
+            <APanelFooter>
+              <AButton>Action</AButton>
+            </APanelFooter>
+          </APanel>
+        </AModal>
+      </div>
+    )
+
+}
+`}
+/>
+
 ## Modal Props
 
 <Props of="AModal" />

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -284,6 +284,64 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+### Size variants
+
+_This assumes a single direct child, such as `APanel`, as the modal content._
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+    const [open, setOpen] = useState(false);
+    const [size, setSize] = useState("small");
+    const ref = useRef();
+    usePopupQuickExit({
+      popupRef: ref,
+      isEnabled: open,
+      onExit: () => setOpen(false)
+    });
+    return (
+      <div>
+        <AButton
+            onClick={() => {setOpen(true); setSize("small")}}>
+            Open Small Modal
+        </AButton>{" "}
+         <AButton
+            onClick={() => {setOpen(true); setSize("medium")}}>
+            Open Medium Modal
+        </AButton>{" "}
+         <AButton
+            onClick={() => {setOpen(true); setSize("large")}}>
+            Open Large Modal
+        </AButton>{" "}
+         <AButton
+            onClick={() => {setOpen(true); setSize("xlarge")}}>
+            Open Extra Large Modal
+        </AButton>
+        <AModal
+            aria-labelledby='modal-title'
+            isOpen={open}
+            {...{[size]: true}}>
+            <APanel ref={ref} type="dialog">
+            <APanelHeader>
+              <APanelTitle id='modal-title'>Modal Demo</APanelTitle>
+              <AButton onClick={() => setOpen(false)} tertiaryAlt icon>
+                <AIcon>close</AIcon>
+              </AButton>
+            </APanelHeader>
+            <APanelBody>
+              Modal content goes here.
+            </APanelBody>
+            <APanelFooter>
+              <AButton>Action</AButton>
+            </APanelFooter>
+          </APanel>
+        </AModal>
+      </div>
+    )
+  }
+`}
+/>
+
 ## Modal Props
 
 <Props of="AModal" />

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -5,6 +5,23 @@
   align-items: center;
   width: 100vw;
   height: 100vh;
+
+  &--small > :first-child {
+    width: 384px;
+    min-width: unset;
+  }
+
+  &--medium > :first-child {
+    width: 576px;
+  }
+
+  &--large > :first-child {
+    width: 768px;
+  }
+
+  &--xlarge > :first-child {
+    width: 912px;
+  }
 }
 
 .a-modal--hidden {


### PR DESCRIPTION
Resolves #111 


This PR adds a prop for each of the four sizes. Additionally, it adds `onClickOutside` so AModal can be a drop in replacement for ADialog