### PR TITLE
#117 - don't hide icon in disabled state

### DIFF
--- a/framework/components/AInputBase/AInputBase.js
+++ b/framework/components/AInputBase/AInputBase.js
@@ -90,7 +90,7 @@ const AInputBase = forwardRef(
           <div className="a-input-base__control">{children}</div>
           {(append || clearable) && (
             <div className="a-input-base__append">
-              {clearable && !readOnly && !disabled && (
+              {clearable && !readOnly && (
                 <AIcon
                   tabIndex={0}
                   role="button"


### PR DESCRIPTION
Resolves #117 


quick test code from Playground inside the docs
```
() => {
  const [status, setStatus] = useState("default");
  const [value, setValue] = useState("autoFocused clearable");
    const [disabled, setDisabled] = useState(false);
  
  useEffect(() => {
    setInterval(() => {
      setDisabled(true)
    }, 2000)
        setInterval(() => {
      setDisabled(false)
    }, 3000)

  }, [setDisabled]);
  
  return (
  <>
    <APanel>
      <APanelHeader>
        <div className="d-flex align-start">
          <ATextInput
            medium
            style={{minWidth: 240}}
            prependIcon="search"
            placeholder="Search"
            clearable
            disabled={disabled}
          />

        </div>
      </APanelHeader>
    </APanel>
    <APanel>
      <APanelHeader>
        <div className="d-flex align-start">
    
                    <ATextInput
            medium
            style={{minWidth: 240}}
            prependIcon="search"
            placeholder="Search"
            clearable
            disabled={true}
          />

        </div>
      </APanelHeader>
    </APanel>
</>
  );
}

```
