### PR TITLE
Add a cellLoader to auto use ASkeleton

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -4,7 +4,7 @@ import React, {forwardRef, useMemo, useRef, useCallback, useState} from "react";
 import AInView from "../AInView";
 import AIcon from "../AIcon";
 import ASimpleTable from "../ASimpleTable";
-import ATooltip from "../ATooltip";
+import {ASkeleton, ASkeletonText} from "../ASkeleton";
 import "./ADataTable.scss";
 
 /**
@@ -325,6 +325,19 @@ const ADataTable = forwardRef(
                       </TableCell>
                     )}
                     {headers.map((y, j) => {
+                      console.log(y.cell, rowItem[y.key]);
+                      const {cellLoading} = rowItem;
+
+                      const content = cellLoading ? (
+                        <ASkeleton noPanel animated style={{padding: 0}}>
+                          <ASkeletonText />
+                        </ASkeleton>
+                      ) : y.cell && y.cell.component ? (
+                        y.cell.component(rowItem)
+                      ) : (
+                        rowItem[y.key]
+                      );
+
                       return (
                         <TableCell
                           key={`a-data-table_cell_${j}`}
@@ -332,9 +345,7 @@ const ADataTable = forwardRef(
                             y.cell?.className || ""
                           }`.trim()}
                         >
-                          {y.cell && y.cell.component
-                            ? y.cell.component(rowItem)
-                            : rowItem[y.key]}
+                          {content}
                         </TableCell>
                       );
                     })}

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -325,11 +325,14 @@ const ADataTable = forwardRef(
                       </TableCell>
                     )}
                     {headers.map((y, j) => {
-                      console.log(y.cell, rowItem[y.key]);
                       const {cellLoading} = rowItem;
 
                       const content = cellLoading ? (
-                        <ASkeleton noPanel animated style={{padding: 0}}>
+                        <ASkeleton
+                          hidePanelBackdrop
+                          animated
+                          style={{padding: 0}}
+                        >
                           <ASkeletonText />
                         </ASkeleton>
                       ) : y.cell && y.cell.component ? (

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -549,6 +549,58 @@ In this example, the associated more details drawer that is opened is used to de
 `}
 />
 
+## Data Table Loading
+
+<Playground
+  code={`() => {
+const headers = [
+    {
+      name: "Alpha",
+      key: "a",
+      align: "end"
+    },
+    {
+      name: "Bravo",
+      key: "b",
+      align: "center"
+    },
+    {
+      name: "Charlie",
+      key: "c"
+    }
+  ];
+  const items = [
+    {
+      a: 11.1,
+      b: 526,
+      c: "aardvark"
+    },
+    {
+      a: 8.9,
+      b: 611,
+      c: "Argentina"
+    },
+    {
+      cellLoading: true
+    }, {
+      cellLoading: true
+    }, {
+      cellLoading: true
+    }
+  ];
+  return (
+    <ADataTable
+      tight
+      headers={headers}
+      items={items}
+      className="mx-auto"
+    />
+  );
+}`
+}
+
+/>
+
 ## Data Table Props
 
 The `ADataTable` component inherits passed props.

--- a/framework/components/ASkeleton/ASkeleton.js
+++ b/framework/components/ASkeleton/ASkeleton.js
@@ -16,12 +16,12 @@ const ASkeleton = forwardRef(
       header,
       horizontal,
       animated,
-      noPanel = false,
+      hidePanelBackdrop = false,
       ...rest
     },
     ref
   ) => {
-    const ContainerComponent = noPanel ? "span" : APanel;
+    const ContainerComponent = hidePanelBackdrop ? "span" : APanel;
 
     let className = baseClass;
 
@@ -80,7 +80,7 @@ ASkeleton.propTypes = {
   /**
    * Use a <span> wrapper instead of `APanel`
    */
-  noPanel: PropTypes.bool
+  hidePanelBackdrop: PropTypes.bool
 };
 
 ASkeleton.displayName = "ASkeleton";

--- a/framework/components/ASkeleton/ASkeleton.js
+++ b/framework/components/ASkeleton/ASkeleton.js
@@ -16,10 +16,13 @@ const ASkeleton = forwardRef(
       header,
       horizontal,
       animated,
+      noPanel = false,
       ...rest
     },
     ref
   ) => {
+    const ContainerComponent = noPanel ? "span" : APanel;
+
     let className = baseClass;
 
     if (propsClassName) {
@@ -45,10 +48,10 @@ const ASkeleton = forwardRef(
     );
 
     return (
-      <APanel ref={ref} className={className} {...rest}>
+      <ContainerComponent ref={ref} className={className} {...rest}>
         {header && <ASkeletonHeader />}
         {content}
-      </APanel>
+      </ContainerComponent>
     );
   }
 );
@@ -73,7 +76,11 @@ ASkeleton.propTypes = {
   /**
    * Show a shine keyframe animation to indicate loading
    */
-  animated: PropTypes.bool
+  animated: PropTypes.bool,
+  /**
+   * Use a <span> wrapper instead of `APanel`
+   */
+  noPanel: PropTypes.bool
 };
 
 ASkeleton.displayName = "ASkeleton";

--- a/framework/components/ASkeleton/ASkeleton.mdx
+++ b/framework/components/ASkeleton/ASkeleton.mdx
@@ -77,6 +77,58 @@ import {ASkeleton, ASkeletonHeader, ASkeletonText, ASkeletonBlock} from "@cisco-
 
 />
 
+## Data Table Loading
+
+<Playground
+  code={`() => {
+const headers = [
+    {
+      name: "Alpha",
+      key: "a",
+      align: "end"
+    },
+    {
+      name: "Bravo",
+      key: "b",
+      align: "center"
+    },
+    {
+      name: "Charlie",
+      key: "c"
+    }
+  ];
+  const items = [
+    {
+      a: 11.1,
+      b: 526,
+      c: "aardvark"
+    },
+    {
+      a: 8.9,
+      b: 611,
+      c: "Argentina"
+    },
+    {
+      cellLoading: true
+    }, {
+      cellLoading: true
+    }, {
+      cellLoading: true
+    }
+  ];
+  return (
+    <ADataTable
+      tight
+      headers={headers}
+      items={items}
+      className="mx-auto"
+    />
+  );
+}`
+}
+
+/>
+
 ## Skeleton Props
 
 The `ASkeleton` component inherits passed props and applies them to the `APanel` root element of the component.

--- a/framework/components/ASkeleton/ASkeleton.mdx
+++ b/framework/components/ASkeleton/ASkeleton.mdx
@@ -40,6 +40,21 @@ import {ASkeleton, ASkeletonHeader, ASkeletonText, ASkeletonBlock} from "@cisco-
     </ASkeleton>`}
 />
 
+## Without Panel backdrop
+
+<Playground
+  code={`<ASkeleton header hidePanelBackdrop>
+      <ASkeleton header nested>
+        <ASkeletonBlock />
+        <ASkeletonText />
+      </ASkeleton>
+      <ASkeleton header nested>
+        <ASkeletonBlock />
+        <ASkeletonText />
+      </ASkeleton>
+    </ASkeleton>`}
+/>
+
 ## Horizontal Layout
 
 <Playground


### PR DESCRIPTION
To make it a bit easier to add a loading state to `ADataTable`, this PR allows the use of a row data object `{cellLoading: true}`. This can be combined with row data objects that have data, and should allow for a full table loading state and infinite scroll situations.


![Screenshot 2023-01-25 at 10 01 23 AM](https://user-images.githubusercontent.com/23561587/214613027-9fa846da-15a4-4f3d-b7ba-a9f69fd0b964.png)
