### PR TITLE
#145 - check if parent a-app to add AToastPlate

### DIFF
--- a/framework/components/AMount/AMount.js
+++ b/framework/components/AMount/AMount.js
@@ -41,13 +41,16 @@ const AMount = forwardRef(
       setToasts: setToasts || setToasts2
     };
 
+    const hasToastPlate =
+      combinedRef.current && combinedRef.current.classList.contains("a-app");
+
     return (
       <TagName {...rest} ref={combinedRef} className={className}>
         <AAppContext.Provider value={appContext}>
           <div ref={newWrapRef} className={wrapClassName}>
             {children}
           </div>
-          <AToastPlate />
+          {hasToastPlate && <AToastPlate />}
         </AAppContext.Provider>
       </TagName>
     );


### PR DESCRIPTION
Adds check on the combined ref for the root class `.a-app` in an effort to check if the `AMount` is the app root or a nested mount.

Resolves #145 