### PR TITLE
Scope AButton medium modifier css class

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -48,7 +48,7 @@ const AButton = forwardRef(
     }
 
     if (medium) {
-      className += " medium";
+      className += " a-button--medium";
     }
 
     if (selectedValues && selectedValues.includes(value)) {

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -466,12 +466,12 @@ $btn-transition: color $transition-duration--extra-fast
     cursor: not-allowed;
   }
 
-  &.medium {
+  &--medium {
     height: 34px;
     padding: 7px 12px;
   }
 
-  &.medium {
+  &--medium {
     &.a-button--icon {
       padding: 8.25px;
       svg.a-icon {

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -467,18 +467,7 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   &--medium {
-    height: 34px;
-    padding: 7px 12px;
-  }
-
-  &--medium {
-    &.a-button--icon {
-      padding: 8.25px;
-      svg.a-icon {
-        width: 14px;
-        height: 14px;
-      }
-    }
+    @include medium-button;
   }
 }
 

--- a/framework/components/AButtonGroup/AButtonGroup.js
+++ b/framework/components/AButtonGroup/AButtonGroup.js
@@ -21,6 +21,7 @@ const AButtonGroup = forwardRef(
       rules,
       selectedValues,
       validationState = "default",
+      medium = false,
       ...rest
     },
     ref
@@ -97,6 +98,10 @@ const AButtonGroup = forwardRef(
       className += ` ${propsClassName}`;
     }
 
+    if (medium) {
+      className += " a-button-group--medium";
+    }
+
     const buttonGroupContext = {
       selectedValues,
       toggleValue: (toggledValue) => {
@@ -158,7 +163,9 @@ AButtonGroup.propTypes = {
   /**
    * Applies a validation state.
    */
-  validationState: PropTypes.oneOf(["default", "warning", "danger"])
+  validationState: PropTypes.oneOf(["default", "warning", "danger"]),
+  /** Magnetic medium sizing */
+  medium: PropTypes.bool
 };
 
 AButtonGroup.displayName = "AButtonGroup";

--- a/framework/components/AButtonGroup/AButtonGroup.mdx
+++ b/framework/components/AButtonGroup/AButtonGroup.mdx
@@ -92,6 +92,49 @@ import {AButtonGroup} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+## Size Variant
+
+<Playground
+  code={`() => {
+  const [selectedValues1, setSelectedValues1] = useState(["One", "Three"]);
+  const [selectedValues2, setSelectedValues2] = useState(["Two"]);
+  const [selectedValues3, setSelectedValues3] = useState(["bar"]);
+  return (
+    <>
+     <div>
+        <h3>Button Group - Medium variant</h3>
+       <AButtonGroup
+          medium
+          selectedValues={selectedValues2}
+          onChange={(_, selectedValues) =>
+            setSelectedValues2(selectedValues)
+          }>
+          <AButton value="One">One</AButton>
+          <AButton value="Two">Two</AButton>
+          <AButton value="Three">Three</AButton>
+        </AButtonGroup>
+        <p>Selected Values: {JSON.stringify(selectedValues2)}</p>
+      </div>
+      <ADivider />
+      <div>
+        <h3>Button Group - Medium button size (verbose)</h3>
+       <AButtonGroup
+          selectedValues={selectedValues2}
+          onChange={(_, selectedValues) =>
+            setSelectedValues2(selectedValues)
+          }>
+          <AButton value="One" medium>One</AButton>
+          <AButton value="Two" medium>Two</AButton>
+          <AButton value="Three" medium>Three</AButton>
+        </AButtonGroup>
+        <p>Selected Values: {JSON.stringify(selectedValues2)}</p>
+      </div>
+    </>
+  );
+}
+`}
+/>
+
 ## Button Group Props
 
 The `AButtonGroup` component inherits passed props.

--- a/framework/components/AButtonGroup/AButtonGroup.scss
+++ b/framework/components/AButtonGroup/AButtonGroup.scss
@@ -120,17 +120,6 @@ $btn-group-icon-font-size: rem(1);
   }
 
   &--medium {
-    .a-button {
-      height: 34px;
-      padding: 7px 12px;
-
-      &.a-button--icon {
-        padding: 8.25px;
-        svg.a-icon {
-          width: 14px;
-          height: 14px;
-        }
-      }
-    }
+    @include medium-button;
   }
 }

--- a/framework/components/AButtonGroup/AButtonGroup.scss
+++ b/framework/components/AButtonGroup/AButtonGroup.scss
@@ -118,4 +118,19 @@ $btn-group-icon-font-size: rem(1);
     margin-left: 0px;
     margin-right: 0px;
   }
+
+  &--medium {
+    .a-button {
+      height: 34px;
+      padding: 7px 12px;
+
+      &.a-button--icon {
+        padding: 8.25px;
+        svg.a-icon {
+          width: 14px;
+          height: 14px;
+        }
+      }
+    }
+  }
 }

--- a/framework/styles/utilities/mixins.scss
+++ b/framework/styles/utilities/mixins.scss
@@ -105,3 +105,19 @@
   width: 1px !important;
   white-space: nowrap !important;
 }
+
+// -----------------------------------------------------------------------------
+// Button sizes
+// -----------------------------------------------------------------------------
+@mixin medium-button {
+  height: 34px;
+  padding: 7px 12px;
+
+  &.a-button--icon {
+    padding: 8.25px;
+    svg.a-icon {
+      width: 14px;
+      height: 14px;
+    }
+  }
+}


### PR DESCRIPTION
- Change `medium` css class to `a-button--medium`
- Add example of medium buttons inside AButtonGroup (verbose)
- Add `medium` prop to `AButtonGroup`

Resolves #155 