### PR TITLE
refactor: add medium button styles to sass mixin

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -467,18 +467,7 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   &--medium {
-    height: 34px;
-    padding: 7px 12px;
-  }
-
-  &--medium {
-    &.a-button--icon {
-      padding: 8.25px;
-      svg.a-icon {
-        width: 14px;
-        height: 14px;
-      }
-    }
+    @include medium-button;
   }
 }
 

--- a/framework/components/AButtonGroup/AButtonGroup.scss
+++ b/framework/components/AButtonGroup/AButtonGroup.scss
@@ -120,17 +120,6 @@ $btn-group-icon-font-size: rem(1);
   }
 
   &--medium {
-    .a-button {
-      height: 34px;
-      padding: 7px 12px;
-
-      &.a-button--icon {
-        padding: 8.25px;
-        svg.a-icon {
-          width: 14px;
-          height: 14px;
-        }
-      }
-    }
+    @include medium-button;
   }
 }

--- a/framework/styles/utilities/mixins.scss
+++ b/framework/styles/utilities/mixins.scss
@@ -105,3 +105,19 @@
   width: 1px !important;
   white-space: nowrap !important;
 }
+
+// -----------------------------------------------------------------------------
+// Button sizes
+// -----------------------------------------------------------------------------
+@mixin medium-button {
+  height: 34px;
+  padding: 7px 12px;
+
+  &.a-button--icon {
+    padding: 8.25px;
+    svg.a-icon {
+      width: 14px;
+      height: 14px;
+    }
+  }
+}


### PR DESCRIPTION
I think a mixin for the button size makes sense so that we can reuse it where needed, but this could also seem a bit excessive. I just worry about the `AButtonGroup` and `AButton` having different declarations for the same thing.