### PR TITLE
fix: listen for mousedown events in useOutsideClick

### DIFF
--- a/framework/hooks/useOutsideClick.js
+++ b/framework/hooks/useOutsideClick.js
@@ -18,10 +18,10 @@ const useOutsideClick = (options) => {
     if (!isEnabled) {
       return;
     }
-    window.addEventListener("click", detectOutside);
+    window.addEventListener("mousedown", detectOutside);
 
     return () => {
-      window.removeEventListener("click", detectOutside);
+      window.removeEventListener("mousedown", detectOutside);
     };
   }, [isEnabled, onClick, detectOutside]);
 };


### PR DESCRIPTION
Closes #143 

`useOutsideClick` used the `click` event listener, which is fired *after* the `mousedown` listener, meaning that there were possibilities for race conditions as it related to components unmounting within the `useOutsideClick`'s container element.

This PR updates `useOutsideClick` to listen to `mousedown` events, meaning that we will be alerted about outside clicks to the container element *before* the user finishes their click. 

[MDN's note about the `mousedown` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/mousedown_event)

> Note: This differs from the [click](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event) event in that click is fired after a full click action occurs; that is, the mouse button is pressed and released while the pointer remains inside the same element. mousedown is fired the moment the button is initially pressed.