### PR TITLE
fix: sync addition and removal of event listener for AMenu click outside

### DIFF
--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -320,7 +320,7 @@ const AMenuBase = forwardRef(
         }
       };
 
-      document.addEventListener("click", clickOutsideHandler);
+      window.addEventListener("click", clickOutsideHandler);
 
       return () => {
         window.removeEventListener("click", clickOutsideHandler);


### PR DESCRIPTION
Closes #171 by syncing the `click` event listeners that are added/removed within `AMenu`.