### PR TITLE
#177 - add toggleSort prop to ADataTable

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -493,7 +493,7 @@ ADataTable.propTypes = {
     direction: PropTypes.oneOf(["asc", "desc"])
   }),
   /**
-   * Allows third click of header sort icon to unset sorting.
+   * Disables third click of header sort icon to unset sorting.
    */
   disableSortReset: PropTypes.bool,
   /**

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -99,7 +99,7 @@ const ADataTable = forwardRef(
       headers,
       maxHeight,
       items,
-      toggleSort = false,
+      disableSortReset = false,
       onSort,
       onScrollToEnd,
       sort,
@@ -215,7 +215,7 @@ const ADataTable = forwardRef(
                           return;
                         }
 
-                        if (!toggleSort) {
+                        if (!disableSortReset) {
                           onSort(
                             sort &&
                               sort.key === x.key &&
@@ -495,7 +495,7 @@ ADataTable.propTypes = {
   /**
    * Allows third click of header sort icon to unset sorting.
    */
-  toggleSort: PropTypes.bool,
+  disableSortReset: PropTypes.bool,
   /**
    * Toggles the `striped` display variant. Darkened backgrounds for alternate rows.
    */

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -99,6 +99,7 @@ const ADataTable = forwardRef(
       headers,
       maxHeight,
       items,
+      toggleSort = false,
       onSort,
       onScrollToEnd,
       sort,
@@ -210,7 +211,11 @@ const ADataTable = forwardRef(
 
                       onClick = () => {
                         setExpandedRows({});
-                        onSort &&
+                        if (!onSort) {
+                          return;
+                        }
+
+                        if (!toggleSort) {
                           onSort(
                             sort &&
                               sort.key === x.key &&
@@ -226,6 +231,17 @@ const ADataTable = forwardRef(
                                       : "asc"
                                 }
                           );
+                        } else {
+                          onSort({
+                            key: x.key,
+                            direction:
+                              sort &&
+                              x.key === sort.key &&
+                              sort.direction === "asc"
+                                ? "desc"
+                                : "asc"
+                          });
+                        }
                       };
                     }
 
@@ -476,6 +492,10 @@ ADataTable.propTypes = {
     key: PropTypes.string,
     direction: PropTypes.oneOf(["asc", "desc"])
   }),
+  /**
+   * Allows third click of header sort icon to unset sorting.
+   */
+  toggleSort: PropTypes.bool,
   /**
    * Toggles the `striped` display variant. Darkened backgrounds for alternate rows.
    */

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -93,6 +93,86 @@ import {ADataTable} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+### Two Stage Sort
+
+By default a table column can be unsorted. Use `toggleSort` to change sorting to flip between "asc" and "desc" on click without the unsorted state.
+
+<Playground
+  code={`() => {
+  const [sort, setSort] = useState();
+  const headers = [
+    {
+      name: "Alpha",
+      key: "a",
+      align: "end",
+      className: "text-capitalize",
+      sortable: true
+    },
+    {
+      name: "Bravo",
+      key: "b",
+      align: "center",
+      sortable: true,
+      sort: false
+    },
+    {
+      name: "Charlie",
+      key: "c",
+      sortable: true,
+      sort: (a, b) =>
+        a.toUpperCase() === b.toUpperCase()
+          ? 0
+          : a.toUpperCase() > b.toUpperCase()
+          ? 1
+          : -1
+    },
+    {
+      name: "Delta",
+      align: "center",
+      cell: {
+        component: (item) => (
+          <a href="/" target="_blank">
+            Details
+          </a>
+        )
+      }
+    }
+  ];
+  const items = [
+    {
+      a: 11.1,
+      b: 526,
+      c: "aardvark"
+    },
+    {
+      a: 8.9,
+      b: 611,
+      c: "Argentina"
+    },
+    {
+      a: 10.5,
+      b: 475,
+      c: "Zanzibar"
+    }
+  ];
+  return (
+    <ADataTable
+      toggleSort
+      striped
+      tight
+      headers={headers}
+      items={items}
+      className="mx-auto"
+      style={{maxWidth: 500}}
+      sort={sort}
+      onSort={(s) => setSort(s)}
+      truncateHeaders
+    />
+  );
+}
+`}
+/>
+
 ### Selectable Rows
 
 Rows can be selected by passing the `isRowSelected` prop to `ADataTable`, which is a function called for every row with the associated data in order to determine if the row should be highlighted in the selected state.

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -95,7 +95,7 @@ import {ADataTable} from "@cisco-sbg-ui/magna-react";
 
 ### Two Stage Sort
 
-By default a table column can be unsorted. Use `toggleSort` to change sorting to flip between "asc" and "desc" on click without the unsorted state.
+By default a table column can be unsorted. Use `disableSortReset` to change sorting to flip between "asc" and "desc" on click without the unsorted state.
 
 <Playground
   code={`() => {
@@ -157,7 +157,7 @@ By default a table column can be unsorted. Use `toggleSort` to change sorting to
   ];
   return (
     <ADataTable
-      toggleSort
+      disableSortReset
       striped
       tight
       headers={headers}


### PR DESCRIPTION
Resolves #177

- Adds `toggleSort` prop to `ADataTable` to swap behavior to simple sorting that skips the "unsorted" state