### PR TITLE
#178 - default to compact; adjust compact row height

### DIFF
--- a/framework/components/ASimpleTable/ASimpleTable.js
+++ b/framework/components/ASimpleTable/ASimpleTable.js
@@ -30,18 +30,14 @@ const ASimpleTable = forwardRef(
 
     if (tight) {
       className += ` a-simple-table--tight`;
-    }
-
-    if (compact) {
+    } else if (compact) {
       className += ` a-simple-table--compact`;
-    }
-
-    if (comfy) {
+    } else if (comfy) {
       className += ` a-simple-table--comfy`;
-    }
-
-    if (spacious) {
+    } else if (spacious) {
       className += ` a-simple-table--spacious`;
+    } else {
+      className += ` a-simple-table--compact`;
     }
 
     if (propsClassName) {

--- a/framework/components/ASimpleTable/ASimpleTable.scss
+++ b/framework/components/ASimpleTable/ASimpleTable.scss
@@ -7,7 +7,7 @@ $table__total--padding-top: 15px;
 $table__title--font-size: 18px;
 $table-row-height: 40px;
 $table-row-height-tight: 30px;
-$table-row-height-compact: 37px;
+$table-row-height-compact: 34px;
 $table-row-height-comfy: 45px;
 $table-row-height-spacious: 53px;
 $table-cell-padding-left-right: 15px;


### PR DESCRIPTION
Resolves #178

- Adjust compact row height to end up at ~38px 
- Default to `compact` table variant