### PR TITLE
feat: add vertical tabs prop to ATabGroup

### DIFF
--- a/framework/components/ATabs/ATab.js
+++ b/framework/components/ATabs/ATab.js
@@ -35,7 +35,8 @@ const ATab = forwardRef(
     const combinedRef = useCombinedRefs(ref, tabRef);
     const [tabId, setTabId] = useState(null);
     const [isSelected, setIsSelected] = useState(null);
-    const {tabChanged, setTabChanged, scrollToMe} = useContext(ATabContext);
+    const {tabChanged, setTabChanged, scrollToMe, vertical} =
+      useContext(ATabContext);
     useEffect(() => {
       if (tabKey) return;
       if (!tabId) {
@@ -68,6 +69,14 @@ const ATab = forwardRef(
     let className = "a-tab-group__tab";
     if ((tabKey && selected) || isSelected) {
       className += " a-tab-group__tab--selected";
+
+      if (vertical) {
+        className += " a-tab-group__tab--selected--vertical";
+      }
+    }
+
+    if (vertical) {
+      className += " a-tab-group__tab--vertical";
     }
 
     if (propsClassName) {

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -16,6 +16,7 @@ const ATabGroup = forwardRef(
       oversized,
       scrolling,
       tall,
+      vertical = false,
       ...rest
     },
     ref
@@ -55,6 +56,11 @@ const ATabGroup = forwardRef(
 
     if (scrolling) {
       className += " a-tab-group--scrolling";
+    }
+
+    let tabContentClassName = "a-tab-group__tab-content";
+    if (vertical) {
+      tabContentClassName += " a-tab-group__tab-content--vertical";
     }
 
     if (propsClassName) {
@@ -108,7 +114,8 @@ const ATabGroup = forwardRef(
               0
             )
         );
-      }
+      },
+      vertical
     };
 
     return (
@@ -142,14 +149,16 @@ const ATabGroup = forwardRef(
 
               const finalTranslateValue = Math.max(translateValue, 0);
               setTranslateX(-finalTranslateValue);
-            }}>
+            }}
+          >
             <AIcon>chevron-left</AIcon>
           </AButton>
         )}
         <div className="a-tab-group__tab-wrapper">
           <div
-            className="a-tab-group__tab-content"
-            style={{transform: `translateX(${translateX}px)`}}>
+            className={tabContentClassName}
+            style={{transform: `translateX(${translateX}px)`}}
+          >
             <ATabContext.Provider value={tabContext}>
               {children}
             </ATabContext.Provider>
@@ -185,7 +194,8 @@ const ATabGroup = forwardRef(
               );
 
               setTranslateX(-finalTranslateValue);
-            }}>
+            }}
+          >
             <AIcon>chevron-right</AIcon>
           </AButton>
         )}

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -50,6 +50,9 @@ const ATabGroup = forwardRef(
 
     if (oversized) {
       className += " a-tab-group--size-oversized";
+      if (vertical) {
+        className += " a-tab-group--size-oversized--vertical";
+      }
     } else if (tall) {
       className += " a-tab-group--size-tall";
     }

--- a/framework/components/ATabs/ATabs.mdx
+++ b/framework/components/ATabs/ATabs.mdx
@@ -51,6 +51,17 @@ import {ATabGroup, ATab, ATabHeading} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+## Vertical Tabs
+
+<Playground
+  code={`<ATabGroup vertical>
+  <ATab>One</ATab>
+  <ATab>Two</ATab>
+  <ATab selected>Three</ATab>
+</ATabGroup>
+`}
+/>
+
 ## Tab Group Props
 
 The `ATabGroup` component inherits passed props.

--- a/framework/components/ATabs/ATabs.mdx
+++ b/framework/components/ATabs/ATabs.mdx
@@ -178,6 +178,28 @@ Tabs will render in the DOM as anchor tags if the `href` property is defined.
 `}
 />
 
+### Oversized Vertical
+
+<Playground
+  code={`<>
+  <ATabGroup oversized vertical>
+    <ATab>
+      <ATabHeading>Heading One</ATabHeading>
+      Subtext One
+    </ATab>
+    <ATab>
+      <ATabHeading>Heading Two</ATabHeading>
+      Subtext Two
+    </ATab>
+    <ATab selected>
+      <ATabHeading>Heading Three</ATabHeading>
+      Subtext Three
+    </ATab>
+  </ATabGroup>
+</>
+`}
+/>
+
 ## Router Integrations
 
 On `ATab`, set the `component` property to your router's link type, for example:

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -38,8 +38,6 @@ $tab-oversized-margin: 0;
     &--vertical:active,
     &--vertical:focus,
     &--vertical:hover {
-      color: map-deep-get($theme, "tabs", "text-color--selected");
-
       @include vertical-tab-bar(
         $tab-bottom-bar-height,
         map-deep-get($theme, "tabs", "bar-color--hover")
@@ -105,12 +103,16 @@ $tab-oversized-margin: 0;
         "oversized-background-color"
       );
 
-      &:last-of-type {
+      &--vertical:not(:last-of-type) {
+        border-bottom: unset;
+      }
+
+      &:not(&--vertical):last-of-type {
         border-right: $border-width solid
           map-deep-get($theme, "control", "stroke-color");
       }
 
-      &--selected {
+      &--selected:not(&--vertical) {
         background-color: $tab-oversized--selected-background-color;
         border-top: $border-width solid transparent;
         border-bottom: $border-width solid transparent;
@@ -120,10 +122,31 @@ $tab-oversized-margin: 0;
         );
       }
 
-      &:focus,
-      &:hover {
+      &--selected--vertical {
+        background-color: $tab-oversized--selected-background-color;
+        @include vertical-tab-bar(
+          $tab-top-bar-height,
+          map-deep-get($theme, "tabs", "bar-color--selected")
+        );
+      }
+
+      &:not(&--vertical):focus,
+      &:not(&--vertical):hover {
         border-top: $border-width solid transparent;
         @include tab-bar(
+          $tab-top-bar-height,
+          map-deep-get($theme, "tabs", "bar-color--hover")
+        );
+        background-color: map-deep-get(
+          $theme,
+          "tabs",
+          "oversized--hover-background-color"
+        );
+      }
+
+      &--vertical:focus,
+      &--vertical:hover {
+        @include vertical-tab-bar(
           $tab-top-bar-height,
           map-deep-get($theme, "tabs", "bar-color--hover")
         );

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -34,6 +34,18 @@ $tab-oversized-margin: 0;
         map-deep-get($theme, "tabs", "bar-color--hover")
       );
     }
+
+    &--vertical:active,
+    &--vertical:focus,
+    &--vertical:hover {
+      color: map-deep-get($theme, "tabs", "text-color--selected");
+
+      @include vertical-tab-bar(
+        $tab-bottom-bar-height,
+        map-deep-get($theme, "tabs", "bar-color--hover")
+      );
+    }
+
     &--selected {
       font-weight: 700;
       color: map-deep-get($theme, "tabs", "text-color--selected");
@@ -51,10 +63,31 @@ $tab-oversized-margin: 0;
           map-deep-get($theme, "tabs", "bar-color--selected")
         );
       }
+
+      &--vertical {
+        @include vertical-tab-bar(
+          $tab-bottom-bar-height,
+          map-deep-get($theme, "tabs", "bar-color--selected")
+        );
+      }
+
+      &--vertical:active,
+      &--vertical:focus,
+      &--vertical:hover {
+        color: map-deep-get($theme, "tabs", "text-color--selected");
+        @include vertical-tab-bar(
+          $tab-bottom-bar-height,
+          map-deep-get($theme, "tabs", "bar-color--selected")
+        );
+      }
     }
 
     &:focus {
       @include tab-bar($tab-bottom-bar-height, inherit);
+    }
+
+    &--vertical:focus {
+      @include vertical-tab-bar($tab-bottom-bar-height, inherit);
     }
   }
 
@@ -133,6 +166,10 @@ $tab-oversized-margin: 0;
     display: flex;
   }
 
+  &__tab-content--vertical {
+    flex-direction: column;
+  }
+
   &__scroll-left,
   &__scroll-right {
     margin-top: -10px;
@@ -157,6 +194,11 @@ $tab-oversized-margin: 0;
     &:active {
       outline: none;
     }
+
+    &--vertical {
+      min-width: 150px;
+      padding-top: $tab-padding-bottom;
+    }
   }
 
   .a-tab-group__tab {
@@ -167,6 +209,10 @@ $tab-oversized-margin: 0;
     &:hover {
       text-decoration: none;
       outline-offset: 0;
+    }
+
+    &--vertical {
+      text-align: left;
     }
   }
 

--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -334,7 +334,7 @@ $atomic-default: (
     "oversized-background-color": map-get($grey, "lighten-6"),
     "oversized--hover-background-color": $white,
     "text-color": map-get($mds-neutral, "neutral-12"),
-    "text-color--selected": map-get($mds-neutral, "neutral-15"),
+    "text-color--selected": map-get($mds-interactive, "interactive-10"),
     "bar-color--hover": map-get($mds-neutral, "neutral-6"),
     "bar-color--selected": map-get($mds-interactive, "interactive-10")
   ),

--- a/framework/styles/utilities/mixins.scss
+++ b/framework/styles/utilities/mixins.scss
@@ -89,6 +89,10 @@
   box-shadow: inset 0 $tab-bar-height 0 -1px $tab-bar-color;
 }
 
+@mixin vertical-tab-bar($tab-bar-height, $tab-bar-color) {
+  box-shadow: inset -4px 0 0 -1px $tab-bar-color;
+}
+
 // -----------------------------------------------------------------------------
 // Content exclusively for screen readers
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #179 by adding a `vertical` prop to `ATabGroup` that will render the tabs vertically. See the [vertical tabs](https://magna-react-git-feat-vertical-tabs.securex-preview.app/components/tab#vertical-tabs) and [oversized vertical tabs](https://magna-react-git-feat-vertical-tabs.securex-preview.app/components/tab#oversized-vertical) demos.

