### PR TITLE
fix: stop event bubbling in AModal

### DIFF
--- a/framework/components/AAccordion/AAccordion.mdx
+++ b/framework/components/AAccordion/AAccordion.mdx
@@ -110,6 +110,46 @@ import {
 `}
 />
 
+## Event Propagation
+
+If you have a component inside an `AAccordionHeader` component with an `onClick` handler, the event will also bubble up to the `AAccordionHeader`, thus toggling the opened/closed state.
+
+To prevent this, you should invoke the `stopPropagation()` method on the inner component's event handler.
+
+<Playground
+  code={`() => {
+    const [countA, setCountA] = useState(0);
+    const [countB, setCountB] = useState(0);
+    return (
+      <>
+        <p>Count A: {countA}</p>
+        <p>Count B: {countB}</p>
+        <AAccordion>
+          <AAccordionPanel>
+            <AAccordionHeader>
+              <AAccordionHeaderTitle>
+                An accordion with an <AButton onClick={() => setCountA(state => state + 1)}>Increment A</AButton> button
+              </AAccordionHeaderTitle>
+            </AAccordionHeader>
+            <AAccordionBody>This accordion opens even when clicking the increment button.</AAccordionBody>
+          </AAccordionPanel>
+          <AAccordionPanel>
+            <AAccordionHeader>
+              <AAccordionHeaderTitle>
+                An accordion with an <AButton onClick={(e) => {
+                  e.stopPropagation();
+                  setCountB(state => state + 1);  
+                }}>Increment B</AButton> button
+              </AAccordionHeaderTitle>
+            </AAccordionHeader>
+            <AAccordionBody>This accordion only opens on a click of the accordion panel.</AAccordionBody>
+          </AAccordionPanel>
+        </AAccordion>
+      </>
+    )
+  }`}
+/>
+
 ## Props
 
 All Accordion components (`AAccordion`, `AAccordionPanel`, `AAccordionHeader`, `AAccordionHeaderTitle`, `AAccordionBody`) inherit passed props.

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -75,6 +75,7 @@ const AModal = forwardRef(
         <APageOverlay
           className={visibilityClass}
           onClick={(e) => {
+            e.stopPropagation();
             const {target} = e;
             if (target !== _ref.current) {
               return;
@@ -103,6 +104,13 @@ const AModal = forwardRef(
         aria-modal="true"
         className={contentClassName}
         ref={handleMultipleRefs(_ref, ref)}
+        onClick={(e) => {
+          e.stopPropagation();
+          const {onClick: propsOnClick} = rest;
+          if (typeof propsOnClick === "function") {
+            propsOnClick(e);
+          }
+        }}
         {...rest}
       >
         {children}


### PR DESCRIPTION
Resolves #191 by stopping events from bubbling outside of `AModal`.

The key thing to note is that even though `AModal` is rendered as a React Portal, React will *still* treat the component as a child of the **React tree** it was rendered in, meaning that [events happening inside of the React Portal will bubble up to their parent components](https://reactjs.org/docs/portals.html#event-bubbling-through-portals).

<details>

<summary>
The solution is to invoke the `stopPropagation()` method from the root component rendered in `AModal`. If you're still not entirely comfortable with this fix, or what what React means by "Event Bubbling Through Portals", then you can expand this snippet to get a lot more information.
</summary>

### Refresher

As a quick refresher on bubbling behavior, let's look at the following example of two buttons:

```jsx
<button onClick={() => alert('Hello from parent')}>
  Parent
  <button onClick={() => alert('Hello from child')}>Child</button>
</button>
```
Clicking "Nested" will trigger *both* browser alerts in the following order: `Hello from child` -> `Hello from parent`. This is because the `click` event from the "Child" button "bubbles up" to the registered `click` event on the "Parent" button.

This is the exact behavior causing #191.

### Context

Now, for a real demonstration of how this is happening inside of Magna React, take the following example (which can be pasted into a Playground editor on the docs site):

```js
() => {
  const [open, setOpen] = useState(false);
  return (
    <AButton onClick={() => alert("Hello world")} secondary className="pa-5">
      Browser Alert or{" "}
      <AButton onClick={() => setOpen(true)} primary className="ml-2">
        Modal Alert
      </AButton>
      {/* Note how `Modal` is being rendered inside a `AButton` component */}
      <AModal isOpen={open} medium>
        <APanel>
          <APanelHeader>
            <APanelTitle>Modal Alert</APanelTitle>
            <AButton icon onClick={() => setOpen(false)}>
              <AIcon>close</AIcon>
            </AButton>
          </APanelHeader>
          <APanelBody>Modal alert content</APanelBody>
        </APanel>
      </AModal>
    </AButton>
  );
};
 ```

Similar to the refresher example, the `click` event on the "Modal Alert" button is bubbling up to the parent "Browser Alert" button. This means that when a user opens the modal alert, they will *also* see the browser alert. Consequently, any clicks inside the modal will also trigger the browser alert due to the same bubbling behavior.

### Solutions

To prevent this from happening, we can do one of two things:

1. Move the "Child" button outside of "Parent" button
2. Invoke the `stopPropagation()` method on the "Child" `click` event

For the sake of Magna React, and this being a component library, we are opting to go with the second option by adding a `click` event listener to the parent component rendered inside `AModal` to prevent any further event from propagating higher up in the React tree. This will cover the case of `AModal` being rendered from within a component that also has a `click` event attached to it.

However, it is also up to consuming applications to recognize this event bubbling behavior, which means they should also invoke the `stopPropagation()` method where necessary. In the example above, that would mean adding `stopPropagation()` to the "Modal Alert" button's `onClick` handler to prevent the initial click on the "Modal Alert" from also triggering the "Browser Alert" button.

</details>