### PR TITLE
fix: export icon map using esm module syntax

### DIFF
--- a/framework/components/AIcon/AIcon.js
+++ b/framework/components/AIcon/AIcon.js
@@ -3,7 +3,7 @@ import React, {forwardRef} from "react";
 
 import Icons from "./icons.json";
 import MagnaIcons from "./magnaIcons.js";
-import {iconNameMap} from "./atomicMap";
+import {iconNameMap} from "./atomicMap.mjs";
 import "./AIcon.scss";
 
 /**

--- a/framework/components/AIcon/atomicMap.mjs
+++ b/framework/components/AIcon/atomicMap.mjs
@@ -1,4 +1,4 @@
-const iconNameMap = {
+export const iconNameMap = {
   add: "plus",
   "add-to-list": "file-plus",
   alarm: "",
@@ -268,5 +268,3 @@ const iconNameMap = {
   "web-tracking": "user-switch",
   "would-have-dropped": ""
 };
-
-module.exports.iconNameMap = iconNameMap;

--- a/framework/components/AIcon/atomicMap.mjs
+++ b/framework/components/AIcon/atomicMap.mjs
@@ -1,3 +1,9 @@
+/**
+ * This file is explicitly saved as an ECMAScript Module
+ * (.mjs) so that other .mjs scripts in this repo can
+ * import it properly.
+ */
+
 export const iconNameMap = {
   add: "plus",
   "add-to-list": "file-plus",

--- a/scripts/copyPhosphorIcons.mjs
+++ b/scripts/copyPhosphorIcons.mjs
@@ -1,7 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import icons from "../framework/components/AIcon/atomicMap.js";
+import {iconNameMap} from "../framework/components/AIcon/atomicMap.mjs";
 
 /**
  * This script will copy phospohor icons from downloads into the svg dir.
@@ -22,8 +22,6 @@ import icons from "../framework/components/AIcon/atomicMap.js";
 
 const phosphorPath = `${os.homedir()}/Downloads/phosphor-icons/SVGs/Regular`;
 const outputBase = "./svg";
-
-const {iconNameMap} = icons;
 
 const generatedListForPhosphor = Object.entries(iconNameMap).map(
   ([atomicKey, phosphorKey]) => phosphorKey || atomicKey


### PR DESCRIPTION
Some apps bundling Magna React are having issues with the `atomicMap.js` file using Common JS module syntax. This PR converts the file to ESM module syntax, and updates imports across the repo accordingly.

![image](https://user-images.githubusercontent.com/94568316/222503235-c98f859f-7494-4a10-8b31-a23130c082ac.png)
