### PR TITLE
correction of displaced selected button in APagination component

### DIFF
--- a/framework/components/APagination/APagination.scss
+++ b/framework/components/APagination/APagination.scss
@@ -78,6 +78,9 @@
         margin-right: 0;
       }
     }
+    > .a-button-group__wrapper > .a-button.a-button--selected {
+      margin-left: 0;
+    }
   }
 
   &__results-per-page {


### PR DESCRIPTION
Pull request solves the undesirable shift of the selected button by 2px to the left which occurred due to inheritance from the AButtonGroup component