### PR TITLE
Limit drawer transition attributes to avoid unwanted animations

### DIFF
--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -105,10 +105,10 @@
 
   &--hidden {
     @include transition(
-      $transform-transition,
       // same transform transition when hiding
+      $transform-transition,
+      // delay visibility change after the transform transition
       visibility 0s linear $animation-duration
-        // delay visibility change after the transform transition
     );
 
     overflow: hidden;

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -10,7 +10,15 @@
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
 
   transform: translateX(0);
-  transition: all 0.3s ease-in-out;
+
+  $animation-duration: 0.3s;
+  // limit transition to transform to avoid animating other properties
+  $transform-transition: transform $animation-duration ease-in-out;
+
+  @include transition(
+    $transform-transition,
+    visibility 0s // immediate visibility change
+  );
 
   &--vertical {
     height: 100vh;
@@ -96,6 +104,13 @@
   }
 
   &--hidden {
+    @include transition(
+      $transform-transition,
+      // same transform transition when hiding
+      visibility 0s linear $animation-duration
+        // delay visibility change after the transform transition
+    );
+
     overflow: hidden;
     visibility: hidden;
 

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -12,11 +12,16 @@
   transform: translateX(0);
 
   $animation-duration: 0.3s;
-  // limit transition to transform to avoid animating other properties
-  $transform-transition: transform $animation-duration ease-in-out;
+  $animation-timing: ease-in-out;
+  $transition-props: $animation-duration $animation-timing;
+
+  // limit transition properties to avoid animating other properties coming form outside
+  $common-transitions: transform $transition-props, width $transition-props,
+    height $transition-props, max-width $transition-props,
+    max-height $transition-props;
 
   @include transition(
-    $transform-transition,
+    $common-transitions,
     visibility 0s // immediate visibility change
   );
 
@@ -105,9 +110,8 @@
 
   &--hidden {
     @include transition(
-      // same transform transition when hiding
-      $transform-transition,
-      // delay visibility change after the transform transition
+      $common-transitions,
+      // delay visibility change after other transitions
       visibility 0s linear $animation-duration
     );
 


### PR DESCRIPTION
`transition: all` in `ADrawer` causes unwanted transitions when setting other css attributes on `ADrawer` from outside. 

Specifically this `top` attribute to offset the drawer below the shell app header causes the drawer to slide in from the top: https://github.com/advthreat/intelligence/blob/master/src/components/Drawer/Drawer.js#L35 

https://user-images.githubusercontent.com/51229231/222739718-66fad22a-f0e9-4739-9acc-28c5071a5053.mov

This has not been apparent until recently. Every drawer was mounted on the page as hidden when the page loaded, so the transition from `top` ran in a hidden state. Now we mount/unmount drawers on demand when we want to show/hide them. This makes the `top` transition run after mounting/showing the drawer.

Side note: Looks like browsers automatically delay `visibility: hidden;` with `transition: all`. I had no idea. Now I had to delay it explicitly, otherwise the drawers disappears immediately on hide. I've added some comments hoping someone will not just shorten this back to `all` at some point in the future. 