### PR TITLE
fix: stop keydown event bubbling in AModal

### DIFF
--- a/framework/components/AAccordion/AAccordion.mdx
+++ b/framework/components/AAccordion/AAccordion.mdx
@@ -112,9 +112,9 @@ import {
 
 ## Event Propagation
 
-If you have a component inside an `AAccordionHeader` component with an `onClick` handler, the event will also bubble up to the `AAccordionHeader`, thus toggling the opened/closed state.
+It's important to note that if you render a component inside `AAccordionHeader` that registers `onClick` or `onKeyDown` handlers (such as another button), those events will also bubble up to the `AAccordionHeader`, thus toggling the opened/closed stateof the accordion.
 
-To prevent this, you should invoke the `stopPropagation()` method on the inner component's event handler.
+To prevent this behavior, you should invoke the `stopPropagation()` method on the inner component's event handlers causing such side effects.
 
 <Playground
   code={`() => {
@@ -128,21 +128,38 @@ To prevent this, you should invoke the `stopPropagation()` method on the inner c
           <AAccordionPanel>
             <AAccordionHeader>
               <AAccordionHeaderTitle>
-                An accordion with an <AButton onClick={() => setCountA(state => state + 1)}>Increment A</AButton> button
+                An accordion with an{" "}
+                <AButton onClick={() => setCountA((state) => state + 1)}>
+                  Increment A
+                </AButton>{" "}
+                button
               </AAccordionHeaderTitle>
             </AAccordionHeader>
-            <AAccordionBody>This accordion opens even when clicking the increment button.</AAccordionBody>
+            <AAccordionBody>
+              This accordion opens even when clicking the increment button.
+            </AAccordionBody>
           </AAccordionPanel>
           <AAccordionPanel>
             <AAccordionHeader>
               <AAccordionHeaderTitle>
-                An accordion with an <AButton onClick={(e) => {
-                  e.stopPropagation();
-                  setCountB(state => state + 1);  
-                }}>Increment B</AButton> button
+                An accordion with an{" "}
+                <AButton
+                  onKeyDown={(e) => {
+                    e.stopPropagation()
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setCountB((state) => state + 1);
+                  }}
+                >
+                  Increment B
+                </AButton>{" "}
+                button
               </AAccordionHeaderTitle>
             </AAccordionHeader>
-            <AAccordionBody>This accordion only opens on a click of the accordion panel.</AAccordionBody>
+            <AAccordionBody>
+              This accordion only opens on a click of the accordion panel.
+            </AAccordionBody>
           </AAccordionPanel>
         </AAccordion>
       </>

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -70,10 +70,37 @@ const AModal = forwardRef(
       return null;
     }
 
+    /**
+     * In the case where `AModal` is rendered inside
+     * a clickable element, like a button component,
+     * we want to prevent user clicks and keydown
+     * presses from bubbling outside the modal, which
+     * could cause unintended side effects. This is
+     * why we call `stopPropagation` on those events.
+     *
+     * @example
+     * <AButton>
+     *   Open Modal
+     *   <AModal isOpen={open}>
+     *      // Don't want clicks here to get to `AButton`
+     *   </AModal>
+     * </AButton>
+     */
     if (withOverlay) {
       return ReactDOM.createPortal(
         <APageOverlay
           className={visibilityClass}
+          onKeyDown={(e) => {
+            const key = e.key;
+            // Still allow the modal to be closed with escape key shortcut
+            if (key !== "Escape") {
+              e.stopPropagation();
+            }
+            const {onKeyDown: propsOnKeyDown} = rest;
+            if (typeof propsOnKeyDown === "function") {
+              propsOnKeyDown(e);
+            }
+          }}
           onClick={(e) => {
             e.stopPropagation();
             const {target} = e;
@@ -104,6 +131,17 @@ const AModal = forwardRef(
         aria-modal="true"
         className={contentClassName}
         ref={handleMultipleRefs(_ref, ref)}
+        onKeyDown={(e) => {
+          const key = e.key;
+          // Still allow the modal to be closed with escape key shortcut
+          if (key !== "Escape") {
+            e.stopPropagation();
+          }
+          const {onKeyDown: propsOnKeyDown} = rest;
+          if (typeof propsOnKeyDown === "function") {
+            propsOnKeyDown(e);
+          }
+        }}
         onClick={(e) => {
           e.stopPropagation();
           const {onClick: propsOnClick} = rest;


### PR DESCRIPTION
Similar to #202 , this PR also resolves #191 by stopping event propagation for `keydown` events if they are not triggered from the escape key (in order to preserve quick escape functionality). 

These become relevant in situations such as when a Modal is rendered within a button.

```javascript
<AButton>
  <AModal>
    {/* Clicks/key presses in here propagate to `AButton` */}
  </AModal>
</AButton>
```

To see this in action, navigate to [Magna React Modal documentation](https://magna-react.vercel.app/components/modal#usage), and paste the following code snippet into a playground editor. Then, once opening the modal, click your enter key or spacebar to see the accordion open/close while the modal is opened.

* Note: when opening the modal, focus will automatically be set to the "X" button (expected). To see the bug/fix, click anywhere within the modal before testing the enter/space

```javascript
() => {
  const [open, setOpen] = useState(false);
  const ref = useRef();
  usePopupQuickExit({
    popupRef: ref,
    isEnabled: open,
    onExit: () => setOpen(false),
  });
  return (
    <div>
      <AAccordion>
        <AAccordionPanel>
          <AAccordionHeader>
            <AAccordionHeaderTitle>
              Accordion Title{" "}
              <AButton onClick={(e) => {
                e.stopPropagation();
                setOpen(true);
              }}>Open Modal</AButton>{" "}
              <Modal isOpen={open} />
            </AAccordionHeaderTitle>
          </AAccordionHeader>
          <AAccordionBody>Accordion content.</AAccordionBody>
        </AAccordionPanel>
      </AAccordion>
    </div>
  );

  function Modal({isOpen}) {
    return (
      <AModal aria-labelledby="modal-title" isOpen={isOpen}>
        <APanel ref={ref} style={{ minWidth: "400px" }} type="dialog">
          <APanelHeader>
            <APanelTitle id="modal-title">Modal Demo</APanelTitle>
            <AButton
              aria-label="Close modal 1"
              onClick={() => setOpen(false)}
              tertiaryAlt
              icon
            >
              <AIcon>close</AIcon>
            </AButton>
          </APanelHeader>
          <APanelBody>Modal content goes here.</APanelBody>
          <APanelFooter>
            <AButton>Action</AButton>
          </APanelFooter>
        </APanel>
      </AModal>
    );
  }
};
```

Compare this behavior to the production docs site vs. this preview one generated in this PR.