### PR TITLE
Add support for setting infoTooltip props

### DIFF
--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -18,6 +18,7 @@ const AFieldBase = forwardRef(
       onClickLabel,
       required,
       infoTooltip,
+      infoTooltipProps = {},
       validationState = "default",
       ...rest
     },
@@ -64,6 +65,8 @@ const AFieldBase = forwardRef(
                   id={`${labelId}-tooltip`}
                   open={infoTooltipOpen}
                   placement="top"
+                  pointer
+                  {...infoTooltipProps}
                 >
                   {infoTooltip}
                 </ATooltip>
@@ -110,6 +113,10 @@ AFieldBase.propTypes = {
    * Adds an information tooltip next to the label
    */
   infoTooltip: PropTypes.string,
+  /**
+   * Overrides props of `ATooltip` used to display `infoTooltip`
+   */
+  infoTooltipProps: PropTypes.instanceOf(ATooltip.propTypes),
   /**
    * Handles the label's `click` event.
    */

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -7,6 +7,7 @@ import React, {
   useState
 } from "react";
 
+import ATooltip from "../ATooltip";
 import AInputBase from "../AInputBase";
 import {AFormContext} from "../AForm";
 import AIcon from "../AIcon";
@@ -435,6 +436,14 @@ ATextInput.propTypes = {
    * Sets the label content.
    */
   label: PropTypes.node,
+  /**
+   * Adds an information tooltip next to the label
+   */
+  infoTooltip: PropTypes.string,
+  /**
+   * Overrides props of `ATooltip` used to display `infoTooltip`
+   */
+  infoTooltipProps: PropTypes.instanceOf(ATooltip.propTypes),
   /**
    * Sets the maximum value of a number type text input.
    */


### PR DESCRIPTION
Fixes #254 by allowing me to set `placement` prop on the `infoTooltip`.