### PR TITLE
Tooltip delay proposal

### DIFF
--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -88,6 +88,8 @@ const AFieldBase = forwardRef(
   }
 );
 
+const {anchorRef, ...infoTooltipProps} = ATooltip.propTypes;
+
 AFieldBase.propTypes = {
   /**
    * Sets the hint content.
@@ -116,7 +118,7 @@ AFieldBase.propTypes = {
   /**
    * Overrides props of `ATooltip` used to display `infoTooltip`
    */
-  infoTooltipProps: PropTypes.instanceOf(ATooltip.propTypes),
+  infoTooltipProps: PropTypes.shape(infoTooltipProps),
   /**
    * Handles the label's `click` event.
    */

--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -116,7 +116,7 @@ AFieldBase.propTypes = {
    */
   infoTooltip: PropTypes.string,
   /**
-   * Overrides props of `ATooltip` used to display `infoTooltip`
+   * Overrides props of `ATooltip` used to display `infoTooltip`. See `ATooltip.propTypes`.
    */
   infoTooltipProps: PropTypes.shape(infoTooltipProps),
   /**

--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -3,7 +3,7 @@ import React, {forwardRef, useRef, useState} from "react";
 
 import AHint from "../AHint";
 import AIcon from "../AIcon";
-import ATooltip from "../ATooltip";
+import ATooltip, {ATooltipPropTypes} from "../ATooltip";
 import "./AFieldBase.scss";
 
 const AFieldBase = forwardRef(
@@ -88,7 +88,7 @@ const AFieldBase = forwardRef(
   }
 );
 
-const {anchorRef, ...infoTooltipProps} = ATooltip.propTypes;
+const {anchorRef, ...infoTooltipProps} = ATooltipPropTypes;
 
 AFieldBase.propTypes = {
   /**

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -407,6 +407,8 @@ const ATextInput = forwardRef(
   }
 );
 
+const {anchorRef, ...infoTooltipProps} = ATooltip.propTypes;
+
 ATextInput.propTypes = {
   /**
    * Appends an icon inside the text input. The value should be an [icon name](/components/icon).
@@ -443,7 +445,7 @@ ATextInput.propTypes = {
   /**
    * Overrides props of `ATooltip` used to display `infoTooltip`
    */
-  infoTooltipProps: PropTypes.instanceOf(ATooltip.propTypes),
+  infoTooltipProps: PropTypes.shape(infoTooltipProps),
   /**
    * Sets the maximum value of a number type text input.
    */

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -7,7 +7,7 @@ import React, {
   useState
 } from "react";
 
-import ATooltip from "../ATooltip";
+import {ATooltipPropTypes} from "../ATooltip";
 import AInputBase from "../AInputBase";
 import {AFormContext} from "../AForm";
 import AIcon from "../AIcon";
@@ -407,7 +407,7 @@ const ATextInput = forwardRef(
   }
 );
 
-const {anchorRef, ...infoTooltipProps} = ATooltip.propTypes;
+const {anchorRef, ...infoTooltipProps} = ATooltipPropTypes;
 
 ATextInput.propTypes = {
   /**

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -443,7 +443,7 @@ ATextInput.propTypes = {
    */
   infoTooltip: PropTypes.string,
   /**
-   * Overrides props of `ATooltip` used to display `infoTooltip`
+   * Overrides props of `ATooltip` used to display `infoTooltip`. See `ATooltip.propTypes`.
    */
   infoTooltipProps: PropTypes.shape(infoTooltipProps),
   /**

--- a/framework/components/ATextInput/ATextInput.mdx
+++ b/framework/components/ATextInput/ATextInput.mdx
@@ -30,6 +30,9 @@ import {ATextInput} from "@cisco-sbg-ui/magna-react";
                 clearable
                 label="Location"
                 infoTooltip="Tooltip for Location input"
+                infoTooltipProps={{ 
+                  closeDelay: 3000 // just to demonstrate passing props, can be omitted
+                }}
                 onChange={(e) => {
                   setValue(e.target.value);
                   setStatus(

--- a/framework/components/ATooltip/ATooltip.js
+++ b/framework/components/ATooltip/ATooltip.js
@@ -100,7 +100,7 @@ const ATooltip = forwardRef(
   }
 );
 
-ATooltip.propTypes = {
+export const ATooltipPropTypes = {
   /**
    * The reference to the menu anchor.
    */
@@ -153,6 +153,8 @@ ATooltip.propTypes = {
    */
   role: PropTypes.string
 };
+
+ATooltip.propTypes = ATooltipPropTypes;
 
 ATooltip.displayName = "ATooltip";
 

--- a/framework/components/ATooltip/ATooltip.js
+++ b/framework/components/ATooltip/ATooltip.js
@@ -42,6 +42,10 @@ const ATooltip = forwardRef(
       timeout.current = setTimeout(() => {
         setIsOpen(true);
       }, openDelay);
+
+      return () => {
+        clearTimeout(timeout.current);
+      };
     }, [openDelay]);
 
     const closeWithDelay = useCallback(() => {
@@ -55,6 +59,10 @@ const ATooltip = forwardRef(
         // when closeDelay is not provided, calculated to be shorter to avoid multiple tooltips on screen
         closeDelay ?? openDelay / 2
       );
+
+      return () => {
+        clearTimeout(timeout.current);
+      };
     }, [closeDelay, openDelay]);
 
     // sync open prop change to internal state with delay

--- a/framework/components/ATooltip/ATooltip.js
+++ b/framework/components/ATooltip/ATooltip.js
@@ -42,12 +42,6 @@ const ATooltip = forwardRef(
       timeout.current = setTimeout(() => {
         setIsOpen(true);
       }, openDelay);
-
-      return () => {
-        if (timeout.current) {
-          clearTimeout(timeout.current);
-        }
-      };
     }, [openDelay]);
 
     const closeWithDelay = useCallback(() => {
@@ -61,12 +55,6 @@ const ATooltip = forwardRef(
         // when closeDelay is not provided, calculated to be shorter to avoid multiple tooltips on screen
         closeDelay ?? openDelay / 2
       );
-
-      return () => {
-        if (timeout.current) {
-          clearTimeout(timeout.current);
-        }
-      };
     }, [closeDelay, openDelay]);
 
     // sync open prop change to internal state with delay
@@ -76,6 +64,12 @@ const ATooltip = forwardRef(
       } else {
         closeWithDelay();
       }
+
+      return () => {
+        if (timeout.current) {
+          clearTimeout(timeout.current);
+        }
+      };
     }, [open, openWithDelay, closeWithDelay]);
 
     let className = `a-tooltip`;

--- a/framework/components/ATooltip/ATooltip.js
+++ b/framework/components/ATooltip/ATooltip.js
@@ -44,7 +44,9 @@ const ATooltip = forwardRef(
       }, openDelay);
 
       return () => {
-        clearTimeout(timeout.current);
+        if (timeout.current) {
+          clearTimeout(timeout.current);
+        }
       };
     }, [openDelay]);
 
@@ -61,7 +63,9 @@ const ATooltip = forwardRef(
       );
 
       return () => {
-        clearTimeout(timeout.current);
+        if (timeout.current) {
+          clearTimeout(timeout.current);
+        }
       };
     }, [closeDelay, openDelay]);
 

--- a/framework/components/ATooltip/ATooltip.mdx
+++ b/framework/components/ATooltip/ATooltip.mdx
@@ -113,7 +113,7 @@ The `ATooltip` component inherits passed props.
       <ARow>
         <ACol cols="2" />
         <ACol className="text-right">
-          <AButton ref={buttonRef12} onClick={() => setOpen12(!open12)}>
+          <AButton ref={buttonRef12} onMouseEnter={() => setOpen12(true)} onMouseLeave={() => setOpen12(false)}>
             Top-Left
           </AButton>
           <ATooltip
@@ -124,7 +124,7 @@ The `ATooltip` component inherits passed props.
           </ATooltip>
         </ACol>
         <ACol className="text-center">
-          <AButton ref={buttonRef1} onClick={() => setOpen1(!open1)}>
+          <AButton ref={buttonRef1}  onMouseEnter={() => setOpen1(true)} onMouseLeave={() => setOpen1(false)}>
             Top
           </AButton>
           <ATooltip anchorRef={buttonRef1} open={open1} placement="top">
@@ -132,7 +132,7 @@ The `ATooltip` component inherits passed props.
           </ATooltip>
         </ACol>
         <ACol>
-          <AButton ref={buttonRef2} onClick={() => setOpen2(!open2)}>
+          <AButton ref={buttonRef2}  onMouseEnter={() => setOpen2(true)} onMouseLeave={() => setOpen2(false)}>
             Top-Right
           </AButton>
           <ATooltip anchorRef={buttonRef2} open={open2} placement="top-right">
@@ -143,7 +143,7 @@ The `ATooltip` component inherits passed props.
       </ARow>
       <ARow>
         <ACol className="text-right">
-          <AButton ref={buttonRef11} onClick={() => setOpen11(!open11)}>
+          <AButton ref={buttonRef11}  onMouseEnter={() => setOpen11(true)} onMouseLeave={() => setOpen11(false)}>
             Left-Top
           </AButton>
           <ATooltip
@@ -155,7 +155,7 @@ The `ATooltip` component inherits passed props.
         </ACol>
         <ACol cols="6" />
         <ACol>
-          <AButton ref={buttonRef3} onClick={() => setOpen3(!open3)}>
+          <AButton ref={buttonRef3} onMouseEnter={() => setOpen3(true)} onMouseLeave={() => setOpen3(false)}>
             Right-Top
           </AButton>
           <ATooltip anchorRef={buttonRef3} open={open3} placement="right-top">
@@ -165,7 +165,7 @@ The `ATooltip` component inherits passed props.
       </ARow>
       <ARow>
         <ACol className="text-right">
-          <AButton ref={buttonRef10} onClick={() => setOpen10(!open10)}>
+          <AButton ref={buttonRef10} onMouseEnter={() => setOpen10(true)} onMouseLeave={() => setOpen10(false)}>
             Left
           </AButton>
           <ATooltip anchorRef={buttonRef10} open={open10} placement="left">
@@ -174,7 +174,7 @@ The `ATooltip` component inherits passed props.
         </ACol>
         <ACol cols="6" />
         <ACol>
-          <AButton ref={buttonRef4} onClick={() => setOpen4(!open4)}>
+          <AButton ref={buttonRef4} onMouseEnter={() => setOpen4(true)} onMouseLeave={() => setOpen4(false)}>
             Right
           </AButton>
           <ATooltip anchorRef={buttonRef4} open={open4} placement="right">
@@ -184,7 +184,7 @@ The `ATooltip` component inherits passed props.
       </ARow>
       <ARow>
         <ACol className="text-right">
-          <AButton ref={buttonRef9} onClick={() => setOpen9(!open9)}>
+          <AButton ref={buttonRef9} onMouseEnter={() => setOpen9(true)} onMouseLeave={() => setOpen9(false)}>
             Left-Bottom
           </AButton>
           <ATooltip
@@ -196,7 +196,7 @@ The `ATooltip` component inherits passed props.
         </ACol>
         <ACol cols="6" />
         <ACol>
-          <AButton ref={buttonRef5} onClick={() => setOpen5(!open5)}>
+          <AButton ref={buttonRef5} onMouseEnter={() => setOpen5(true)} onMouseLeave={() => setOpen5(false)}>
             Right-Bottom
           </AButton>
           <ATooltip
@@ -210,7 +210,7 @@ The `ATooltip` component inherits passed props.
       <ARow>
         <ACol cols="2" />
         <ACol className="text-right">
-          <AButton ref={buttonRef8} onClick={() => setOpen8(!open8)}>
+          <AButton ref={buttonRef8} onMouseEnter={() => setOpen8(true)} onMouseLeave={() => setOpen8(false)}>
             Bottom-Left
           </AButton>
           <ATooltip
@@ -221,7 +221,7 @@ The `ATooltip` component inherits passed props.
           </ATooltip>
         </ACol>
         <ACol className="text-center">
-          <AButton ref={buttonRef7} onClick={() => setOpen7(!open7)}>
+          <AButton ref={buttonRef7} onMouseEnter={() => setOpen7(true)} onMouseLeave={() => setOpen7(false)}>
             Bottom
           </AButton>
           <ATooltip anchorRef={buttonRef7} open={open7} placement="bottom">
@@ -229,7 +229,7 @@ The `ATooltip` component inherits passed props.
           </ATooltip>
         </ACol>
         <ACol>
-          <AButton ref={buttonRef6} onClick={() => setOpen6(!open6)}>
+          <AButton ref={buttonRef6} onMouseEnter={() => setOpen6(true)} onMouseLeave={() => setOpen6(false)}>
             Bottom-Right
           </AButton>
           <ATooltip
@@ -265,7 +265,12 @@ The `ATooltip` component inherits passed props.
         If the tooltip is larger than the anchor, the pointer is placed in the
         center of the anchor.
       </p>
-      <AButton secondary ref={buttonRef1} onClick={() => setOpen1(!open1)}>
+      <AButton 
+        secondary
+        ref={buttonRef1}
+        onMouseEnter={() => setOpen1(true)}
+        onMouseLeave={() => setOpen1(false)}
+      >
         Large, Short Anchor Has Less Wide, Taller Tooltips
       </AButton>
       <ATooltip
@@ -290,7 +295,9 @@ The `ATooltip` component inherits passed props.
         secondary
         ref={buttonRef2}
         className="mt-10 mb-6"
-        onClick={() => setOpen2(!open2)}>
+        onMouseEnter={() => setOpen2(true)} 
+        onMouseLeave={() => setOpen2(false)}
+      >
         <AIcon>information</AIcon>
       </AButton>
       <ATooltip
@@ -349,6 +356,7 @@ The `ATooltip` component inherits passed props.
             anchorRef={buttonRef}
             open={open}
             placement="bottom"
+            openDelay={0}
             onClose={() => setOpen(false)}>
             Tooltip
           </ATooltip>

--- a/framework/components/ATooltip/index.js
+++ b/framework/components/ATooltip/index.js
@@ -1,1 +1,1 @@
-export {default} from "./ATooltip";
+export {default, ATooltipPropTypes} from "./ATooltip";


### PR DESCRIPTION
Delays showing/hiding the tooltip by default when toggling `open` prop. This can be breaking for apps that implement delays themselves (like I do in intelligence), but it would make everything more consistent. 

Also adds a tip by default.

Examples updated to show tooltip on hover which is a more common and recommended use case: https://magnetic.cisco.com/0a43ab5cd/p/727988-popover

Relates to #255.
