### PR TITLE
fix: prevent AMenu components from closing AModal

### DIFF
--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -320,10 +320,10 @@ const AMenuBase = forwardRef(
         }
       };
 
-      window.addEventListener("click", clickOutsideHandler);
+      window.addEventListener("mousedown", clickOutsideHandler);
 
       return () => {
-        window.removeEventListener("click", clickOutsideHandler);
+        window.removeEventListener("mousedown", clickOutsideHandler);
       };
     }, [anchorRef, combinedRef, onClose, open]);
 
@@ -360,7 +360,13 @@ const AMenuBase = forwardRef(
       (open &&
         appRef.current &&
         ReactDOM.createPortal(
-          <div {...rest} ref={combinedRef} className={className} style={style}>
+          <div
+            data-ignore-outside-click
+            {...rest}
+            ref={combinedRef}
+            className={className}
+            style={style}
+          >
             {pointer && (
               <div className="a-menu-base__pointer" style={pointerStyle} />
             )}

--- a/framework/hooks/useOutsideClick.js
+++ b/framework/hooks/useOutsideClick.js
@@ -5,7 +5,11 @@ const useOutsideClick = (options) => {
 
   const detectOutside = useCallback(
     (e) => {
-      if (!rootRef?.current?.contains(e.target)) {
+      const ignoreEl = e.target.closest("[data-ignore-outside-click]");
+      const shouldIgnore =
+        ignoreEl && (e.target === ignoreEl || ignoreEl.contains(e.target));
+      // Don't register as outside click if the click is coming from within a menu
+      if (!rootRef?.current?.contains(e.target) && !shouldIgnore) {
         if (typeof onClick === "function") {
           onClick(e);
         }


### PR DESCRIPTION
This fixes the issue related to `ASelect` components closing a hypothetical `AModal` they are rendered in. It's important to note that issue was not exclusive to `ASelect`. It was happening for all components that render `AMenuBase`.

This PR:
* Aligns outside click logic in `AMenuBase` to use the same event listener as `useOutsideClick` that was changed in #162
* Ignores outside click events from elements specifying a `[data-ignore-outside-click]` data attribute.

<details>
<summary>To test this out, paste the following snippet into any playground editor from <a href="https://magna-react-git-fix-modal-with-select.securex-preview.app/components/modal">this preview branch</a></summary>

```js
() => {
  const items = [
    { id: 1, name: "Bread, Cereal, Rice, and Pasta" },
    { id: 2, name: "Vegetables" },
    { id: 3, name: "Fruit", selected: true },
    { id: 4, name: "Milk, Yogurt, and Cheese" },
    { id: 5, name: "Meat, Poultry, Fish", disabled: true },
    { id: 6, name: "Fats, Oils, and Sweets" },
  ];
  const buttonRef = useRef(null);
  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
  const [selectedItem, setSelectedItem] = useState(items[2]);
  const [open, setOpen] = useState(false);
  const comboboxItems = [
    "Bread, Cereal, Rice, and Pasta",
    "Vegetables",
    "Fruit",
    "Milk, Yogurt, and Cheese",
    "Meat, Poultry, Fish",
    "Fats, Oils, and Sweets",
  ];
  const [value, setValue] = useState("");
  const [filteredItems, setFilteredItems] = useState(comboboxItems);
  const ref = useRef();
  usePopupQuickExit({
    popupRef: ref,
    isEnabled: open,
    onExit: () => setOpen(false),
  });
  return (
    <div>
      <AButton onClick={() => setOpen(true)}>Open Modal</AButton>
      <AModal medium aria-labelledby="modal-title" isOpen={open}>
        <APanel ref={ref} style={{ minWidth: "400px" }} type="dialog">
          <APanelHeader>
            <APanelTitle id="modal-title">Modal Demo</APanelTitle>
            <AButton
              aria-label="Close modal 1"
              onClick={() => setOpen(false)}
              tertiaryAlt
              icon
            >
              <AIcon>close</AIcon>
            </AButton>
          </APanelHeader>
          <APanelBody>
            <ASelect
              label="Food Group"
              items={items}
              itemText="name"
              itemValue="id"
              placeholder="Pick a Food Group"
              onSelected={(item) => setSelectedItem(item)}
              hint="Some hint"
            />
            <br />
            <br />
            <ACombobox
              medium
              prependContent={
                <AListItem twoLine className="my-1 mx-2">
                  Advertisement
                </AListItem>
              }
              appendContent={
                <>
                  <ADivider className="ma-0" />
                  <AListItem>
                    <AIcon size={12} left>
                      add
                    </AIcon>
                    Add Role
                  </AListItem>
                </>
              }
              clearable
              label="Food Group"
              items={filteredItems}
              placeholder="Pick a Food Group"
              onSelected={(item) => {
                setValue(item);
              }}
              value={value}
              onChange={(e) => {
                setFilteredItems(
                  comboboxItems.filter((x) =>
                    x.toLowerCase().includes(e.target.value.toLowerCase())
                  )
                );
                setValue(e.target.value);
              }}
            />
            <br />
            <br />
            <AButton
              ref={buttonRef}
              onClick={() => setIsTooltipOpen(!isTooltipOpen)}
            >
              Open Tooltip
            </AButton>
            <ATooltip
              anchorRef={buttonRef}
              open={isTooltipOpen}
              placement="bottom"
              onClose={() => setIsTooltipOpen(false)}
            >
              Tooltip
            </ATooltip>
          </APanelBody>
          <APanelFooter>
            <AButton>Action</AButton>
          </APanelFooter>
        </APanel>
      </AModal>
    </div>
  );
}
```
</details>