### PR TITLE
#243 - closer sync to current design for status colors

### DIFF
--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -7,10 +7,10 @@ $atomic-default: (
     "header-focus": map-get($mds-blue, "blue-8")
   ),
   "alert": (
-    "bg": map-get($mds-purple, "purple-1"),
-    "success-bg": map-get($mds-blue, "blue-1"),
-    "warning-bg": map-get($mds-yellow, "yellow-1"),
-    "danger-bg": map-get($mds-red, "red-1"),
+    "bg": map-get($mds-light-theme, "status-info-bg"),
+    "success-bg": map-get($mds-light-theme, "status-positive-bg"),
+    "warning-bg": map-get($mds-light-theme, "status-warning-bg"),
+    "danger-bg": map-get($mds-light-theme, "status-negative-bg"),
     "close": map-get($mds-neutral, "neutral-9"),
     "close-hover": map-get($mds-neutral, "neutral-9")
   ),

--- a/framework/styles/theme/dusk.scss
+++ b/framework/styles/theme/dusk.scss
@@ -7,10 +7,10 @@ $atomic-dusk: (
     "header-focus": map-get($mds-blue, "blue-1")
   ),
   "alert": (
-    "bg": #b587fa4d,
-    "success-bg": #49b5f54d,
-    "warning-bg": #e0a4194d,
-    "danger-bg": #d9384366,
+    "bg": map-get($mds-dark-theme, "status-info-bg"),
+    "success-bg": map-get($mds-dark-theme, "status-positive-bg"),
+    "warning-bg": map-get($mds-dark-theme, "status-warning-bg"),
+    "danger-bg": map-get($mds-dark-theme, "status-negative-bg"),
     "close": map-get($mds-neutral, "neutral-6"),
     "close-hover": map-get($mds-neutral, "neutral-6")
   ),

--- a/framework/styles/utilities/palette.scss
+++ b/framework/styles/utilities/palette.scss
@@ -463,10 +463,14 @@ $mds-light-theme: (
   "secondary-background": map-get($mds-neutral, "neutral-2"),
   "secondary-gray": map-get($mds-neutral, "neutral-12"),
   "supplemental-text": map-get($mds-neutral, "neutral-7"),
-  "status-info": map-get($mds-purple, "purple-10"),
-  "status-positive": map-get($mds-blue, "blue-7"),
-  "status-warning": map-get($mds-yellow, "yellow-7"),
-  "status-negative": map-get($mds-red, "red-10"),
+  "status-info": #2774d9,
+  "status-positive": #45991f,
+  "status-warning": #d9b216,
+  "status-negative": #c24632,
+  "status-info-bg": #d9f1ff,
+  "status-positive-bg": #eaf7e4,
+  "status-warning-bg": #fcf5d4,
+  "status-negative-bg": #fce2de,
   "table-border": map-get($mds-neutral, "neutral-11")
 );
 $mds-dark-theme: (
@@ -490,10 +494,14 @@ $mds-dark-theme: (
   "secondary-background": map-get($mds-neutral, "neutral-15"),
   "secondary-gray": map-get($mds-neutral, "neutral-6"),
   "supplemental-text": map-get($mds-neutral, "neutral-12"),
-  "status-info": map-get($mds-purple, "purple-6"),
-  "status-positive": map-get($mds-blue, "blue-5"),
-  "status-warning": map-get($mds-yellow, "yellow-4"),
-  "status-negative": map-get($mds-red, "red-7"),
+  "status-info": #2774d9,
+  "status-positive": #1f9933,
+  "status-warning": #d9b216,
+  "status-negative": #c24632,
+  "status-info-bg": rgba(73, 181, 245, 0.302),
+  "status-positive-bg": darken(#4cbf7f, 35%),
+  "status-warning-bg": rgba(224, 164, 25, 0.302),
+  "status-negative-bg": rgba(217, 56, 67, 0.4),
   "table-border": map-get($mds-neutral, "neutral-7")
 );
 


### PR DESCRIPTION
Resolves #243 

Note: dark theme colors are a best guess since Magnetic still doesn't have an official dark theme, and there are at least three different base colors for info across multiple current source of truth figmas.