### PR TITLE
Add useToggle hook for delay open of tooltip

### DIFF
--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React, {forwardRef, useRef, useState} from "react";
 
+import useToggle from "../../hooks/useToggle";
 import AHint from "../AHint";
 import AIcon from "../AIcon";
 import ATooltip from "../ATooltip";
@@ -25,7 +26,11 @@ const AFieldBase = forwardRef(
     ref
   ) => {
     const infoIconRef = useRef(),
-      [infoTooltipOpen, setInfoTooltipOpen] = useState(false);
+      {
+        isOpen: isInfoTooltipOpen,
+        open: openInfoTooltip,
+        close: closeInfoTooltip
+      } = useToggle();
 
     let className = "a-field-base";
 
@@ -55,15 +60,15 @@ const AFieldBase = forwardRef(
               <>
                 <AIcon
                   ref={infoIconRef}
-                  onMouseEnter={() => setInfoTooltipOpen(true)}
-                  onMouseLeave={() => setInfoTooltipOpen(false)}
+                  onMouseEnter={openInfoTooltip}
+                  onMouseLeave={closeInfoTooltip}
                 >
                   information
                 </AIcon>
                 <ATooltip
                   anchorRef={infoIconRef}
                   id={`${labelId}-tooltip`}
-                  open={infoTooltipOpen}
+                  open={isInfoTooltipOpen}
                   placement="top"
                   pointer
                   {...infoTooltipProps}

--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -1,10 +1,10 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useRef, useState} from "react";
+import React, {forwardRef} from "react";
 
-import useToggle from "../../hooks/useToggle";
 import AHint from "../AHint";
 import AIcon from "../AIcon";
 import ATooltip from "../ATooltip";
+import ATriggerTooltip from "../ATriggerTooltip";
 import "./AFieldBase.scss";
 
 const AFieldBase = forwardRef(
@@ -25,13 +25,6 @@ const AFieldBase = forwardRef(
     },
     ref
   ) => {
-    const infoIconRef = useRef(),
-      {
-        isOpen: isInfoTooltipOpen,
-        open: openInfoTooltip,
-        close: closeInfoTooltip
-      } = useToggle();
-
     let className = "a-field-base";
 
     if (validationState !== "default") {
@@ -57,25 +50,15 @@ const AFieldBase = forwardRef(
               <span className="a-field-base__label--required">*</span>
             )}
             {infoTooltip && (
-              <>
-                <AIcon
-                  ref={infoIconRef}
-                  onMouseEnter={openInfoTooltip}
-                  onMouseLeave={closeInfoTooltip}
-                >
-                  information
-                </AIcon>
-                <ATooltip
-                  anchorRef={infoIconRef}
-                  id={`${labelId}-tooltip`}
-                  open={isInfoTooltipOpen}
-                  placement="top"
-                  pointer
-                  {...infoTooltipProps}
-                >
-                  {infoTooltip}
-                </ATooltip>
-              </>
+              <ATriggerTooltip
+                id={`${labelId}-tooltip`}
+                placement="top"
+                content={infoTooltip}
+                pointer
+                {...infoTooltipProps}
+              >
+                <AIcon>information</AIcon>
+              </ATriggerTooltip>
             )}
           </label>
         )}

--- a/framework/components/ATooltip/ATooltip.js
+++ b/framework/components/ATooltip/ATooltip.js
@@ -14,7 +14,7 @@ const ATooltip = forwardRef(
       onClose,
       open,
       placement,
-      pointer,
+      pointer = true,
       role = "tooltip",
       ...rest
     },

--- a/framework/components/ATooltip/ATooltip.mdx
+++ b/framework/components/ATooltip/ATooltip.mdx
@@ -21,7 +21,7 @@ It is necessary for `ATooltip` to be a descendant of `AApp` for mounting.
 <Playground
   code={`() => {
   const iconRef = useRef(null);
-  const {isOpen, open, close} = useToggle(400, 0);
+  const {isOpen, open, close} = useToggle();
 return (
 
 <>

--- a/framework/components/ATooltip/ATooltip.mdx
+++ b/framework/components/ATooltip/ATooltip.mdx
@@ -16,7 +16,33 @@ import {ATooltip} from "@cisco-sbg-ui/magna-react";
 
 It is necessary for `ATooltip` to be a descendant of `AApp` for mounting.
 
-## Usage
+## Usage (hook with delay options)
+
+<Playground
+  code={`() => {
+  const iconRef = useRef(null);
+  const {isOpen, open, close} = useToggle(400, 0);
+return (
+
+<>
+  By default the openDelay is 400ms
+  <br />
+  <br />
+  <AIcon ref={iconRef} onMouseEnter={open} onMouseLeave={close}>
+    information
+  </AIcon>
+  <ATooltip
+    anchorRef={iconRef}
+    id="tooltip_usage_1"
+    open={isOpen}
+    placement="bottom-right"
+    pointer>
+    Tooltip
+  </ATooltip>
+</>
+); } `} />
+
+## Manual Usage
 
 <Playground
   code={`() => {
@@ -96,156 +122,137 @@ The `ATooltip` component inherits passed props.
   const buttonRef10 = useRef(null);
   const buttonRef11 = useRef(null);
   const buttonRef12 = useRef(null);
-  const [open1, setOpen1] = useState(false);
-  const [open2, setOpen2] = useState(false);
-  const [open3, setOpen3] = useState(false);
-  const [open4, setOpen4] = useState(false);
-  const [open5, setOpen5] = useState(false);
-  const [open6, setOpen6] = useState(false);
-  const [open7, setOpen7] = useState(false);
-  const [open8, setOpen8] = useState(false);
-  const [open9, setOpen9] = useState(false);
-  const [open10, setOpen10] = useState(false);
-  const [open11, setOpen11] = useState(false);
-  const [open12, setOpen12] = useState(false);
-  return (
-    <AContainer className="pa-6">
-      <ARow>
-        <ACol cols="2" />
-        <ACol className="text-right">
-          <AButton ref={buttonRef12} onClick={() => setOpen12(!open12)}>
-            Top-Left
-          </AButton>
-          <ATooltip
-            anchorRef={buttonRef12}
-            open={open12}
-            placement="top-left">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol className="text-center">
-          <AButton ref={buttonRef1} onClick={() => setOpen1(!open1)}>
-            Top
-          </AButton>
-          <ATooltip anchorRef={buttonRef1} open={open1} placement="top">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol>
-          <AButton ref={buttonRef2} onClick={() => setOpen2(!open2)}>
-            Top-Right
-          </AButton>
-          <ATooltip anchorRef={buttonRef2} open={open2} placement="top-right">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol cols="2" />
-      </ARow>
-      <ARow>
-        <ACol className="text-right">
-          <AButton ref={buttonRef11} onClick={() => setOpen11(!open11)}>
-            Left-Top
-          </AButton>
-          <ATooltip
-            anchorRef={buttonRef11}
-            open={open11}
-            placement="left-top">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol cols="6" />
-        <ACol>
-          <AButton ref={buttonRef3} onClick={() => setOpen3(!open3)}>
-            Right-Top
-          </AButton>
-          <ATooltip anchorRef={buttonRef3} open={open3} placement="right-top">
-            Tooltip
-          </ATooltip>
-        </ACol>
-      </ARow>
-      <ARow>
-        <ACol className="text-right">
-          <AButton ref={buttonRef10} onClick={() => setOpen10(!open10)}>
-            Left
-          </AButton>
-          <ATooltip anchorRef={buttonRef10} open={open10} placement="left">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol cols="6" />
-        <ACol>
-          <AButton ref={buttonRef4} onClick={() => setOpen4(!open4)}>
-            Right
-          </AButton>
-          <ATooltip anchorRef={buttonRef4} open={open4} placement="right">
-            Tooltip
-          </ATooltip>
-        </ACol>
-      </ARow>
-      <ARow>
-        <ACol className="text-right">
-          <AButton ref={buttonRef9} onClick={() => setOpen9(!open9)}>
-            Left-Bottom
-          </AButton>
-          <ATooltip
-            anchorRef={buttonRef9}
-            open={open9}
-            placement="left-bottom">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol cols="6" />
-        <ACol>
-          <AButton ref={buttonRef5} onClick={() => setOpen5(!open5)}>
-            Right-Bottom
-          </AButton>
-          <ATooltip
-            anchorRef={buttonRef5}
-            open={open5}
-            placement="right-bottom">
-            Tooltip
-          </ATooltip>
-        </ACol>
-      </ARow>
-      <ARow>
-        <ACol cols="2" />
-        <ACol className="text-right">
-          <AButton ref={buttonRef8} onClick={() => setOpen8(!open8)}>
-            Bottom-Left
-          </AButton>
-          <ATooltip
-            anchorRef={buttonRef8}
-            open={open8}
-            placement="bottom-left">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol className="text-center">
-          <AButton ref={buttonRef7} onClick={() => setOpen7(!open7)}>
-            Bottom
-          </AButton>
-          <ATooltip anchorRef={buttonRef7} open={open7} placement="bottom">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol>
-          <AButton ref={buttonRef6} onClick={() => setOpen6(!open6)}>
-            Bottom-Right
-          </AButton>
-          <ATooltip
-            anchorRef={buttonRef6}
-            open={open6}
-            placement="bottom-right">
-            Tooltip
-          </ATooltip>
-        </ACol>
-        <ACol cols="2" />
-      </ARow>
-    </AContainer>
-  );
-}
-`}
-/>
+  const {isOpen: isOpen1, open: open1, close: close1} = useToggle(0);
+  const {isOpen: isOpen2, open: open2, close: close2} = useToggle(0);
+  const {isOpen: isOpen3, open: open3, close: close3} = useToggle(0);
+  const {isOpen: isOpen4, open: open4, close: close4} = useToggle(0);
+  const {isOpen: isOpen5, open: open5, close: close5} = useToggle(0);
+  const {isOpen: isOpen6, open: open6, close: close6} = useToggle(0);
+  const {isOpen: isOpen7, open: open7, close: close7} = useToggle(0);
+  const {isOpen: isOpen8, open: open8, close: close8} = useToggle(0);
+  const {isOpen: isOpen9, open: open9, close: close9} = useToggle(0);
+  const {isOpen: isOpen10, open: open10, close: close10} = useToggle(0);
+  const {isOpen: isOpen11, open: open11, close: close11} = useToggle(0);
+  const {isOpen: isOpen12, open: open12, close: close12} = useToggle(0);
+
+return (
+
+<AContainer className="pa-6">
+  <ARow>
+    <ACol cols="2" />
+    <ACol className="text-right">
+      <AButton ref={buttonRef12} onMouseEnter={open12} onMouseLeave={close12}>
+        Top-Left
+      </AButton>
+      <ATooltip anchorRef={buttonRef12} open={isOpen12} placement="top-left">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol className="text-center">
+      <AButton ref={buttonRef1} onMouseEnter={open1} onMouseLeave={close1}>
+        Top
+      </AButton>
+      <ATooltip anchorRef={buttonRef1} open={isOpen1} placement="top">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol>
+      <AButton ref={buttonRef2} onMouseEnter={open2} onMouseLeave={close2}>
+        Top-Right
+      </AButton>
+      <ATooltip anchorRef={buttonRef2} open={isOpen2} placement="top-right">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol cols="2" />
+  </ARow>
+  <ARow>
+    <ACol className="text-right">
+      <AButton ref={buttonRef11} onMouseEnter={open11} onMouseLeave={close11}>
+        Left-Top
+      </AButton>
+      <ATooltip anchorRef={buttonRef11} open={isOpen11} placement="left-top">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol cols="6" />
+    <ACol>
+      <AButton ref={buttonRef3} onMouseEnter={open3} onMouseLeave={close3}>
+        Right-Top
+      </AButton>
+      <ATooltip anchorRef={buttonRef3} open={isOpen3} placement="right-top">
+        Tooltip
+      </ATooltip>
+    </ACol>
+  </ARow>
+  <ARow>
+    <ACol className="text-right">
+      <AButton ref={buttonRef10} onMouseEnter={open10} onMouseLeave={close10}>
+        Left
+      </AButton>
+      <ATooltip anchorRef={buttonRef10} open={isOpen10} placement="left">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol cols="6" />
+    <ACol>
+      <AButton ref={buttonRef4} onMouseEnter={open4} onMouseLeave={close4}>
+        Right
+      </AButton>
+      <ATooltip anchorRef={buttonRef4} open={isOpen4} placement="right">
+        Tooltip
+      </ATooltip>
+    </ACol>
+  </ARow>
+  <ARow>
+    <ACol className="text-right">
+      <AButton ref={buttonRef9} onMouseEnter={open9} onMouseLeave={close9}>
+        Left-Bottom
+      </AButton>
+      <ATooltip anchorRef={buttonRef9} open={isOpen9} placement="left-bottom">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol cols="6" />
+    <ACol>
+      <AButton ref={buttonRef5} onMouseEnter={open5} onMouseLeave={close5}>
+        Right-Bottom
+      </AButton>
+      <ATooltip anchorRef={buttonRef5} open={isOpen5} placement="right-bottom">
+        Tooltip
+      </ATooltip>
+    </ACol>
+  </ARow>
+  <ARow>
+    <ACol cols="2" />
+    <ACol className="text-right">
+      <AButton ref={buttonRef8} onMouseEnter={open8} onMouseLeave={close8}>
+        Bottom-Left
+      </AButton>
+      <ATooltip anchorRef={buttonRef8} open={isOpen8} placement="bottom-left">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol className="text-center">
+      <AButton ref={buttonRef7} onMouseEnter={open7} onMouseLeave={close7}>
+        Bottom
+      </AButton>
+      <ATooltip anchorRef={buttonRef7} open={isOpen7} placement="bottom">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol>
+      <AButton ref={buttonRef6} onMouseEnter={open6} onMouseLeave={close6}>
+        Bottom-Right
+      </AButton>
+      <ATooltip anchorRef={buttonRef6} open={isOpen6} placement="bottom-right">
+        Tooltip
+      </ATooltip>
+    </ACol>
+    <ACol cols="2" />
+  </ARow>
+</AContainer>
+); } `} />
 
 ## Pointer
 

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -1,0 +1,77 @@
+import PropTypes from "prop-types";
+import React, {useEffect, useRef} from "react";
+
+import ATooltip from "../ATooltip";
+import useToggle from "../../hooks/useToggle";
+
+const ATriggerTooltip = ({
+  children,
+  trigger = "mouseenter",
+  openDelay = 400,
+  closeDelay,
+  content,
+  ...rest
+}) => {
+  const childrenRef = useRef([]);
+  const {isOpen, open, close, toggle} = useToggle(openDelay, closeDelay);
+
+  useEffect(() => {
+    const childRefs = childrenRef.current;
+    switch (trigger) {
+      case "mouseenter":
+        childRefs.forEach((childRef) => {
+          childRef.addEventListener("mouseenter", open);
+          childRef.addEventListener("mouseleave", close);
+        });
+        break;
+      case "click":
+        childRefs.forEach((childRef) => {
+          childRef.addEventListener("click", toggle);
+        });
+        break;
+    }
+  }, [trigger, childrenRef, close, open, toggle]);
+
+  const childElements = childrenRef.current.map((childRef, index) => {
+    return (
+      <ATooltip
+        key={`index-${index}`}
+        anchorRef={{current: childRef}}
+        open={isOpen}
+        pointer
+        {...rest}
+      >
+        {content}
+      </ATooltip>
+    );
+  });
+
+  return (
+    <>
+      {React.Children.map(children, (child, index) =>
+        React.cloneElement(child, {
+          ...child.props,
+          ref: (ref) => {
+            childrenRef.current[index] = ref;
+          }
+        })
+      )}
+      {childElements}
+    </>
+  );
+};
+
+ATriggerTooltip.propTypes = {
+  /** DOM event to trigger the tooltip */
+  trigger: PropTypes.string,
+  /** Delay in milliseconds before tooltip will open */
+  openDelay: PropTypes.number,
+  /** Delay in milliseconds before tooltip will close */
+  closeDelay: PropTypes.number,
+  /** Tooltip content */
+  content: PropTypes.string.isRequired
+};
+
+ATriggerTooltip.displayName = "ATriggerTooltip";
+
+export default ATriggerTooltip;

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -13,6 +13,7 @@ const ATriggerTooltip = ({
   openDelay = 400,
   closeDelay,
   content,
+  disabled = false,
   ...rest
 }) => {
   const childrenRef = useRef([]);
@@ -22,12 +23,18 @@ const ATriggerTooltip = ({
     rootRef: triggerRef,
     onClick: close
   });
+  const childrenRefCurrent = childrenRef.current;
 
   useEffect(() => {
+    if (!content || disabled) {
+      return;
+    }
+
     const childRefs =
       triggerRef && triggerRef.current
         ? [triggerRef.current]
-        : childrenRef.current;
+        : childrenRefCurrent;
+
     switch (trigger) {
       case "hover":
         childRefs.forEach((childRef) => {
@@ -41,7 +48,27 @@ const ATriggerTooltip = ({
         });
         break;
     }
-  }, [trigger, childrenRef, triggerRef, close, open, toggle]);
+
+    return () => {
+      childRefs.forEach((childRef) => {
+        if (!childRef) {
+          return;
+        }
+        childRef.removeEventListener("mouseenter", open);
+        childRef.removeEventListener("mouseleave", close);
+        childRef.removeEventListener("click", toggle);
+      });
+    };
+  }, [
+    trigger,
+    childrenRefCurrent,
+    triggerRef,
+    close,
+    open,
+    toggle,
+    disabled,
+    content
+  ]);
 
   // If an anchorRef is provided, use it. Otherwise, attach to first child.
   const tooltipAnchorRef = anchorRef || {current: childrenRef.current[0]};
@@ -68,7 +95,7 @@ const ATriggerTooltip = ({
 
 ATriggerTooltip.propTypes = {
   /** DOM event to trigger the tooltip */
-  trigger: PropTypes.string,
+  trigger: PropTypes.oneOf(["hover", "click"]),
   /**
    * Anchors the tooltip to the specified ref, leaving
    * trigger event on the child(ren).
@@ -82,7 +109,9 @@ ATriggerTooltip.propTypes = {
   /** Delay in milliseconds before tooltip will close */
   closeDelay: PropTypes.number,
   /** Tooltip content */
-  content: PropTypes.string.isRequired
+  content: PropTypes.string,
+  /** Disable the tooltip */
+  disabled: PropTypes.bool
 };
 
 ATriggerTooltip.displayName = "ATriggerTooltip";

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React, {useEffect, useRef} from "react";
 
 import ATooltip from "../ATooltip";
-import useToggle from "../../hooks/useToggle";
+import useToggle from "../../hooks/useToggle/useToggle";
 
 const ATriggerTooltip = ({
   children,

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -4,6 +4,7 @@ import React, {useEffect, useRef} from "react";
 import ATooltip from "../ATooltip";
 import useToggle from "../../hooks/useToggle/useToggle";
 import useOutsideClick from "../../hooks/useOutsideClick/useOutsideClick";
+import {handleMultipleRefs} from "../../utils/helpers";
 
 const ATriggerTooltip = ({
   children,
@@ -83,9 +84,9 @@ const ATriggerTooltip = ({
       {React.Children.map(children, (child, index) =>
         React.cloneElement(child, {
           ...child.props,
-          ref: (ref) => {
-            childrenRef.current[index] = ref;
-          }
+          ref: handleMultipleRefs(child.props.ref, (node) => {
+            childrenRef.current[index] = node;
+          })
         })
       )}
       {tooltipElement}

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -1,0 +1,74 @@
+---
+name: TriggerTooltips**
+route: /components/triggertooltip
+components: ATriggerTooltip
+---
+
+# Trigger Tooltips
+
+## Install
+
+Integrate with your build to [auto-import](/#integrating), or add an import in your component:
+
+```
+import {ATriggerTooltip} from "@cisco-sbg-ui/magna-react";
+```
+
+It is necessary for `ATriggerTooltip` to be a descendant of `AApp` for mounting.
+
+Children of `ATriggerTooltip` must be able to accept a ref.
+
+## Usage
+
+<Playground
+  code={`() => {
+return (
+
+<>
+  By default the openDelay is 400ms
+  <br />
+  <br />
+
+<span style={{verticalAlign: "super", margin: "0 5px 0 0"}}>
+  Trigger by hover
+</span>
+
+  <ATriggerTooltip
+    id="tooltip_usage_1"
+    placement="bottom-left"
+    content="Tooltip text"
+    pointer>
+     <AIcon>
+    information</AIcon>
+  </ATooltip>
+
+<br />
+<br />
+
+<span style={{verticalAlign: "super", margin: "0 5px 0 0"}}>
+  Trigger by click
+</span>
+
+  <ATriggerTooltip
+    id="tooltip_usage_1"
+    placement="bottom-left"
+    content="Tooltip text"
+    trigger="click"
+    pointer>
+     <AIcon>
+    information</AIcon>
+  </ATooltip>
+</>
+); } `} />
+
+## Tooltip Props
+
+The `ATriggerTooltip` component inherits passed props.
+
+<Props of="ATriggerTooltip" />
+
+## Accessibility Notes
+
+By default, `ATooltip` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [tooltip](https://www.w3.org/TR/wai-aria/#tooltip).
+
+For better accessibility: add an `id` to the tooltip and set the `aria-describedby` attribute on the anchor to the new `id`.

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -35,9 +35,8 @@ return (
 
   <ATriggerTooltip
     id="tooltip_usage_1"
-    placement="bottom-left"
-    content="Tooltip text"
-    pointer>
+    placement="right"
+    content="Tooltip text">
      <AIcon>
     information</AIcon>
   </ATooltip>
@@ -50,18 +49,72 @@ return (
 </span>
 
   <ATriggerTooltip
-    id="tooltip_usage_1"
-    placement="bottom-left"
+    id="tooltip_usage_2"
+    placement="right"
     content="Tooltip text"
-    trigger="click"
-    pointer>
+    trigger="click">
      <AIcon>
     information</AIcon>
   </ATooltip>
 </>
 ); } `} />
 
-## Tooltip Props
+## Anchor to element other than child
+
+<Playground
+  code={`() => {
+    const iconRef = useRef()
+return (
+
+<>
+<AIcon ref={iconRef}>information</AIcon>
+
+<br />
+<br />
+<br />
+<ATriggerTooltip placement="top" anchorRef={iconRef} content="Tooltip text">
+  <div>I will open the tooltip on the info icon!</div>
+</ATriggerTooltip>
+
+</>
+); } `} />
+
+## Anchor and Trigger, multiple tooltips
+
+To avoid nested wrapping of tooltips, combining `triggerRef` and `anchorRef` allows for multiple tooltips with different triggers.
+
+<Playground
+  code={`() => {
+    const iconRef = useRef();
+    const buttonRef = useRef();
+return (
+
+<>
+<AIcon ref={iconRef}>information</AIcon>
+
+<br />
+<br />
+<br />
+<AButton ref={buttonRef}>I am the trigger</AButton>
+<ATriggerTooltip
+  placement="top"
+  anchorRef={iconRef}
+  triggerRef={buttonRef}
+  content="I appear on HOVER"
+/>
+<ATriggerTooltip
+  placement="right"
+  trigger="click"
+  anchorRef={iconRef}
+  triggerRef={buttonRef}
+  openDelay={0}
+  content="I appear on CLICK"
+/>
+
+</>
+); } `} />
+
+## TriggerTooltip Props
 
 The `ATriggerTooltip` component inherits passed props.
 

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -20,15 +20,13 @@ Children of `ATriggerTooltip` must be able to accept a ref.
 
 ## Usage
 
+By default the openDelay is 400ms
+
 <Playground
   code={`() => {
 return (
 
 <>
-  By default the openDelay is 400ms
-  <br />
-  <br />
-
 <span style={{verticalAlign: "super", margin: "0 5px 0 0"}}>
   Trigger by hover
 </span>
@@ -52,6 +50,7 @@ return (
     id="tooltip_usage_2"
     placement="right"
     content="Tooltip text"
+    openDelay={0}
     trigger="click">
      <AIcon>
     information</AIcon>
@@ -73,7 +72,7 @@ return (
 <br />
 <br />
 <ATriggerTooltip placement="top" anchorRef={iconRef} content="Tooltip text">
-  <div>I will open the tooltip on the info icon!</div>
+  <AButton>I will open the tooltip on the info icon!</AButton>
 </ATriggerTooltip>
 
 </>
@@ -110,6 +109,28 @@ return (
   openDelay={0}
   content="I appear on CLICK"
 />
+
+</>
+); } `} />
+
+## Disable Tooltip
+
+<Playground
+  code={`() => {
+    const [disabled, setDisabled] = useState(false)
+return (
+
+<>
+<AButton onClick={() => {
+  setDisabled(!disabled)
+}}>{disabled ? "Enable tooltip" : "Disable tooltip"}</AButton>
+<br />
+<br />
+<br />
+<span style={{verticalAlign: "super", margin: "0 5px 0 0"}}>{"Tooltip is "}{disabled?"disabled":"enabled"}</span>
+<ATriggerTooltip disabled={disabled} placement="top" content="Contionally enabled tooltip">
+  <AIcon>information</AIcon>
+</ATriggerTooltip>
 
 </>
 ); } `} />

--- a/framework/components/ATriggerTooltip/index.js
+++ b/framework/components/ATriggerTooltip/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ATriggerTooltip";

--- a/framework/hooks/useToggle/useToggle.js
+++ b/framework/hooks/useToggle/useToggle.js
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 
 const useToggle = (openDelay = 400, closeDelay = 0) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -29,6 +29,10 @@ const useToggle = (openDelay = 400, closeDelay = 0) => {
   const toggle = useCallback(() => {
     isOpen ? close : open;
   }, [isOpen, open, close]);
+
+  useEffect(() => {
+    timeout.current && clearTimeout(timeout.current);
+  }, [timeout]);
 
   return {isOpen, open, close, toggle};
 };

--- a/framework/hooks/useToggle/useToggle.js
+++ b/framework/hooks/useToggle/useToggle.js
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from "react";
 
-const useToggle = (openDelay = 400, closeDelay = 0) => {
+const useToggle = (openDelay = 400, closeDelay) => {
   const [isOpen, setIsOpen] = useState(false);
   const timeout = useRef();
 
@@ -27,7 +27,7 @@ const useToggle = (openDelay = 400, closeDelay = 0) => {
   }, [closeDelay, openDelay, timeout]);
 
   const toggle = useCallback(() => {
-    isOpen ? close : open;
+    isOpen ? close() : open();
   }, [isOpen, open, close]);
 
   useEffect(() => {

--- a/framework/hooks/useToggle/useToggle.js
+++ b/framework/hooks/useToggle/useToggle.js
@@ -1,0 +1,36 @@
+import {useCallback, useRef, useState} from "react";
+
+const useToggle = (openDelay = 400, closeDelay = 0) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const timeout = useRef();
+
+  const open = useCallback(() => {
+    timeout.current && clearTimeout(timeout.current);
+
+    timeout.current = setTimeout(() => {
+      setIsOpen(true);
+    }, openDelay);
+  }, [openDelay, timeout]);
+
+  const close = useCallback(() => {
+    timeout.current && clearTimeout(timeout.current);
+
+    timeout.current = setTimeout(
+      () => {
+        setIsOpen(false);
+      },
+      // When closeDelay is not provided, calculated
+      // to be shorter to avoid multiple tooltips on
+      // screen
+      closeDelay ?? openDelay / 2
+    );
+  }, [closeDelay, openDelay, timeout]);
+
+  const toggle = useCallback(() => {
+    isOpen ? close : open;
+  }, [isOpen, open, close]);
+
+  return {isOpen, open, close, toggle};
+};
+
+export default useToggle;

--- a/framework/hooks/useToggle/useToggle.js
+++ b/framework/hooks/useToggle/useToggle.js
@@ -31,7 +31,9 @@ const useToggle = (openDelay = 400, closeDelay) => {
   }, [isOpen, open, close]);
 
   useEffect(() => {
-    timeout.current && clearTimeout(timeout.current);
+    return () => {
+      timeout.current && clearTimeout(timeout.current);
+    };
   }, [timeout]);
 
   return {isOpen, open, close, toggle};

--- a/framework/hooks/useToggle/useToggle.mdx
+++ b/framework/hooks/useToggle/useToggle.mdx
@@ -1,0 +1,46 @@
+---
+name: useToggle
+route: /hooks/use-toggle
+components: useToggle
+---
+
+# useToggle
+
+## Install
+
+Integrate with your build to [auto-import](/#integrating), or add an import in your component:
+
+```
+import { useToggle } from "@cisco-sbg-ui/magna-react";
+```
+
+## Description
+
+`useToggle` handles state for `isOpen` and provides `open`, `close`, and `toggle` convenience functions
+
+### Parameters
+
+- `openDelay`: Delay before `isOpen` gets set to true
+- `closeDelay`: Delay before `isOpen` gets set to false
+
+## Usage
+
+<Playground
+  code={`() => {
+  const iconRef = useRef(null);
+  const {isOpen, open, close} = useToggle();
+
+return (
+
+<>
+  By default the openDelay is 400ms
+  <br />
+  <br />
+  <AIcon ref={iconRef} onMouseEnter={open} onMouseLeave={close}>
+    information
+  </AIcon>
+  <ATooltip anchorRef={iconRef} open={isOpen} pointer>
+    Tooltip
+  </ATooltip>
+</>
+); } `} />

--- a/framework/index.js
+++ b/framework/index.js
@@ -86,6 +86,7 @@ import {
 import {ATheme, useATheme} from "./components/ATheme";
 import AToast from "./components/AToast";
 import ATooltip from "./components/ATooltip";
+import ATriggerTooltip from "./components/ATriggerTooltip";
 import ATree from "./components/ATree";
 import {useABreakpoint} from "./components/ABreakpoint";
 import {useAToaster, AToastPlate} from "./components/AToaster";
@@ -185,6 +186,7 @@ export {
   AToast,
   AToastPlate,
   ATooltip,
+  ATriggerTooltip,
   ATree,
   useABreakpoint,
   useADateRange,

--- a/framework/index.js
+++ b/framework/index.js
@@ -95,6 +95,7 @@ import useInView from "./hooks/useInView/useInView";
 import useMediaQuery from "./hooks/useMediaQuery/useMediaQuery";
 import useOutsideClick from "./hooks/useOutsideClick/useOutsideClick";
 import usePopupQuickExit from "./hooks/usePopupQuickExit/usePopupQuickExit";
+import useToggle from "./hooks/useToggle";
 
 export {
   AAccordion,
@@ -195,5 +196,6 @@ export {
   useInView,
   useMediaQuery,
   useOutsideClick,
-  usePopupQuickExit
+  usePopupQuickExit,
+  useToggle
 };

--- a/framework/index.js
+++ b/framework/index.js
@@ -86,8 +86,8 @@ import {
 import {ATheme, useATheme} from "./components/ATheme";
 import AToast from "./components/AToast";
 import ATooltip from "./components/ATooltip";
-import ATriggerTooltip from "./components/ATriggerTooltip";
 import ATree from "./components/ATree";
+import ATriggerTooltip from "./components/ATriggerTooltip";
 import {useABreakpoint} from "./components/ABreakpoint";
 import {useAToaster, AToastPlate} from "./components/AToaster";
 import useEscapeKeydown from "./hooks/useEscapeKeydown/useEscapeKeydown";
@@ -96,7 +96,7 @@ import useInView from "./hooks/useInView/useInView";
 import useMediaQuery from "./hooks/useMediaQuery/useMediaQuery";
 import useOutsideClick from "./hooks/useOutsideClick/useOutsideClick";
 import usePopupQuickExit from "./hooks/usePopupQuickExit/usePopupQuickExit";
-import useToggle from "./hooks/useToggle";
+import useToggle from "./hooks/useToggle/useToggle";
 
 export {
   AAccordion,
@@ -186,8 +186,8 @@ export {
   AToast,
   AToastPlate,
   ATooltip,
-  ATriggerTooltip,
   ATree,
+  ATriggerTooltip,
   useABreakpoint,
   useADateRange,
   useAAutoTheme,


### PR DESCRIPTION
Adds `useToggle` as a hook for controlling components with an "open" prop. Provides

- isOpen state prop
- function to open by event
- function to close by event
- function to toggle by event

`const {isOpen, open, close} = useToggle(400, 0);`