### PR TITLE
Abstract menu placement into a hook; use hook in ASelect and ACombobox

### DIFF
--- a/framework/components/ACombobox/ACombobox.js
+++ b/framework/components/ACombobox/ACombobox.js
@@ -14,6 +14,7 @@ import AMenu from "../AMenu";
 import {AListItem} from "../AList";
 import {useCombinedRefs} from "../../utils/hooks";
 import {keyCodes} from "../../utils/helpers";
+import useMenuSpacing from "../AMenuBase/hooks";
 import "./ACombobox.scss";
 
 let comboboxCounter = 0;
@@ -58,6 +59,10 @@ const ACombobox = forwardRef(
     const [error, setError] = useState("");
     const [workingValidationState, setWorkingValidationState] =
       useState(validationState);
+    const {checkMenuSpacing, menuPlacement} = useMenuSpacing(
+      inputBaseSurfaceRef,
+      menuRef
+    );
 
     const {register, unregister} = useContext(AFormContext);
     useEffect(() => {
@@ -84,6 +89,12 @@ const ACombobox = forwardRef(
         };
       }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+      if (isOpen && menuRef.current) {
+        checkMenuSpacing();
+      }
+    }, [isOpen, checkMenuSpacing, menuRef]);
 
     const validate = (testValue = value) => {
       if (rules || required) {
@@ -221,7 +232,8 @@ const ACombobox = forwardRef(
       style: {
         minWidth: "max-content",
         width: inputBaseSurfaceRef?.current?.clientWidth + 2 || "auto"
-      }
+      },
+      placement: menuPlacement
     };
 
     return (

--- a/framework/components/AMenuBase/hooks.js
+++ b/framework/components/AMenuBase/hooks.js
@@ -1,0 +1,34 @@
+import {useCallback, useState} from "react";
+
+/**
+ * Determines if a menu should flip its placement to above an
+ * element if there is not enough vertical space below to
+ * render the entire menu.
+ *
+ * To be used with ASelect and other components that use AMenu
+ * in a dropdown sort of way.
+ */
+
+const useMenuSpacing = (surfaceRef, menuRef, maxHeight) => {
+  const [menuSpace, setMenuSpace] = useState(0);
+
+  const checkMenuSpacing = useCallback(() => {
+    const inputBottom = surfaceRef?.current?.getBoundingClientRect().bottom,
+      verticalSpace = inputBottom
+        ? window.innerHeight - inputBottom - 10
+        : null;
+
+    verticalSpace && setMenuSpace(verticalSpace);
+  }, [surfaceRef]);
+
+  const menuHeight = menuRef?.current?.clientHeight || 0;
+
+  const menuPlacement =
+    menuHeight < menuSpace || (maxHeight && menuSpace > parseInt(maxHeight))
+      ? "bottom"
+      : "top";
+
+  return {checkMenuSpacing, menuPlacement};
+};
+
+export default useMenuSpacing;

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -13,6 +13,7 @@ import AIcon from "../AIcon";
 import AMenu from "../AMenu";
 import {AListItem} from "../AList";
 import {keyCodes} from "../../utils/helpers";
+import useMenuSpacing from "../AMenuBase/hooks";
 import "./ASelect.scss";
 
 let selectCounter = 0;
@@ -66,21 +67,11 @@ const ASelect = forwardRef(
     const [error, setError] = useState("");
     const [workingValidationState, setWorkingValidationState] =
       useState(validationState);
-    const [menuSpace, setMenuSpace] = useState(0);
-    const checkMenuSpacing = () => {
-      const inputBottom = surfaceRef?.current?.getBoundingClientRect().bottom,
-        verticalSpace = inputBottom
-          ? window.innerHeight - inputBottom - 10
-          : null;
-
-      verticalSpace && setMenuSpace(verticalSpace);
-    };
-
-    const menuHeight = menuRef?.current?.clientHeight;
-    const menuPlacement =
-      menuHeight < menuSpace || (maxHeight && menuSpace > parseInt(maxHeight))
-        ? "bottom"
-        : "top";
+    const {checkMenuSpacing, menuPlacement} = useMenuSpacing(
+      surfaceRef,
+      menuRef,
+      maxHeight
+    );
 
     const {register, unregister} = useContext(AFormContext);
     useEffect(() => {
@@ -94,7 +85,7 @@ const ASelect = forwardRef(
           menuRef.current.focus();
         }, 0);
       }
-    }, [isOpen, menuRef]);
+    }, [isOpen, checkMenuSpacing, menuRef]);
 
     useEffect(() => {
       const newSelectedItem = items.find((x) => x[itemSelected]);


### PR DESCRIPTION
Adds bottom edge detection to ACombobox. Logic has been abstracted into the `useMenuSpacing` hook. 

This should potentially be enhanced to add scroll detection to recalculate the menu placement.