### PR TITLE
AApp/ATheme listen for theme prop changes to switch theme

### DIFF
--- a/framework/components/AApp/AApp.js
+++ b/framework/components/AApp/AApp.js
@@ -68,7 +68,7 @@ AApp.propTypes = {
    */
   defaultTheme: PropTypes.oneOf(["default", "dusk"]),
   /**
-   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme. Do not use "theme" and "persist" props at the same time. Providing a "theme" prop indicates that the theme is managed from outside.
+   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme. Do not use "theme" and "persist" props at the same time. Providing a "theme" prop indicates that the theme is managed from outside and it will not be persisted.
    */
   theme: PropTypes.oneOf(["default", "dusk"])
 };

--- a/framework/components/AApp/AApp.js
+++ b/framework/components/AApp/AApp.js
@@ -11,6 +11,7 @@ const AApp = forwardRef(
       animations = true,
       children,
       className: propsClassName,
+      theme,
       defaultTheme,
       persistTheme = false,
       scrollbars = true,
@@ -40,7 +41,9 @@ const AApp = forwardRef(
         component={ATheme}
         wrapClassName="a-app--wrap"
         persist={persistTheme}
-        defaultTheme={defaultTheme}>
+        theme={theme}
+        defaultTheme={defaultTheme}
+      >
         {children}
       </AMount>
     );
@@ -53,17 +56,21 @@ AApp.propTypes = {
    */
   animations: PropTypes.bool,
   /**
-   * Sets the default theme.
+   * Toggles styled scrollbars.
    */
-  defaultTheme: PropTypes.oneOf(["default", "dusk"]),
+  scrollbars: PropTypes.bool,
   /**
-   * Toggles whether the theme is persisted in local storage.
+   * Toggles whether the theme is loaded from local storage on mount, and persisted to local storage on theme change.
    */
   persistTheme: PropTypes.bool,
   /**
-   * Toggles styled scrollbars.
+   * Sets the default theme on mount. Changes to this prop are not reflected as a current theme.
    */
-  scrollbars: PropTypes.bool
+  defaultTheme: PropTypes.oneOf(["default", "dusk"]),
+  /**
+   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme.
+   */
+  theme: PropTypes.oneOf(["default", "dusk"])
 };
 
 AApp.displayName = "AApp";

--- a/framework/components/AApp/AApp.js
+++ b/framework/components/AApp/AApp.js
@@ -68,7 +68,7 @@ AApp.propTypes = {
    */
   defaultTheme: PropTypes.oneOf(["default", "dusk"]),
   /**
-   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme.
+   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme. Do not use "theme" and "persist" props at the same time. Providing a "theme" prop indicates that the theme is managed from outside.
    */
   theme: PropTypes.oneOf(["default", "dusk"])
 };

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -12,14 +12,15 @@ const ATheme = forwardRef(
     ref
   ) => {
     const [currentTheme, setCurrentTheme] = useState("dusk");
-    const isDark = currentTheme === "dusk"
-    const isLight = currentTheme !== "dusk"
+    const isDark = currentTheme === "dusk";
+    const isLight = currentTheme !== "dusk";
 
     useIsomorphicLayoutEffect(() => {
       let initialTheme = "default";
       if (persist) {
         if (Object.prototype.hasOwnProperty.call(localStorage, LS_KEY)) {
-          initialTheme = localStorage.getItem(LS_KEY) === "dusk" ? "dusk" : "default";
+          initialTheme =
+            localStorage.getItem(LS_KEY) === "dusk" ? "dusk" : "default";
         } else if (["default", "dusk"].includes(defaultTheme)) {
           initialTheme = defaultTheme;
         } else if (
@@ -33,7 +34,8 @@ const ATheme = forwardRef(
       }
 
       setCurrentTheme(initialTheme);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+      // listen for defaultTheme prop change
+    }, [defaultTheme]);
 
     const themeContext = {
       persist,

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -39,6 +39,8 @@ const ATheme = forwardRef(
     // eagerly returns the highest priority setting
     const getInitialClientTheme = useCallback(() => {
       // supported theme in 'theme' prop overrides 'defaultTheme' and ignores 'persist' flag
+      // (this being the first case also works around a race condition between the useEffect initializing the currentTheme
+      // and the useEffect syncing the currentTheme with theme prop by both having the same outcome)
       if (isSupportedTheme(theme)) {
         return theme;
       }

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -30,24 +30,26 @@ const ATheme = forwardRef(
   ) => {
     const [currentTheme, setCurrentTheme] = useState(DEFAULT_INITIAL_THEME);
 
+    // eagerly returns the highest priority setting
     const getInitialClientTheme = useCallback(() => {
-      // take initial theme from 'defaultTheme' prop or fallback to DEFAULT_THEME
-      let initialTheme = isSupportedTheme(defaultTheme)
-        ? defaultTheme
-        : DEFAULT_INITIAL_THEME;
-      // supported theme in 'theme' prop overrides 'defaultTheme'
-      if (isSupportedTheme(theme)) {
-        initialTheme = theme;
-      }
-      // when persist is enabled and available
+      // persist is enabled and localStorage available
       if (persist && typeof localStorage !== "undefined") {
-        const persistedTheme = localStorage.getItem(LS_KEY);
         // supported persisted theme overrides both 'defaultTheme' and 'theme' props
+        const persistedTheme = localStorage.getItem(LS_KEY);
         if (isSupportedTheme(persistedTheme)) {
-          initialTheme = persistedTheme;
+          return persistedTheme;
         }
       }
-      return initialTheme;
+      // supported theme in 'theme' prop overrides 'defaultTheme'
+      if (isSupportedTheme(theme)) {
+        return theme;
+      }
+      // supported theme in 'defaultTheme'
+      if (isSupportedTheme(defaultTheme)) {
+        return defaultTheme;
+      }
+      // fallback
+      return DEFAULT_INITIAL_THEME;
     }, [persist, theme, defaultTheme]);
 
     // set initial theme based on client settings (AAutoTheme can override this further)

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -15,18 +15,18 @@ function isSupportedTheme(theme) {
 }
 
 class ThemeStorage {
-  LS_KEY = "persist-magna-react-theme";
+  static LS_KEY = "persist-magna-react-theme";
 
   static isSupported() {
     return typeof localStorage !== "undefined";
   }
 
   static loadTheme() {
-    return localStorage.getItem(this.LS_KEY);
+    return localStorage.getItem(ThemeStorage.LS_KEY);
   }
 
   static saveTheme(theme) {
-    localStorage.setItem(this.LS_KEY, theme);
+    localStorage.setItem(ThemeStorage.LS_KEY, theme);
   }
 }
 

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -48,7 +48,7 @@ const ATheme = forwardRef(
       );
     }
 
-    const [currentTheme, setCurrentTheme] = useState(DEFAULT_INITIAL_THEME);
+    const [currentTheme, setCurrentTheme] = useState(); // undefined indicates not initialized
 
     const shouldUseThemeStorage =
       ThemeStorage.isSupported() &&
@@ -84,9 +84,14 @@ const ATheme = forwardRef(
 
     // reflect theme prop changes to currentTheme
     useIsomorphicLayoutEffect(() => {
-      if (isSupportedTheme(theme)) {
-        setCurrentTheme(theme);
-      }
+      setCurrentTheme((previousTheme) => {
+        // change the current theme only if it has been initialized already
+        // to avoid a race condition with the theme initialization effect
+        const themeInitialized = typeof previousTheme !== "undefined";
+        return themeInitialized && isSupportedTheme(theme)
+          ? theme
+          : previousTheme;
+      });
     }, [theme]);
 
     // persist currentTheme on change

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -30,7 +30,7 @@ const ATheme = forwardRef(
   ) => {
     if (persist && theme) {
       console.warn(
-        `Do not use "theme" and "persist" props at the same time in "ATheme". Providing a "theme" prop indicates that the theme is managed from outside.`
+        'Do not use "theme" and "persist" props at the same time in "ATheme". Providing a "theme" prop indicates that the theme is managed from outside and it will not be persisted.'
       );
     }
 
@@ -38,17 +38,17 @@ const ATheme = forwardRef(
 
     // eagerly returns the highest priority setting
     const getInitialClientTheme = useCallback(() => {
-      // persist is enabled and localStorage available
+      // supported theme in 'theme' prop overrides 'defaultTheme' and ignores 'persist' flag
+      if (isSupportedTheme(theme)) {
+        return theme;
+      }
+      // when persist is enabled and localStorage available
       if (persist && typeof localStorage !== "undefined") {
-        // supported persisted theme overrides both 'defaultTheme' and 'theme' props
+        // supported persisted theme overrides 'defaultTheme' prop
         const persistedTheme = localStorage.getItem(LS_KEY);
         if (isSupportedTheme(persistedTheme)) {
           return persistedTheme;
         }
-      }
-      // supported theme in 'theme' prop overrides 'defaultTheme'
-      if (isSupportedTheme(theme)) {
-        return theme;
       }
       // supported theme in 'defaultTheme'
       if (isSupportedTheme(defaultTheme)) {
@@ -71,12 +71,13 @@ const ATheme = forwardRef(
       }
     }, [theme]);
 
-    // persist currentTheme on change when persist is enabled
+    // persist currentTheme on change
     useIsomorphicLayoutEffect(() => {
-      if (persist) {
+      // when "persist" is enabled, localStorage is supported, and "theme" is not managed from outside
+      if (persist && typeof localStorage !== "undefined" && !theme) {
         localStorage?.setItem(LS_KEY, currentTheme);
       }
-    }, [currentTheme, persist]);
+    }, [currentTheme, persist, theme]);
 
     const isDark = currentTheme === DUSK_THEME;
     const isLight = currentTheme !== DUSK_THEME;
@@ -120,7 +121,7 @@ ATheme.propTypes = {
    */
   defaultTheme: PropTypes.oneOf(SUPPORTED_THEMES),
   /**
-   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme. Do not use "theme" and "persist" props at the same time. Providing a "theme" prop indicates that the theme is managed from outside.
+   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme. Do not use "theme" and "persist" props at the same time. Providing a "theme" prop indicates that the theme is managed from outside and it will not be persisted.
    */
   theme: PropTypes.oneOf(SUPPORTED_THEMES)
 };

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -28,6 +28,12 @@ const ATheme = forwardRef(
     },
     ref
   ) => {
+    if (persist && theme) {
+      console.warn(
+        `Do not use "theme" and "persist" props at the same time in "ATheme". Providing a "theme" prop indicates that the theme is managed from outside.`
+      );
+    }
+
     const [currentTheme, setCurrentTheme] = useState(DEFAULT_INITIAL_THEME);
 
     // eagerly returns the highest priority setting
@@ -114,7 +120,7 @@ ATheme.propTypes = {
    */
   defaultTheme: PropTypes.oneOf(SUPPORTED_THEMES),
   /**
-   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme.
+   * Sets the current theme. Changes to this prop are reflected as a current theme. Takes precedence over defaultTheme. Do not use "theme" and "persist" props at the same time. Providing a "theme" prop indicates that the theme is managed from outside.
    */
   theme: PropTypes.oneOf(SUPPORTED_THEMES)
 };

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -10,6 +10,8 @@ const DEFAULT_THEME = "default";
 const DUSK_THEME = "dusk";
 const SUPPORTED_THEMES = [DEFAULT_THEME, DUSK_THEME];
 
+const DEFAULT_INITIAL_THEME = DEFAULT_THEME;
+
 function isSupportedTheme(theme) {
   return SUPPORTED_THEMES.includes(theme);
 }
@@ -26,13 +28,13 @@ const ATheme = forwardRef(
     },
     ref
   ) => {
-    const [currentTheme, setCurrentTheme] = useState(DEFAULT_THEME);
+    const [currentTheme, setCurrentTheme] = useState(DEFAULT_INITIAL_THEME);
 
     const getInitialClientTheme = useCallback(() => {
       // take initial theme from 'defaultTheme' prop or fallback to DEFAULT_THEME
       let initialTheme = isSupportedTheme(defaultTheme)
         ? defaultTheme
-        : DEFAULT_THEME;
+        : DEFAULT_INITIAL_THEME;
       // supported theme in 'theme' prop overrides 'defaultTheme'
       if (isSupportedTheme(theme)) {
         initialTheme = theme;


### PR DESCRIPTION
Adds support for `theme` prop to `ATheme` and `AApp` that can be used to sync nested app theme with its parent's theme. 

Some apps are using `theme`, assuming the theme will get propagated from the parent app to their nested app. Eg:
- https://github.com/advthreat/incident-manager/blob/master/src/AppWrapper.js#L9
- https://github.com/advthreat/intelligence/blob/master/src/module-federation/RemoteApp.js#L63

This has no effect as the `theme` prop does not exist.

These apps could use `defaultTheme` instead, but changes to `defaultTheme` prop are not reflected back to the current theme (which given its name makes sense).

At least some apps have figured this out and use `useEffect` to call `setCurrentTheme` to sync its theme: https://github.com/advthreat/securex-ui-monorepo/pull/304/files#diff-96ad99e94990287ef61dc6a42d6124b9cf297d63c9e2f8a4f245d81a727dc149R117
However that seems like a very convoluted way of doing things. This `useEffect` also needs to be nested 1 layer deeper than the app's `AApp`.

`ATheme` has been cleaned up a bit in this PR. I think there were some logic mistakes too.

fixes #279 