### PR TITLE
feat: implement roving focus in useFocusTrap

### DIFF
--- a/framework/hooks/useFocusTrap/useFocustrap.mdx
+++ b/framework/hooks/useFocusTrap/useFocustrap.mdx
@@ -48,7 +48,7 @@ A configuration object with the following properites:
           <APanelTitle>Focus Trap Demo</APanelTitle>
         </APanelHeader>
         <APanelBody>
-          Click into this panel, then press your <kbd>Shift</kbd> and <kbd>Shift+Tab</kbd> keys.
+          Pressing <kbd>Shift</kbd> or <kbd>Shift+Tab</kbd> only allow focus within this panel.
           <ul>
             {domains.map((domain) => (
               <li key={domain}>

--- a/framework/hooks/useFocusTrap/useFocustrap.mdx
+++ b/framework/hooks/useFocusTrap/useFocustrap.mdx
@@ -48,7 +48,7 @@ A configuration object with the following properites:
           <APanelTitle>Focus Trap Demo</APanelTitle>
         </APanelHeader>
         <APanelBody>
-          Pressing <kbd>Shift</kbd> or <kbd>Shift+Tab</kbd> only allow focus within this panel.
+          Pressing <kbd>Tab</kbd> or <kbd>Shift+Tab</kbd> only allow focus within this panel.
           <ul>
             {domains.map((domain) => (
               <li key={domain}>

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -268,3 +268,15 @@ export const kebabify = (str) => {
     })
     .join("");
 };
+
+export const isBackwardTab = (e) => {
+  const key = e.key;
+  const isTabbingBack = e.shiftKey && key === "Tab";
+  return isTabbingBack;
+};
+
+export const isForwardTab = (e) => {
+  const key = e.key;
+  const isTabbingForward = !isBackwardTab(e) && key === "Tab";
+  return isTabbingForward;
+};


### PR DESCRIPTION
Closes #283 by updating the `useFocusTrap` [`TreeWalker` instance](https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker) to accept the root (parent) node of the trap. This allows the focus trap to determine its first and last child, which allows for "roving" behavior.

This PR also fixes an issue related to the focus trap not working in a Modal due to the strict `e.stopPropagation()` behavior on `keydown` events inside that component which was merged in #244.

For a demonstration, navigate to [this preview branch's `useFocusTrap` docs](https://magna-react-git-feat-roving-focus-trap.securex-preview.app/hooks/use-focus-trap#usage) and constantly press either <kbd>Tab</kbd> or <kbd>Shift + Tab</kbd>. Focus will circulate through the trap.