### PR TITLE
fix: cleanup body scroll when AModal unmounts

### DIFF
--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -45,6 +45,7 @@ const AModal = forwardRef(
     });
     useEffect(() => {
       isOpen && lockScroll ? preventBodyScroll() : allowBodyScroll();
+      return allowBodyScroll;
     }, [lockScroll, isOpen]);
     let visibilityClass = "";
     if (!isOpen) {


### PR DESCRIPTION
Closes #263 by returning a cleanup function from the `AModal` `useEffect` to prevent body scroll when the component unmounts.

This was causing problems when `AModal` was conditionally rendered, like below:

```jsx
() => {
    const [open, setOpen] = useState(false);
    const ref = useRef();
    usePopupQuickExit({
      popupRef: ref,
      isEnabled: open,
      onExit: () => setOpen(false)
    });
    return (
      <div>
        <AButton
            onClick={() => setOpen(true)}>
            Open Modal
        </AButton>
        {open && (
          <AModal
              aria-labelledby='modal-title'
              isOpen={open}>
              <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
                <APanelHeader>
                  <APanelTitle id='modal-title'>Modal Demo</APanelTitle>
                  <AButton aria-label="Close modal 1" onClick={() => setOpen(false)} tertiaryAlt icon>
                    <AIcon>close</AIcon>
                  </AButton>
                </APanelHeader>
                <APanelBody>
                  Modal content goes here.
                </APanelBody>
                <APanelFooter>
                  <AButton>Action</AButton>
                </APanelFooter>
              </APanel>
          </AModal>
        )}
      </div>
    )
  }
```