### PR TITLE
Default animate skeleton

### DIFF
--- a/framework/components/ASkeleton/ASkeleton.js
+++ b/framework/components/ASkeleton/ASkeleton.js
@@ -15,7 +15,7 @@ const ASkeleton = forwardRef(
       nested,
       header,
       horizontal,
-      animated,
+      animated = true,
       hidePanelBackdrop = false,
       ...rest
     },

--- a/framework/components/ASkeleton/ASkeleton.mdx
+++ b/framework/components/ASkeleton/ASkeleton.mdx
@@ -17,7 +17,18 @@ import {ASkeleton, ASkeletonHeader, ASkeletonText, ASkeletonBlock} from "@cisco-
 ## Simple
 
 <Playground
-  code={`<ASkeleton header animated>
+  code={`<ASkeleton header>
+      <ASkeletonText />
+      <ASkeletonBlock />
+      <ASkeletonBlock />
+      <ASkeletonBlock height={200} />
+    </ASkeleton>`}
+/>
+
+## Not animated
+
+<Playground
+  code={`<ASkeleton header animated={false}>
       <ASkeletonText />
       <ASkeletonBlock />
       <ASkeletonBlock />


### PR DESCRIPTION
Since ASkeleton is used as a loader state more often than not, set `animate` to true for the default. 