### PR TITLE
fix: return boolean from modal propagation helper

### DIFF
--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -26,7 +26,7 @@ import "./AModal.scss";
  */
 const shouldStopPropagation = (e) => {
   const key = e.key;
-  key !== "Escape" && !isForwardTab(e) && isBackwardTab(e);
+  return key !== "Escape" && !isForwardTab(e) && !isBackwardTab(e);
 };
 
 const AModal = forwardRef(


### PR DESCRIPTION
Resolves #287 by overcoming my Friday afternoon programming miseries.

In all seriousness, the reason this bug was happening was because I forgot to return the variable that determines if we should stop propagation on keydown events, hence why an `Enter` or `Space` click was closing an accordion when the Modal was rendered inside of it.

<details>
<summary>Reproduction code block</summary>

```javascript
() => {
  const [open, setOpen] = useState(false);
  const ref = useRef();
  usePopupQuickExit({
    popupRef: ref,
    isEnabled: open,
    onExit: () => setOpen(false),
  });
  return (
    <div>
      <AAccordion>
        <AAccordionPanel>
          <AAccordionHeader>
            <AAccordionHeaderTitle>
              Accordion Title{" "}
              <AButton onClick={(e) => {
                e.stopPropagation();
                setOpen(true);
              }}>Open Modal</AButton>{" "}
              <Modal isOpen={open} />
            </AAccordionHeaderTitle>
          </AAccordionHeader>
          <AAccordionBody>Accordion content.</AAccordionBody>
        </AAccordionPanel>
      </AAccordion>
    </div>
  );

  function Modal({isOpen}) {
    return (
      <AModal aria-labelledby="modal-title" isOpen={isOpen}>
        <APanel ref={ref} style={{ minWidth: "400px" }} type="dialog">
          <APanelHeader>
            <APanelTitle id="modal-title">Modal Demo</APanelTitle>
            <AButton
              aria-label="Close modal 1"
              onClick={() => setOpen(false)}
              tertiaryAlt
              icon
            >
              <AIcon>close</AIcon>
            </AButton>
          </APanelHeader>
          <APanelBody>Modal content goes here.</APanelBody>
          <APanelFooter>
            <AButton>Action</AButton>
          </APanelFooter>
        </APanel>
      </AModal>
    );
  }
};
 ```

</details>