### PR TITLE
Workaround for info tooltip positioning

### DIFF
--- a/framework/components/AFieldBase/AFieldBase.scss
+++ b/framework/components/AFieldBase/AFieldBase.scss
@@ -26,7 +26,7 @@
       height: 16px;
       width: 16px;
       vertical-align: text-bottom;
-      margin: 0 5px;
+      padding: 0 5px;
     }
   }
 }


### PR DESCRIPTION
Tooltip has troubles positioning itself on small targets, casing the pointer to be too close to the edge. I don't wanna dive into this fully right now but this fixes at least this specific case.

Before:
<img width="284" alt="image" src="https://user-images.githubusercontent.com/51229231/225272716-8781fcef-3aaf-40f2-b605-92bbc1b536ba.png">

After:
<img width="298" alt="image" src="https://user-images.githubusercontent.com/51229231/225272815-8d8b0dcc-abbd-49d6-afc8-91000f8e5a28.png">
