### PR TITLE
Support rich ATriggerTooltip content

### DIFF
--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -110,7 +110,7 @@ ATriggerTooltip.propTypes = {
   /** Delay in milliseconds before tooltip will close */
   closeDelay: PropTypes.number,
   /** Tooltip content */
-  content: PropTypes.string,
+  content: PropTypes.node,
   /** Disable the tooltip */
   disabled: PropTypes.bool
 };

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -34,7 +34,7 @@ return (
   <ATriggerTooltip
     id="tooltip_usage_1"
     placement="right"
-    content="Tooltip text">
+    content="String tooltip text">
      <AIcon>
     information</AIcon>
   </ATooltip>
@@ -49,7 +49,7 @@ return (
   <ATriggerTooltip
     id="tooltip_usage_2"
     placement="right"
-    content="Tooltip text"
+    content={<><strong>Rich</strong> tooltip text</>}
     openDelay={0}
     trigger="click">
      <AIcon>


### PR DESCRIPTION
Relaxes `ATriggerTooltip` content prop type a bit to allow formatting without warnings.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/51229231/225347660-36e44ee9-8951-4bea-967e-64daa0508904.png">
