### PR TITLE
Close drawer/#292

### DIFF
--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -450,6 +450,7 @@ In this example, the associated more details drawer that is opened is used to de
             position='absolute'
             slideIn='right'
             openWidth='200px'
+            onClose={() => setIsDrawerOpen(false)}
             isOpen={isDrawerOpen}>
           <ADrawerContent>
             <p className='mt-0'>More details about the {drawerContent['firstCol']?.toLowerCase()}.</p>

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -2,6 +2,8 @@ import React, {forwardRef} from "react";
 import PropTypes from "prop-types";
 
 import AModal from "../AModal/AModal";
+import AButton from "../AButton/AButton";
+import AIcon from "../AIcon/AIcon";
 
 import "./ADrawer.scss";
 
@@ -20,6 +22,8 @@ const ADrawer = forwardRef(
       slim = false,
       slimHeight,
       slimWidth,
+      onClose,
+      closeTitle,
       style: propsStyle,
       ...rest
     },
@@ -32,6 +36,8 @@ const ADrawer = forwardRef(
     const orientation =
       slideIn === "bottom" || slideIn === "top" ? "horizontal" : "vertical";
     let className = `a-drawer a-drawer--${orientation} a-drawer--${position} a-drawer--${slideIn}`;
+    const closeButtonClassName = "a-drawer--close-button";
+
     const style = {...propsStyle};
 
     if (slim) {
@@ -82,6 +88,16 @@ const ADrawer = forwardRef(
           className={className}
           style={style}
         >
+          {onClose && (
+            <AButton
+              className={closeButtonClassName}
+              onClick={onClose}
+              icon
+              tertiaryAlt
+            >
+              {closeTitle ? closeTitle : <AIcon>x</AIcon>}
+            </AButton>
+          )}
           {children}
         </DrawerPanelComponent>
       );
@@ -95,6 +111,16 @@ const ADrawer = forwardRef(
           className={className}
           style={style}
         >
+          {onClose && (
+            <AButton
+              className={closeButtonClassName}
+              onClick={onClose}
+              icon
+              tertiaryAlt
+            >
+              {closeTitle ? closeTitle : <AIcon>x</AIcon>}
+            </AButton>
+          )}
           {children}
         </DrawerPanelComponent>
       </AModal>
@@ -168,7 +194,16 @@ ADrawer.propTypes = {
    * The width of the drawer when it is rendered as slim. If not specified,
    * it defaults to 50px.
    */
-  slimWidth: PropTypes.string
+  slimWidth: PropTypes.string,
+  /**
+   * Pass onClose handler for Drawer to handle onClose icon and action.
+   * Default: x Icon
+   */
+  onClose: PropTypes.func,
+  /**
+   * Option for close button title instead of default icon
+   */
+  closeTitle: PropTypes.string
 };
 
 ADrawer.displayName = "ADrawer";

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -24,6 +24,7 @@ const ADrawer = forwardRef(
       slimWidth,
       onClose,
       closeTitle,
+      closeBtnProps,
       style: propsStyle,
       ...rest
     },
@@ -94,8 +95,13 @@ const ADrawer = forwardRef(
               onClick={onClose}
               icon
               tertiaryAlt
+              {...closeBtnProps}
             >
-              {closeTitle ? closeTitle : <AIcon>x</AIcon>}
+              {closeTitle ? (
+                <div className="pa-2">{closeTitle}</div>
+              ) : (
+                <AIcon>close</AIcon>
+              )}
             </AButton>
           )}
           {children}
@@ -117,8 +123,13 @@ const ADrawer = forwardRef(
               onClick={onClose}
               icon
               tertiaryAlt
+              {...closeBtnProps}
             >
-              {closeTitle ? closeTitle : <AIcon>x</AIcon>}
+              {closeTitle ? (
+                <div className="pa-2">{closeTitle}</div>
+              ) : (
+                <AIcon>close</AIcon>
+              )}
             </AButton>
           )}
           {children}
@@ -203,7 +214,14 @@ ADrawer.propTypes = {
   /**
    * Option for close button title instead of default icon
    */
-  closeTitle: PropTypes.string
+  closeTitle: PropTypes.string,
+  /**
+   * Any additional props for close button
+   */
+  closeBtnProps: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.arrayOf(PropTypes.object)
+  ])
 };
 
 ADrawer.displayName = "ADrawer";

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -62,9 +62,10 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='left'
             ref={leftDrawerContentRef}
             isOpen={isLeftOpen}
+            onClose={() => setIsLeftOpen(false)}
             data-test-drawer-left>
           <ADrawerContent>
-            <h3 id='left-drawer-title'>Left Drawer</h3> <ADivider /> <AButton onClick={() => setIsLeftOpen(false)} data-test-drawer-close-left>Close</AButton>
+            <h3 id='left-drawer-title' className="mt-1">Left Drawer</h3> <ADivider /> <AButton onClick={() => setIsLeftOpen(false)} data-test-drawer-close-left>Close</AButton>
           </ADrawerContent>
         </ADrawer>
 
@@ -75,9 +76,10 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
+            onClose={() => setIsRightOpen(false)}
             data-test-drawer-right>
           <ADrawerContent>
-            <h3 id='right-drawer-title' >Right Drawer</h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+            <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
           </ADrawerContent>
         </ADrawer>
 
@@ -88,9 +90,10 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='bottom'
             ref={bottomDrawerContentRef}
             isOpen={isBottomOpen}
+            onClose={() => setIsBottomOpen(false)}
             data-test-drawer-bottom>
           <ADrawerContent>
-            <h3 id='bottom-drawer-title' >Bottom Drawer</h3> <ADivider /> <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>
+            <h3 id='bottom-drawer-title' className="mt-1">Bottom Drawer</h3> <ADivider /> <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>
           </ADrawerContent>
         </ADrawer>
       </>

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -45,6 +45,13 @@
     }
   }
 
+  &--close-button {
+    float: right;
+    position: relative;
+    top: 14px;
+    right: 10px;
+  }
+
   /**
     * When the drawer should render over the entire
     * page

--- a/framework/components/ADrawer/ADrawerContent.scss
+++ b/framework/components/ADrawer/ADrawerContent.scss
@@ -1,3 +1,3 @@
 .a-drawer__content {
-  padding: 24px;
+  padding: 16px 24px;
 }


### PR DESCRIPTION
Closes #292 - Add close button option to drawer.  

- Adds options for close icon or a title
- Skipped className as usage of this is unlikely at this time.
- Adjustment on `ADrawerContent` padding.  Most repos are overwriting the `24px` with `padding: 16px 24px` so if you can't beat em'--


**Button with icon**
![Screenshot 2023-03-15 at 11 31 39 AM](https://user-images.githubusercontent.com/112431822/225360251-c723ae5d-1b93-4f01-84c8-14c7fbda95af.png)

**Button with title**
![Screenshot 2023-03-15 at 10 35 16 AM](https://user-images.githubusercontent.com/112431822/225359615-eab1a272-59be-409b-87a8-f0ed9de85dd4.png)

**Functionality**

![drawerClose](https://user-images.githubusercontent.com/112431822/225360462-9d055811-ad7e-4054-9970-33b0aae2a46f.gif)

