### PR TITLE
refactor: btn to absolute

### DIFF
--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -450,7 +450,7 @@ In this example, the associated more details drawer that is opened is used to de
             position='absolute'
             slideIn='right'
             openWidth='200px'
-            onClose={() => setIsDrawerOpen(false)}
+            closeBtnOnClick={() => setIsDrawerOpen(false)}
             isOpen={isDrawerOpen}>
           <ADrawerContent>
             <p className='mt-0'>More details about the {drawerContent['firstCol']?.toLowerCase()}.</p>

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -22,7 +22,7 @@ const ADrawer = forwardRef(
       slim = false,
       slimHeight,
       slimWidth,
-      onClose,
+      closeBtnOnClick,
       closeTitle,
       closeBtnProps,
       style: propsStyle,
@@ -82,11 +82,11 @@ const ADrawer = forwardRef(
     }
 
     let closeButton;
-    if (onClose) {
+    if (closeBtnOnClick) {
       closeButton = (
         <AButton
           className={closeButtonClassName}
-          onClick={onClose}
+          onClick={closeBtnOnClick}
           icon
           tertiaryAlt
           {...closeBtnProps}
@@ -195,7 +195,7 @@ ADrawer.propTypes = {
    * Pass onClose handler for Drawer to handle onClose icon and action.
    * Default: x Icon
    */
-  onClose: PropTypes.func,
+  closeBtnOnClick: PropTypes.func,
   /**
    * Option for close button title instead of default icon
    */

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -62,7 +62,7 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='left'
             ref={leftDrawerContentRef}
             isOpen={isLeftOpen}
-            onClose={() => setIsLeftOpen(false)}
+            closeBtnOnClick={() => setIsLeftOpen(false)}
             data-test-drawer-left>
           <ADrawerContent>
             <h3 id='left-drawer-title' className="mt-1">Left Drawer</h3> <ADivider /> <AButton onClick={() => setIsLeftOpen(false)} data-test-drawer-close-left>Close</AButton>
@@ -76,7 +76,7 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
-            onClose={() => setIsRightOpen(false)}
+            closeBtnOnClick={() => setIsRightOpen(false)}
             data-test-drawer-right>
           <ADrawerContent>
             <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
@@ -90,7 +90,7 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='bottom'
             ref={bottomDrawerContentRef}
             isOpen={isBottomOpen}
-            onClose={() => setIsBottomOpen(false)}
+            closeBtnOnClick={() => setIsBottomOpen(false)}
             data-test-drawer-bottom>
           <ADrawerContent>
             <h3 id='bottom-drawer-title' className="mt-1">Bottom Drawer</h3> <ADivider /> <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -46,8 +46,7 @@
   }
 
   &--close-button {
-    float: right;
-    position: relative;
+    position: absolute;
     top: 14px;
     right: 10px;
   }


### PR DESCRIPTION
Had to move to absolute due to need for flex column display coming from Apps.  Unfortunately, this means content on left will overflow again (which is what we were trying to solve for) so this means overflow will need to be managed in the element next to it here and there. Ideally it would be nice to have option to control header content and its children with ADrawerHeader, but the refactor necessary for that to happen in the apps would be quite a rewrite on their part.