### PR TITLE
#307 - changed disabled prop to ariaDisabled

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -96,13 +96,13 @@ const AButton = forwardRef(
       }
     } else if (component) {
       TagName = component;
-      props.disabled = disabled;
       props.value = value;
       props.target = target;
+      props["aria-disable"] = disabled;
     } else {
-      props.disabled = disabled;
       props.type = type;
       props.value = value;
+      props["aria-disabled"] = disabled;
     }
 
     return <TagName {...props}>{children}</TagName>;

--- a/framework/components/ATooltip/ATooltip.mdx
+++ b/framework/components/ATooltip/ATooltip.mdx
@@ -367,6 +367,26 @@ return (
 `}
 />
 
+## `disabled` Button
+
+<Playground
+  code={`() => {
+  const buttonRef = useRef(null);
+  const [open, setOpen] = useState(false);
+  return (
+    <ATriggerTooltip content="foobar">
+     <AButton
+          secondary
+          small
+          >
+          Disabled Button
+        </AButton>
+        </ATriggerTooltip>
+  );
+}
+`}
+/>
+
 ## Accessibility Notes
 
 By default, `ATooltip` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [tooltip](https://www.w3.org/TR/wai-aria/#tooltip).


### PR DESCRIPTION
This changes the `disabled` prop on `AButton` to `ariaDisable`.

Behavior that relies on the `disabled` prop will be broken, notably form submission. Given buttons don't submit values to forms unless clicked, this is likely not an issue for this library. More information https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled


This will allow for tooltips on disabled `AButton` components.


Resolves #307 