### PR TITLE
#306 - don't use fitContentWidth for validation state alert

### DIFF
--- a/framework/components/AHint/AHint.js
+++ b/framework/components/AHint/AHint.js
@@ -20,7 +20,7 @@ const AHint = forwardRef(
     let content = <span>{children}</span>;
     if (hasValidationState) {
       content = (
-        <AAlert level={validationState} dismissable={false} fitContentWidth>
+        <AAlert level={validationState} dismissable={false}>
           {children}
         </AAlert>
       );


### PR DESCRIPTION
Leaving the prop on `AAlert` for use elsewhere, but not setting it for validation states in `AFieldBase`

Resolves #306 