### PR TITLE
remove keyframes file; move skeleton shine to component scss

### DIFF
--- a/framework/components/ASkeleton/ASkeleton.scss
+++ b/framework/components/ASkeleton/ASkeleton.scss
@@ -80,4 +80,13 @@
       animation: 6s a-skeleton-shine linear infinite;
     }
   }
+
+  @keyframes a-skeleton-shine {
+    from {
+      background-position-x: 200%;
+    }
+    to {
+      background-position-x: -200%;
+    }
+  }
 }

--- a/framework/styles/utilities/index.scss
+++ b/framework/styles/utilities/index.scss
@@ -2,4 +2,3 @@
 @import "./palette";
 @import "./variables";
 @import "./mixins";
-@import "./keyframes";

--- a/framework/styles/utilities/keyframes.scss
+++ b/framework/styles/utilities/keyframes.scss
@@ -1,8 +1,0 @@
-@keyframes a-skeleton-shine {
-  from {
-    background-position-x: 200%;
-  }
-  to {
-    background-position-x: -200%;
-  }
-}


### PR DESCRIPTION
They keyframes file was causing the keyframe to get imported into every component's scss. 