### PR TITLE
Add ASpinLoader component

### DIFF
--- a/framework/components/ALoader/ALoader.mdx
+++ b/framework/components/ALoader/ALoader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Loaders**
 route: /components/loader
-components: ACiscoLoader, ADotLoader, APageLoader
+components: ACiscoLoader, ADotLoader, APageLoader, ASpinLoader
 ---
 
 # Loaders
@@ -14,7 +14,8 @@ Integrate with your build to [auto-import](/#integrating), or add an import in y
 import {
   ACiscoLoader,
   ADotLoader,
-  APageLoader
+  APageLoader,
+  ASpinLoader
 } from "@cisco-sbg-ui/magna-react";
 ```
 
@@ -30,6 +31,29 @@ import {
   <ADivider />
   <h3>Page Loader</h3>
   <APageLoader size="small" center />
+  <ADivider />
+   <h3>Spin Loader</h3>
+  <ASpinLoader>Loading Text</ASpinLoader><br />
+</div>
+`}
+/>
+
+## Spin Variants
+
+<Playground
+  code={`<div>
+   <h3>Small</h3>
+  <ASpinLoader size="small">Small loader</ASpinLoader>
+  <ADivider />
+   <h3>Large</h3>
+  <ASpinLoader size="large">Large loader</ASpinLoader>
+  <ADivider />
+  <h3>Children left</h3>
+  <ASpinLoader childPlacement="left">Left of spinner</ASpinLoader>
+  <ADivider />
+  <h3>Children right</h3>
+  <ASpinLoader childPlacement="right">Right of spinner</ASpinLoader>
+
 </div>
 `}
 />
@@ -73,7 +97,13 @@ The `APageLoader` component inherits passed props.
 
 <Props of="APageLoader" />
 
+## Spin Loader Props
+
+The `ASpinLoader` component inherits passed props.
+
+<Props of="ASpinLoader" />
+
 ## Accessibility Notes
 
-By default, `ACiscoLoader`, `ADotLoader`, and `APageLoader` are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [progressbar](https://www.w3.org/TR/wai-aria/#progressbar).
+By default, `ACiscoLoader`, `ADotLoader`, `APageLoader`, `ASpinLoader` are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [progressbar](https://www.w3.org/TR/wai-aria/#progressbar).
 Additionally applied are the suggested `aria-valuemin` and `aria-valuemax` set at `0` and `100`, respectively, although all loaders are indeterminate.

--- a/framework/components/ALoader/ALoader.mdx
+++ b/framework/components/ALoader/ALoader.mdx
@@ -45,15 +45,23 @@ import {
    <h3>Small</h3>
   <ASpinLoader size="small">Small loader</ASpinLoader>
   <ADivider />
+     <h3>Medium</h3>
+  <ASpinLoader size="medium">Medium loader</ASpinLoader>
+  <ADivider />
    <h3>Large</h3>
   <ASpinLoader size="large">Large loader</ASpinLoader>
   <ADivider />
-  <h3>Children left</h3>
-  <ASpinLoader childPlacement="left">Left of spinner</ASpinLoader>
+  <h3>Children top</h3>
+  <ASpinLoader childPlacement="top">Top of spinner</ASpinLoader>
   <ADivider />
   <h3>Children right</h3>
   <ASpinLoader childPlacement="right">Right of spinner</ASpinLoader>
-
+  <ADivider />
+    <h3>Children bottom</h3>
+  <ASpinLoader childPlacement="bottom">Bottom of spinner</ASpinLoader>
+  <ADivider />
+    <h3>Children left</h3>
+  <ASpinLoader childPlacement="left">Left of spinner</ASpinLoader>
 </div>
 `}
 />
@@ -105,5 +113,5 @@ The `ASpinLoader` component inherits passed props.
 
 ## Accessibility Notes
 
-By default, `ACiscoLoader`, `ADotLoader`, `APageLoader`, `ASpinLoader` are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [progressbar](https://www.w3.org/TR/wai-aria/#progressbar).
+By default, `ACiscoLoader`, `ADotLoader`, `APageLoader`, and `ASpinLoader` are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [progressbar](https://www.w3.org/TR/wai-aria/#progressbar).
 Additionally applied are the suggested `aria-valuemin` and `aria-valuemax` set at `0` and `100`, respectively, although all loaders are indeterminate.

--- a/framework/components/ALoader/ASpinLoader.js
+++ b/framework/components/ALoader/ASpinLoader.js
@@ -73,11 +73,6 @@ ASpinLoader.propTypes = {
    */
   size: PropTypes.oneOf(["small", "medium", "large"]),
   /**
-   * When used with `children`, renders the loader when true, `children`
-   * when false.
-   */
-  loading: PropTypes.bool,
-  /**
    * Place children above or below spinner
    */
   childPlacement: PropTypes.oneOf(["top", "bottom", "left", "right"])

--- a/framework/components/ALoader/ASpinLoader.js
+++ b/framework/components/ALoader/ASpinLoader.js
@@ -1,0 +1,88 @@
+import PropTypes from "prop-types";
+import React, {forwardRef} from "react";
+
+import "./ASpinLoader.scss";
+const baseClass = "a-spin-loader";
+
+const ASpinLoader = forwardRef(
+  (
+    {
+      className: propsClassName,
+      size,
+      children,
+      childPlacement = "bottom",
+      ...rest
+    },
+    ref
+  ) => {
+    let className = baseClass,
+      containerClassName = `${baseClass}__container`,
+      spinnerClasslassName = `${baseClass}__spinner`;
+
+    switch (size) {
+      case "small": {
+        className += ` ${baseClass}--size-small`;
+        break;
+      }
+
+      case "large": {
+        className += ` ${baseClass}--size-large`;
+        break;
+      }
+
+      default: {
+        className += ` ${baseClass}--size-medium`;
+      }
+    }
+
+    switch (childPlacement) {
+      case "left":
+        className += ` ${baseClass}--placement-left`;
+        break;
+
+      case "right":
+        className += ` ${baseClass}--placement-right`;
+        break;
+    }
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return (
+      <div className={className} {...rest}>
+        {["top", "left"].includes(childPlacement) && children}
+        <div className={containerClassName}>
+          <div
+            role="progressbar"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            ref={ref}
+            className={spinnerClasslassName}
+          />
+        </div>
+        {["bottom", "right"].includes(childPlacement) && children}
+      </div>
+    );
+  }
+);
+
+ASpinLoader.propTypes = {
+  /**
+   * Sets the size of the indicator.
+   */
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  /**
+   * When used with `children`, renders the loader when true, `children`
+   * when false.
+   */
+  loading: PropTypes.bool,
+  /**
+   * Place children above or below spinner
+   */
+  childPlacement: PropTypes.oneOf(["top", "bottom", "left", "right"])
+};
+
+ASpinLoader.displayName = "ASpinLoader";
+
+export default ASpinLoader;

--- a/framework/components/ALoader/ASpinLoader.scss
+++ b/framework/components/ALoader/ASpinLoader.scss
@@ -1,0 +1,220 @@
+@use "sass:math";
+
+@import "../../styles";
+
+$spin-loader-padding: 0;
+$spin-loader-margin: 10px 0;
+$spin-loader-small-diameter: 16px;
+$spin-loader-medium-diameter: 20px;
+$spin-loader-large-diameter: 24px;
+$spin-loader-small-thickness: 2px;
+$spin-loader-medium-thickness: 2px;
+$spin-loader-large-thickness: 3px;
+$spin-loader-small-font-size: 12px;
+$spin-loader-medium-font-size: 14px;
+$spin-loader-large-font-size: 16px;
+$spin-loader-animation-delay: 1.1s;
+
+$spinner: ".a-spin-loader__spinner";
+
+@include theme(a-spin-loader) using ($theme) {
+  color: map-deep-get($theme, "loader", "font-color");
+  &__spinner {
+    &:after {
+      @include loader-border(
+        $spin-loader-medium-thickness,
+        map-deep-get($theme, "loader", "main-color"),
+        transparent,
+        transparent,
+        transparent
+      );
+    }
+    &:before {
+      @include loader-border(
+        $spin-loader-medium-thickness,
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color")
+      );
+    }
+  }
+  &--size-small #{$spinner} {
+    &:before {
+      @include loader-border(
+        $spin-loader-small-thickness,
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color")
+      );
+    }
+    &:after {
+      @include loader-border(
+        $spin-loader-small-thickness,
+        map-deep-get($theme, "loader", "main-color"),
+        transparent,
+        transparent,
+        transparent
+      );
+    }
+  }
+  &--size-medium #{$spinner} {
+    &:before {
+      @include loader-border(
+        $spin-loader-medium-thickness,
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color")
+      );
+    }
+    &:after {
+      @include loader-border(
+        $spin-loader-medium-thickness,
+        map-deep-get($theme, "loader", "main-color"),
+        transparent,
+        transparent,
+        transparent
+      );
+    }
+  }
+  &--size-large #{$spinner} {
+    &:before {
+      @include loader-border(
+        $spin-loader-large-thickness,
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color"),
+        map-deep-get($theme, "loader", "background-color")
+      );
+    }
+    &:after {
+      @include loader-border(
+        $spin-loader-large-thickness,
+        map-deep-get($theme, "loader", "main-color"),
+        transparent,
+        transparent,
+        transparent
+      );
+    }
+  }
+}
+
+.a-spin-loader {
+  display: inline-flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  margin: $spin-loader-margin;
+  padding: $spin-loader-padding;
+  font-size: $spin-loader-medium-font-size;
+  text-align: center;
+  overflow: hidden;
+  font-weight: 600;
+
+  &__container {
+    position: relative;
+  }
+
+  &__spinner {
+    &:after,
+    &:before {
+      position: absolute;
+      top: 0;
+      left: calc(50% - math.div($spin-loader-medium-diameter, 2));
+      border-radius: 50%;
+      content: " ";
+      @include loader-bounding-box(
+        $spin-loader-medium-diameter,
+        $spin-loader-medium-diameter
+      );
+    }
+    &:after {
+      animation: spin-loader-animation $spin-loader-animation-delay linear
+        infinite;
+    }
+  }
+
+  &--placement-right {
+    flex-direction: row;
+    #{$spinner} {
+      margin: 0 0 0 15px;
+    }
+  }
+
+  &--placement-left {
+    flex-direction: row;
+    #{$spinner} {
+      margin: 0 15px 0 0;
+    }
+  }
+
+  &--size-small {
+    font-size: $spin-loader-small-font-size;
+    #{$spinner} {
+      width: $spin-loader-small-diameter;
+      height: $spin-loader-small-diameter;
+      &:after,
+      &:before {
+        left: calc(50% - math.div($spin-loader-small-diameter, 2));
+        @include loader-bounding-box(
+          $spin-loader-small-diameter,
+          $spin-loader-small-diameter
+        );
+      }
+    }
+  }
+  &--size-medium {
+    font-size: $spin-loader-medium-font-size;
+    #{$spinner} {
+      width: $spin-loader-medium-diameter;
+      height: $spin-loader-medium-diameter;
+      &:after,
+      &:before {
+        left: calc(50% - math.div($spin-loader-medium-diameter, 2));
+        @include loader-bounding-box(
+          $spin-loader-medium-diameter,
+          $spin-loader-medium-diameter
+        );
+      }
+    }
+  }
+  &--size-large {
+    font-size: $spin-loader-large-font-size;
+    #{$spinner} {
+      width: $spin-loader-large-diameter;
+      height: $spin-loader-large-diameter;
+      &:after,
+      &:before {
+        left: calc(50% - math.div($spin-loader-large-diameter, 2));
+        @include loader-bounding-box(
+          $spin-loader-large-diameter,
+          $spin-loader-large-diameter
+        );
+      }
+    }
+  }
+
+  &--center {
+    display: block;
+    margin: 10px auto;
+  }
+}
+
+@-webkit-keyframes spin-loader-animation {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+@keyframes spin-loader-animation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/framework/components/ALoader/index.js
+++ b/framework/components/ALoader/index.js
@@ -1,5 +1,6 @@
 import ACiscoLoader from "./ACiscoLoader";
 import ADotLoader from "./ADotLoader";
 import APageLoader from "./APageLoader";
+import ASpinLoader from "./ASpinLoader";
 
-export {ACiscoLoader, ADotLoader, APageLoader};
+export {ACiscoLoader, ADotLoader, APageLoader, ASpinLoader};

--- a/framework/index.js
+++ b/framework/index.js
@@ -39,7 +39,12 @@ import {
   AListItemContent,
   AListItemAction
 } from "./components/AList";
-import {ACiscoLoader, ADotLoader, APageLoader} from "./components/ALoader";
+import {
+  ACiscoLoader,
+  ADotLoader,
+  APageLoader,
+  ASpinLoader
+} from "./components/ALoader";
 import AMenuBase from "./components/AMenuBase";
 import AMenu from "./components/AMenu";
 import AModal from "./components/AModal";
@@ -166,6 +171,7 @@ export {
   ASkeletonText,
   ASlider,
   ASpacer,
+  ASpinLoader,
   AStepper,
   AStep,
   AStepTitle,

--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -238,7 +238,8 @@ $atomic-default: (
   ),
   "loader": (
     "background-color": map-get($mds-neutral, "neutral-4"),
-    "main-color": map-get($mds-blue, "blue-7")
+    "main-color": map-get($mds-blue, "blue-7"),
+    "font-color": map-get($mds-light-theme, "default-text")
   ),
   "menu": (
     "box-shadow": 0px 2px 5px rgba(0, 0, 0, 0.05),

--- a/framework/styles/theme/dusk.scss
+++ b/framework/styles/theme/dusk.scss
@@ -237,8 +237,9 @@ $atomic-dusk: (
     "opacity--disabled": 1
   ),
   "loader": (
-    "background-color": map-get($mds-neutral, "neutral-14"),
-    "main-color": map-get($mds-blue, "blue-5")
+    "background-color": map-get($mds-neutral, "neutral-12"),
+    "main-color": map-get($mds-blue, "blue-5"),
+    "font-color": map-get($mds-neutral, "neutral-12")
   ),
   "menu": (
     "box-shadow": 0px 2px 5px rgba(0, 0, 0, 0.05),


### PR DESCRIPTION
Part of #305 

Adds new `ASpinLoader` component. The component handles the basic spinner in small, medium, and large variants. It allows allows for children and placing the children around the spinner to match variants in the design.