### PR TITLE
feat: add prop to set animation duration for AProgressbar

### DIFF
--- a/framework/components/AProgressbar/AProgressbar.js
+++ b/framework/components/AProgressbar/AProgressbar.js
@@ -9,6 +9,7 @@ const AProgressbar = forwardRef(
   (
     {
       className: propsClassName,
+      animationDuration,
       size,
       disabled,
       displayText,
@@ -72,7 +73,10 @@ const AProgressbar = forwardRef(
         <div className={`${baseClass}__bar`}>
           <div
             className={`${baseClass}__fill`}
-            style={{width: `${fixedPercentage}%`}}
+            style={{
+              width: `${fixedPercentage}%`,
+              animationDuration
+            }}
           ></div>
         </div>
       </div>
@@ -81,6 +85,11 @@ const AProgressbar = forwardRef(
 );
 
 AProgressbar.propTypes = {
+  /**
+   * Determines the duration of the progress bar (if animated).
+   * @example 0.3s
+   */
+  animationDuration: PropTypes.string,
   /**
    * Sets the size of the indicator.
    */

--- a/framework/components/AProgressbar/AProgressbar.mdx
+++ b/framework/components/AProgressbar/AProgressbar.mdx
@@ -97,6 +97,16 @@ The `AProgressbar` component inherits passed props.
 `}
 />
 
+## Custom Animation Duration
+
+<Playground
+  code={`<div>
+  <AProgressbar animationDuration="2s" indeterminate />
+  <AProgressbar animationDuration="2s" striped percentage={40} />
+</div>
+`}
+/>
+
 ## Accessibility Notes
 
 By default, `AProgressbar` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [progressbar](https://www.w3.org/TR/wai-aria/#progressbar).

--- a/framework/components/AProgressbar/AProgressbar.scss
+++ b/framework/components/AProgressbar/AProgressbar.scss
@@ -104,7 +104,6 @@ $progressbar-transition: width 0.6s ease !default;
     }
     .a-progressbar__fill {
       position: absolute;
-      animation: 1s a-progress-bar-indeterminate linear infinite !important;
     }
   }
 
@@ -176,6 +175,11 @@ $progressbar-transition: width 0.6s ease !default;
   &--size-large {
     .a-progressbar__fill {
       animation: progressbar-stripes-large $progressbar-animation-timing;
+    }
+  }
+  &--indeterminate {
+    .a-progressbar__fill {
+      animation: 1s a-progress-bar-indeterminate linear infinite;
     }
   }
 }


### PR DESCRIPTION
Allows the animation duration to be specified as a prop. If not passed, it will use the value set in the scss file.