### PR TITLE
#307 add wrapChildren prop to ATriggerTooltip

### DIFF
--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -15,6 +15,8 @@ const ATriggerTooltip = ({
   closeDelay,
   content,
   disabled = false,
+  wrapChildren = false,
+  wrapperClass,
   ...rest
 }) => {
   const childrenRef = useRef([]);
@@ -87,14 +89,25 @@ const ATriggerTooltip = ({
 
   return (
     <>
-      {React.Children.map(children, (child, index) =>
-        React.cloneElement(child, {
-          ...child.props,
-          ref: handleMultipleRefs(child.props.ref, (node) => {
+      {React.Children.map(children, (child, index) => {
+        const toClone = wrapChildren ? (
+          <div
+            className={wrapperClass}
+            style={{height: "fit-content", width: "fit-content"}}
+          >
+            {child}
+          </div>
+        ) : (
+          child
+        );
+
+        return React.cloneElement(toClone, {
+          ...toClone.props,
+          ref: handleMultipleRefs(toClone.props.ref, (node) => {
             childrenRef.current[index] = node;
           })
-        })
-      )}
+        });
+      })}
       {tooltipElement}
     </>
   );
@@ -118,7 +131,16 @@ ATriggerTooltip.propTypes = {
   /** Tooltip content */
   content: PropTypes.node,
   /** Disable the tooltip */
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  /**
+   * Wrap the children elements in a div to allow tooltips on
+   * disabled elements.
+   */
+  wrapChildren: PropTypes.bool,
+  /**
+   * Pass a class to the child wrapper.
+   */
+  wrapperClass: PropTypes.string
 };
 
 ATriggerTooltip.displayName = "ATriggerTooltip";

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -135,6 +135,23 @@ return (
 </>
 ); } `} />
 
+## On a disabled element
+
+Use `wrapChildren` to wrapper a disabled element and allow events.
+
+<Playground
+  code={`() => {
+
+return (
+
+<ATriggerTooltip
+  placement="top"
+  content="This works on a disabled element"
+  wrapChildren>
+  <AButton disabled>Disabled Button</AButton>
+</ATriggerTooltip>
+); } `} />
+
 ## TriggerTooltip Props
 
 The `ATriggerTooltip` component inherits passed props.


### PR DESCRIPTION
Adds `wrapChildren` and `wrapperClass` to `ATriggerTooltip`

This is intended to be used to allow tooltips on `disabled` elements, such as `<AButton disabled>Disabled Button</AButton>`. 


Resolves #307 