### PR TITLE
fix: update tooltip export style to fix automatic import

### DIFF
--- a/framework/components/ATooltip/index.js
+++ b/framework/components/ATooltip/index.js
@@ -1,1 +1,3 @@
-export {default, ATooltipPropTypes} from "./ATooltip";
+import ATooltip, {ATooltipPropTypes} from "./ATooltip";
+
+export {ATooltip, ATooltipPropTypes};

--- a/framework/index.js
+++ b/framework/index.js
@@ -90,7 +90,7 @@ import {
 } from "./components/ATimeline";
 import {ATheme, useATheme} from "./components/ATheme";
 import AToast from "./components/AToast";
-import ATooltip from "./components/ATooltip";
+import {ATooltip} from "./components/ATooltip";
 import ATree from "./components/ATree";
 import ATriggerTooltip from "./components/ATriggerTooltip";
 import {useABreakpoint} from "./components/ABreakpoint";


### PR DESCRIPTION
The logic inside the [`generate-babel-preset.js` script](https://github.com/cisco-sbg-ui/magna-react/blob/canary/build/generate-babel-preset.js) to prepare Magna React components for `babel-plugin-auto-import` does not handle the way `ATooltip` recently began exporting its components in #278.

Previously, `generate-babel-preset.js` would output the following for `babel-plugin-auto-import` to consume:

```json
{
  "default": "ATooltip",
  "path": "@cisco-sbg-ui/magna-react/lib/components/ATooltip"
} 
```

Currently, it looks like this:

```json
{
  "default": "ATooltipExports",
  "members": ["default", "ATooltipPropTypes"],
  "path": "@cisco-sbg-ui/magna-react/lib/components/ATooltip"
} 
```

`ATooltip` was never mapped in the `ATooltipExports` `members`, hence why some consuming applications were getting errors when trying to use `ATooltip` without an explicit `import` statement.

This PR updates the exports to follow the pattern used in other components so that we can properly map `ATooltip` as a global export.