### PR TITLE
Refactor/drawer mounting

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -6,6 +6,7 @@ import AButton from "../AButton/AButton";
 import AIcon from "../AIcon/AIcon";
 
 import "./ADrawer.scss";
+import {useDelayUnmount} from "../../utils/hooks";
 
 const ADrawer = forwardRef(
   (
@@ -30,6 +31,7 @@ const ADrawer = forwardRef(
     },
     ref
   ) => {
+    const shouldRender = useDelayUnmount(isOpen, 300);
     // A fixed drawer should automatically render as a modal unless specified
     const shouldRenderModal =
       propsAsModal || (position === "fixed" && propsAsModal == undefined);
@@ -40,6 +42,12 @@ const ADrawer = forwardRef(
     const closeButtonClassName = "a-drawer--close-button";
 
     const style = {...propsStyle};
+
+    if (isOpen) {
+      className += ` slide-in-from-${slideIn}`;
+    } else {
+      className += ` slide-out-to-${slideIn}`;
+    }
 
     if (slim) {
       className += ` a-drawer--slim`;
@@ -55,7 +63,7 @@ const ADrawer = forwardRef(
       }
     }
     if (!isOpen) {
-      className += ` a-drawer--hidden`;
+      //className += ` a-drawer--hidden`;
     } else if (!slim && openWidth) {
       style.width = openWidth;
     } else if (!slim && openHeight) {
@@ -113,11 +121,11 @@ const ADrawer = forwardRef(
     );
 
     if (!shouldRenderModal) {
-      return drawerPanelComponent;
+      return shouldRender && drawerPanelComponent;
     }
 
     return (
-      <AModal isOpen={isOpen} {...rest}>
+      <AModal delayMount={300} isOpen={isOpen} withAnimations={false} {...rest}>
         {drawerPanelComponent}
       </AModal>
     );

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -1,5 +1,14 @@
 @import "../../styles";
 
+$transition-duration: 0.3s;
+$transition-timing: ease-in-out;
+$transition-props: $transition-duration $transition-timing;
+
+//limit transition properties to avoid animating other properties coming form outside
+$common-transitions: transform $transition-props, width $transition-props,
+  height $transition-props, max-width $transition-props,
+  max-height $transition-props;
+
 @include theme(a-drawer) using ($theme) {
   background: map-deep-get($theme, "drawer", "bg");
 }
@@ -9,16 +18,7 @@
 
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
 
-  transform: translateX(0);
-
-  $transition-duration: 0.3s;
-  $transition-timing: ease-in-out;
-  $transition-props: $transition-duration $transition-timing;
-
-  // limit transition properties to avoid animating other properties coming form outside
-  $common-transitions: transform $transition-props, width $transition-props,
-    height $transition-props, max-width $transition-props,
-    max-height $transition-props;
+  transform: translateX(100%);
 
   @include transition(
     $common-transitions,
@@ -113,33 +113,112 @@
     bottom: 0;
     left: 0;
   }
+}
 
-  &--hidden {
-    @include transition(
-      $common-transitions,
-      // delay visibility change after other transitions
-      visibility 0s linear $transition-duration
-    );
+.slide-in-from-right {
+  animation-name: slideInFromRight;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    overflow: hidden;
-    visibility: hidden;
+.slide-out-to-right {
+  animation-name: slideOutToRight;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    &.a-drawer--left {
-      transform: translateX(-100%);
-    }
+.slide-in-from-left {
+  animation-name: slideInFromLeft;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    &.a-drawer--right {
-      transform: translateX(100%);
-    }
+.slide-out-to-left {
+  animation-name: slideOutToLeft;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    &.a-drawer--bottom {
-      transform: translateY(100%);
-    }
-  }
+.slide-in-from-bottom {
+  animation-name: slideInFromBottom;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.slide-out-to-bottom {
+  animation-name: slideOutToBottom;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
 }
 
 @media (prefers-reduced-motion) {
   .a-drawer {
     transition: none;
+  }
+}
+
+@keyframes slideInFromRight {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutToRight {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slideInFromLeft {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutToLeft {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes slideInFromBottom {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideOutToBottom {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
   }
 }

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -11,9 +11,9 @@
 
   transform: translateX(0);
 
-  $animation-duration: 0.3s;
-  $animation-timing: ease-in-out;
-  $transition-props: $animation-duration $animation-timing;
+  $transition-duration: 0.3s;
+  $transition-timing: ease-in-out;
+  $transition-props: $transition-duration $transition-timing;
 
   // limit transition properties to avoid animating other properties coming form outside
   $common-transitions: transform $transition-props, width $transition-props,
@@ -118,7 +118,7 @@
     @include transition(
       $common-transitions,
       // delay visibility change after other transitions
-      visibility 0s linear $animation-duration
+      visibility 0s linear $transition-duration
     );
 
     overflow: hidden;

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -36,6 +36,7 @@ const AModal = forwardRef(
       appendTo = null,
       as = "div",
       className: propsClassName,
+      delayMount = 100,
       children,
       lockScroll = true,
       withOverlay = true,
@@ -57,7 +58,7 @@ const AModal = forwardRef(
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
 
-    const shouldRender = useDelayUnmount(isOpen, 100);
+    const shouldRender = useDelayUnmount(isOpen, delayMount);
 
     useFocusTrap({
       rootRef: _ref,

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -39,6 +39,7 @@ const AModal = forwardRef(
       children,
       lockScroll = true,
       withOverlay = true,
+      withAnimations = true,
       trapFocus = true,
       isOpen: propsIsOpen,
       small,
@@ -56,7 +57,7 @@ const AModal = forwardRef(
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
 
-    const shouldRender = useDelayUnmount(isOpen, 300);
+    const shouldRender = useDelayUnmount(isOpen, 100);
 
     useFocusTrap({
       rootRef: _ref,
@@ -68,17 +69,19 @@ const AModal = forwardRef(
       return allowBodyScroll;
     }, [lockScroll, shouldRender]);
 
-    const animationClassName = isOpen
-      ? "animation-fade-in"
-      : "animation-fade-out";
-
     let visibilityClass = "";
 
     if (!shouldRender) {
       visibilityClass += "a-modal--hidden";
     }
 
+    let overlayClassName = "";
     let contentClassName = `a-modal-container ${visibilityClass}`;
+
+    if (withAnimations) {
+      overlayClassName = isOpen ? "animation-fade-in" : "animation-fade-out";
+      contentClassName += isOpen ? " animation-grow" : " animation-shrink";
+    }
 
     if (small) {
       contentClassName += " a-modal-container--small";
@@ -119,8 +122,7 @@ const AModal = forwardRef(
     if (withOverlay) {
       return ReactDOM.createPortal(
         <APageOverlay
-          //style={isOpen ? mountedStyle : unmountedStyle}
-          className={`${visibilityClass} ${animationClassName}`}
+          className={`${visibilityClass} ${overlayClassName}`}
           onKeyDown={(e) => {
             if (shouldStopPropagation(e)) {
               e.stopPropagation();
@@ -160,7 +162,7 @@ const AModal = forwardRef(
         <Component
           role="dialog"
           aria-modal="true"
-          className={`${contentClassName} ${animationClassName}`}
+          className={`${contentClassName}`}
           ref={handleMultipleRefs(_ref, ref)}
           onKeyDown={(e) => {
             if (shouldStopPropagation(e)) {
@@ -273,7 +275,12 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   /**
    * If not using the `usePopupQuickExit` hook, pass in a function to handle clicking outside of the modal event. `withOverlay` prop must be set to true.
    */
-  onClickOutside: PropTypes.func
+  onClickOutside: PropTypes.func,
+
+  /**
+   * Determines if the modal should open and close with CSS animations.
+   */
+  withAnimations: PropTypes.bool
 };
 
 AModal.displayName = "AModal";

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -140,6 +140,49 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+### Without Animations
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+    const [open, setOpen] = useState(false);
+    const ref = useRef();
+    usePopupQuickExit({
+      popupRef: ref,
+      isEnabled: open,
+      onExit: () => setOpen(false)
+    });
+    return (
+      <div>
+        <AButton
+            onClick={() => setOpen(true)}>
+            Open Modal
+        </AButton>
+        <AModal
+            withAnimations={false}
+            aria-labelledby='modal-title'
+            isOpen={open}>
+            <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
+              <APanelHeader>
+                <APanelTitle id='modal-title'>No Animations</APanelTitle>
+                <AButton aria-label="Close modal 1" onClick={() => setOpen(false)} tertiaryAlt icon>
+                  <AIcon>close</AIcon>
+                </AButton>
+              </APanelHeader>
+              <APanelBody>
+                Modal content goes here.
+              </APanelBody>
+              <APanelFooter>
+                <AButton>Action</AButton>
+              </APanelFooter>
+            </APanel>
+        </AModal>
+      </div>
+    )
+  }
+`}
+/>
+
 ### Form Example
 
 <Playground

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -5,6 +5,7 @@
   align-items: center;
   width: 100vw;
   height: 100vh;
+  animation-delay: 0s;
 
   .a-panel {
     &__title {
@@ -33,4 +34,56 @@
 
 .a-modal--hidden {
   visibility: hidden;
+}
+
+.animation-fade-in {
+  animation-name: fadeIn;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.animation-fade-out {
+  animation-name: fadeOut;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes slideIn {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slideOut {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
 }

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -39,7 +39,7 @@
 .animation-fade-in {
   animation-name: fadeIn;
   animation-delay: 0s;
-  animation-duration: 0.3s;
+  animation-duration: 0.15s;
   animation-timing-function: ease-in-out;
   animation-fill-mode: forwards;
 }
@@ -47,9 +47,43 @@
 .animation-fade-out {
   animation-name: fadeOut;
   animation-delay: 0s;
-  animation-duration: 0.3s;
+  animation-duration: 0.15s;
   animation-timing-function: ease-in-out;
   animation-fill-mode: forwards;
+}
+
+.animation-grow {
+  animation-name: grow;
+  animation-delay: 0s;
+  animation-duration: 0.15s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.animation-shrink {
+  animation-name: shrink;
+  animation-delay: 0s;
+  animation-duration: 0.15s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+@keyframes grow {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes shrink {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0);
+  }
 }
 
 @keyframes fadeIn {

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -1,4 +1,4 @@
-import {useEffect, useLayoutEffect, useRef} from "react";
+import {useEffect, useLayoutEffect, useRef, useState} from "react";
 
 export const useCombinedRefs = (...refs) => {
   const targetRef = useRef();
@@ -20,3 +20,21 @@ export const useCombinedRefs = (...refs) => {
 
 export const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export const useDelayUnmount = (isOpen, delayTime) => {
+  const timeout = useRef();
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useLayoutEffect(() => {
+    if (isOpen && !shouldRender) {
+      setShouldRender(true);
+    } else if (!isOpen && shouldRender) {
+      timeout.current = setTimeout(() => {
+        setShouldRender(false);
+        clearTimeout(timeout.current);
+      }, delayTime);
+    }
+    return () => clearTimeout(timeout.current);
+  }, [isOpen, delayTime, shouldRender]);
+  return shouldRender;
+};


### PR DESCRIPTION
This is a draft PR to explore options in conditionally rendering both `AModal` and `ADrawer`. The intent is that we don't always need to keep their children rendered in order to perform smooth transitions.

This will also give `AModal` a similar animation found in the Magnetic React team's modal.