### PR TITLE
feat: conditionally render modal and drawer children

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -31,7 +31,7 @@ const ADrawer = forwardRef(
     },
     ref
   ) => {
-    const shouldRender = useDelayUnmount(isOpen, 300);
+    const shouldRenderChildren = useDelayUnmount({isOpen, delayTime: 300});
     // A fixed drawer should automatically render as a modal unless specified
     const shouldRenderModal =
       propsAsModal || (position === "fixed" && propsAsModal == undefined);
@@ -121,11 +121,12 @@ const ADrawer = forwardRef(
     );
 
     if (!shouldRenderModal) {
-      return shouldRender && drawerPanelComponent;
+      return shouldRenderChildren && drawerPanelComponent;
     }
 
     return (
       <AModal delayMount={300} isOpen={isOpen} withAnimations={false} {...rest}>
+        {/* `AModal` already handles children mounting conditional */}
         {drawerPanelComponent}
       </AModal>
     );

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -48,6 +48,10 @@ const ADrawer = forwardRef(
 
     const style = {...propsStyle};
 
+    if (shouldRenderModal) {
+      className += " a-drawer--modal";
+    }
+
     if (withTransitions) {
       className += " a-drawer--transitions";
     }

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -136,9 +136,9 @@ const ADrawer = forwardRef(
       <AModal
         {...rest}
         ref={ref}
-        centerContent={false}
         className={className}
         delayUnmount={300}
+        withCenteredContent={false}
         withTransitions={false}
         isOpen={shouldRenderChildren}
       >

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -48,16 +48,20 @@ const ADrawer = forwardRef(
 
     const style = {...propsStyle};
 
-    if (withAnimations && shouldRenderChildren) {
-      className += isOpen
-        ? ` slide-in-from-${slideIn}`
-        : ` slide-out-to-${slideIn}`;
+    let visibilityClassName = "a-drawer";
+
+    if (withAnimations) {
+      visibilityClassName += " a-drawer--transitions";
     }
 
-    className += shouldRenderChildren ? " a-drawer--show" : " a-drawer--hidden";
+    if (shouldRenderChildren) {
+      visibilityClassName += isOpen ? " a-drawer--show" : " a-drawer--hidden";
+    } else {
+      visibilityClassName += " a-drawer--hidden";
+    }
 
     if (slim) {
-      className += ` a-drawer--slim`;
+      className += " a-drawer--slim";
 
       if (slimWidth) {
         style.width = slimWidth;
@@ -69,11 +73,10 @@ const ADrawer = forwardRef(
         style.maxHeight = slimHeight;
       }
     }
-    if (!isOpen) {
-      //className += ` a-drawer--hidden`;
-    } else if (!slim && openWidth) {
+
+    if (isOpen && !slim && openWidth) {
       style.width = openWidth;
-    } else if (!slim && openHeight) {
+    } else if (isOpen && !slim && openHeight) {
       style.height = openHeight;
     }
     if (propsClassName) {
@@ -119,7 +122,7 @@ const ADrawer = forwardRef(
       <DrawerPanelComponent
         {...rest}
         ref={ref}
-        className={className}
+        className={`${className} ${visibilityClassName}`}
         style={style}
       >
         {closeButton}
@@ -133,9 +136,10 @@ const ADrawer = forwardRef(
 
     return (
       <AModal
-        delayMount={withAnimations ? 300 : 0}
-        isOpen={isOpen}
+        alwaysRenderChildren={true}
+        delayMount={300}
         withAnimations={false}
+        isOpen={shouldRenderChildren}
         {...rest}
       >
         {drawerPanelComponent}

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -27,7 +27,7 @@ const ADrawer = forwardRef(
       closeTitle,
       closeBtnProps,
       style: propsStyle,
-      withAnimations = true,
+      withTransitions = true,
       ...rest
     },
     ref
@@ -35,7 +35,7 @@ const ADrawer = forwardRef(
     const shouldRenderChildren = useDelayUnmount({
       isOpen,
       delayTime: 300,
-      isEnabled: withAnimations
+      isEnabled: withTransitions
     });
     // A fixed drawer should automatically render as a modal unless specified
     const shouldRenderModal =
@@ -48,16 +48,14 @@ const ADrawer = forwardRef(
 
     const style = {...propsStyle};
 
-    let visibilityClassName = "a-drawer";
-
-    if (withAnimations) {
-      visibilityClassName += " a-drawer--transitions";
+    if (withTransitions) {
+      className += " a-drawer--transitions";
     }
 
     if (shouldRenderChildren) {
-      visibilityClassName += isOpen ? " a-drawer--show" : " a-drawer--hidden";
+      className += isOpen ? " a-drawer--show" : " a-drawer--hidden";
     } else {
-      visibilityClassName += " a-drawer--hidden";
+      className += " a-drawer--hidden";
     }
 
     if (slim) {
@@ -122,7 +120,7 @@ const ADrawer = forwardRef(
       <DrawerPanelComponent
         {...rest}
         ref={ref}
-        className={`${className} ${visibilityClassName}`}
+        className={shouldRenderModal ? "" : className}
         style={style}
       >
         {closeButton}
@@ -136,9 +134,10 @@ const ADrawer = forwardRef(
 
     return (
       <AModal
-        alwaysRenderChildren={true}
+        centerContent={false}
+        className={className}
         delayUnmount={300}
-        withAnimations={false}
+        withTransitions={false}
         isOpen={shouldRenderChildren}
         {...rest}
       >

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -6,6 +6,7 @@ import AButton from "../AButton/AButton";
 import AIcon from "../AIcon/AIcon";
 
 import "./ADrawer.scss";
+import {useDelayUnmount} from "../../utils/hooks";
 
 const ADrawer = forwardRef(
   (
@@ -30,6 +31,7 @@ const ADrawer = forwardRef(
     },
     ref
   ) => {
+    const shouldRender = useDelayUnmount(isOpen, 300);
     // A fixed drawer should automatically render as a modal unless specified
     const shouldRenderModal =
       propsAsModal || (position === "fixed" && propsAsModal == undefined);
@@ -40,6 +42,12 @@ const ADrawer = forwardRef(
     const closeButtonClassName = "a-drawer--close-button";
 
     const style = {...propsStyle};
+
+    if (isOpen) {
+      className += ` slide-in-from-${slideIn}`;
+    } else {
+      className += ` slide-out-to-${slideIn}`;
+    }
 
     if (slim) {
       className += ` a-drawer--slim`;
@@ -55,7 +63,7 @@ const ADrawer = forwardRef(
       }
     }
     if (!isOpen) {
-      className += ` a-drawer--hidden`;
+      //className += ` a-drawer--hidden`;
     } else if (!slim && openWidth) {
       style.width = openWidth;
     } else if (!slim && openHeight) {
@@ -113,11 +121,11 @@ const ADrawer = forwardRef(
     );
 
     if (!shouldRenderModal) {
-      return drawerPanelComponent;
+      return shouldRender && drawerPanelComponent;
     }
 
     return (
-      <AModal isOpen={isOpen} {...rest}>
+      <AModal delayMount={300} isOpen={isOpen} withAnimations={false} {...rest}>
         {drawerPanelComponent}
       </AModal>
     );

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -119,7 +119,7 @@ const ADrawer = forwardRef(
     const drawerPanelComponent = (
       <DrawerPanelComponent
         {...rest}
-        ref={ref}
+        ref={shouldRenderModal ? null : ref}
         className={shouldRenderModal ? "" : className}
         style={style}
       >
@@ -134,12 +134,13 @@ const ADrawer = forwardRef(
 
     return (
       <AModal
+        {...rest}
+        ref={ref}
         centerContent={false}
         className={className}
         delayUnmount={300}
         withTransitions={false}
         isOpen={shouldRenderChildren}
-        {...rest}
       >
         {drawerPanelComponent}
       </AModal>

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -121,7 +121,7 @@ const ADrawer = forwardRef(
         {...rest}
         ref={shouldRenderModal ? null : ref}
         className={shouldRenderModal ? "" : className}
-        style={style}
+        style={shouldRenderModal ? {} : style}
       >
         {closeButton}
         {shouldRenderChildren && children}
@@ -141,6 +141,7 @@ const ADrawer = forwardRef(
         withCenteredContent={false}
         withTransitions={false}
         isOpen={shouldRenderChildren}
+        style={style}
       >
         {drawerPanelComponent}
       </AModal>

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -27,11 +27,16 @@ const ADrawer = forwardRef(
       closeTitle,
       closeBtnProps,
       style: propsStyle,
+      withAnimations = true,
       ...rest
     },
     ref
   ) => {
-    const shouldRenderChildren = useDelayUnmount({isOpen, delayTime: 300});
+    const shouldRenderChildren = useDelayUnmount({
+      isOpen,
+      delayTime: 300,
+      isEnabled: withAnimations
+    });
     // A fixed drawer should automatically render as a modal unless specified
     const shouldRenderModal =
       propsAsModal || (position === "fixed" && propsAsModal == undefined);
@@ -43,11 +48,13 @@ const ADrawer = forwardRef(
 
     const style = {...propsStyle};
 
-    if (isOpen) {
-      className += ` slide-in-from-${slideIn}`;
-    } else {
-      className += ` slide-out-to-${slideIn}`;
+    if (withAnimations && shouldRenderChildren) {
+      className += isOpen
+        ? ` slide-in-from-${slideIn}`
+        : ` slide-out-to-${slideIn}`;
     }
+
+    className += shouldRenderChildren ? " a-drawer--show" : " a-drawer--hidden";
 
     if (slim) {
       className += ` a-drawer--slim`;
@@ -116,17 +123,21 @@ const ADrawer = forwardRef(
         style={style}
       >
         {closeButton}
-        {children}
+        {shouldRenderChildren && children}
       </DrawerPanelComponent>
     );
 
     if (!shouldRenderModal) {
-      return shouldRenderChildren && drawerPanelComponent;
+      return drawerPanelComponent;
     }
 
     return (
-      <AModal delayMount={300} isOpen={isOpen} withAnimations={false} {...rest}>
-        {/* `AModal` already handles children mounting conditional */}
+      <AModal
+        delayMount={withAnimations ? 300 : 0}
+        isOpen={isOpen}
+        withAnimations={false}
+        {...rest}
+      >
         {drawerPanelComponent}
       </AModal>
     );

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -137,7 +137,7 @@ const ADrawer = forwardRef(
     return (
       <AModal
         alwaysRenderChildren={true}
-        delayMount={300}
+        delayUnmount={300}
         withAnimations={false}
         isOpen={shouldRenderChildren}
         {...rest}

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -528,7 +528,7 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
   }`}
 />
 
-### Without Animations
+### Without CSS Transitions
 
 <Playground
   code={`() => {
@@ -545,7 +545,7 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
         <p>Right slide-in</p>
         <AButton onClick={() => setIsRightOpen(true)} data-test-drawer-trigger-right>Open Right</AButton>
         <ADrawer
-            withAnimations={false}
+            withTransitions={false}
             aria-labelledby='right-drawer-title'
             slideIn='right'
             ref={rightDrawerContentRef}

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -102,6 +102,41 @@ The drawer can slide-in from the left, right, or bottom of the page.
 }`}
 />
 
+### Custom Width
+
+<Playground
+  code={`() => {
+
+    const rightDrawerContentRef = useRef();
+    const [isRightOpen, setIsRightOpen] = useState(false);
+    usePopupQuickExit({
+      popupRef: rightDrawerContentRef,
+      isEnabled: isRightOpen,
+      onExit: () => setIsRightOpen(false)
+    });
+
+    return (
+      <>
+        <p>Right slide-in</p>
+        <AButton onClick={() => setIsRightOpen(true)} data-test-drawer-trigger-right>Open Right</AButton>
+        <ADrawer
+            openWidth='800px'
+            aria-labelledby='right-drawer-title'
+            slideIn='right'
+            ref={rightDrawerContentRef}
+            isOpen={isRightOpen}
+            closeBtnOnClick={() => setIsRightOpen(false)}
+            data-test-drawer-right>
+          <ADrawerContent>
+            <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerContent>
+        </ADrawer>
+      </>
+    )
+
+}`}
+/>
+
 ### Drawer Positioning Strategies
 
 By default, `ADrawer` is rendered as a fixed element. This means that the drawer will pan the entire viewport, covering any content underneath [0].

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -528,6 +528,40 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
   }`}
 />
 
+### Without Animations
+
+<Playground
+  code={`() => {
+    const rightDrawerContentRef = useRef();
+    const [isRightOpen, setIsRightOpen] = useState(false);
+    usePopupQuickExit({
+      popupRef: rightDrawerContentRef,
+      isEnabled: isRightOpen,
+      onExit: () => setIsRightOpen(false)
+    });
+
+    return (
+      <>
+        <p>Right slide-in</p>
+        <AButton onClick={() => setIsRightOpen(true)} data-test-drawer-trigger-right>Open Right</AButton>
+        <ADrawer
+            withAnimations={false}
+            aria-labelledby='right-drawer-title'
+            slideIn='right'
+            ref={rightDrawerContentRef}
+            isOpen={isRightOpen}
+            closeBtnOnClick={() => setIsRightOpen(false)}
+            data-test-drawer-right>
+          <ADrawerContent>
+            <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerContent>
+        </ADrawer>
+      </>
+    )
+
+}`}
+/>
+
 ## Drawer Props
 
 <Props of="ADrawer" />

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -17,6 +17,11 @@ $common-transitions: transform $transition-props, width $transition-props,
   overflow: hidden;
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
 
+  &--modal {
+    top: unset;
+    left: unset;
+  }
+
   &--transitions {
     @include transition(
       $common-transitions,

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -1,5 +1,14 @@
 @import "../../styles";
 
+$transition-duration: 0.3s;
+$transition-timing: ease-in-out;
+$transition-props: $transition-duration $transition-timing;
+
+//limit transition properties to avoid animating other properties coming form outside
+$common-transitions: transform $transition-props, width $transition-props,
+  height $transition-props, max-width $transition-props,
+  max-height $transition-props;
+
 @include theme(a-drawer) using ($theme) {
   background: map-deep-get($theme, "drawer", "bg");
 }
@@ -9,16 +18,7 @@
 
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
 
-  transform: translateX(0);
-
-  $transition-duration: 0.3s;
-  $transition-timing: ease-in-out;
-  $transition-props: $transition-duration $transition-timing;
-
-  // limit transition properties to avoid animating other properties coming form outside
-  $common-transitions: transform $transition-props, width $transition-props,
-    height $transition-props, max-width $transition-props,
-    max-height $transition-props;
+  transform: translateX(100%);
 
   @include transition(
     $common-transitions,
@@ -113,33 +113,112 @@
     bottom: 0;
     left: 0;
   }
+}
 
-  &--hidden {
-    @include transition(
-      $common-transitions,
-      // delay visibility change after other transitions
-      visibility 0s linear $transition-duration
-    );
+.slide-in-from-right {
+  animation-name: slideInFromRight;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    overflow: hidden;
-    visibility: hidden;
+.slide-out-to-right {
+  animation-name: slideOutToRight;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    &.a-drawer--left {
-      transform: translateX(-100%);
-    }
+.slide-in-from-left {
+  animation-name: slideInFromLeft;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    &.a-drawer--right {
-      transform: translateX(100%);
-    }
+.slide-out-to-left {
+  animation-name: slideOutToLeft;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
 
-    &.a-drawer--bottom {
-      transform: translateY(100%);
-    }
-  }
+.slide-in-from-bottom {
+  animation-name: slideInFromBottom;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.slide-out-to-bottom {
+  animation-name: slideOutToBottom;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
 }
 
 @media (prefers-reduced-motion) {
   .a-drawer {
     transition: none;
+  }
+}
+
+@keyframes slideInFromRight {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutToRight {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slideInFromLeft {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutToLeft {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes slideInFromBottom {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideOutToBottom {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
   }
 }

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -124,16 +124,19 @@ $common-transitions: transform $transition-props, width $transition-props,
   &--left:not(.a-drawer--relative) {
     top: 0;
     left: 0;
+    right: unset;
   }
 
   &--right:not(.a-drawer--relative) {
     top: 0;
     right: 0;
+    left: unset;
   }
 
   &--bottom:not(.a-drawer--relative) {
     bottom: 0;
     left: 0;
+    top: unset;
   }
 }
 

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -18,12 +18,18 @@ $common-transitions: transform $transition-props, width $transition-props,
 
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
 
-  transform: translateX(100%);
-
   @include transition(
     $common-transitions,
     visibility 0s // immediate visibility change
   );
+
+  &--hidden {
+    transform: translateX(100%);
+  }
+
+  &--show {
+    transform: translateX(0);
+  }
 
   &--vertical {
     height: 100vh;

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -11,9 +11,9 @@
 
   transform: translateX(0);
 
-  $animation-duration: 0.3s;
-  $animation-timing: ease-in-out;
-  $transition-props: $animation-duration $animation-timing;
+  $transition-duration: 0.3s;
+  $transition-timing: ease-in-out;
+  $transition-props: $transition-duration $transition-timing;
 
   // limit transition properties to avoid animating other properties coming form outside
   $common-transitions: transform $transition-props, width $transition-props,
@@ -118,7 +118,7 @@
     @include transition(
       $common-transitions,
       // delay visibility change after other transitions
-      visibility 0s linear $animation-duration
+      visibility 0s linear $transition-duration
     );
 
     overflow: hidden;

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -15,16 +15,27 @@ $common-transitions: transform $transition-props, width $transition-props,
 
 .a-drawer {
   overflow: hidden;
-
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
 
-  @include transition(
-    $common-transitions,
-    visibility 0s // immediate visibility change
-  );
+  &--transitions {
+    @include transition(
+      $common-transitions,
+      visibility 0s // immediate visibility change
+    );
+  }
 
   &--hidden {
-    transform: translateX(100%);
+    &.a-drawer--left {
+      transform: translateX(-100%);
+    }
+
+    &.a-drawer--right {
+      transform: translateX(100%);
+    }
+
+    &.a-drawer--bottom {
+      transform: translateY(100%);
+    }
   }
 
   &--show {
@@ -121,110 +132,8 @@ $common-transitions: transform $transition-props, width $transition-props,
   }
 }
 
-.slide-in-from-right {
-  animation-name: slideInFromRight;
-  animation-delay: 0s;
-  animation-duration: 0.3s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.slide-out-to-right {
-  animation-name: slideOutToRight;
-  animation-delay: 0s;
-  animation-duration: 0.3s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.slide-in-from-left {
-  animation-name: slideInFromLeft;
-  animation-delay: 0s;
-  animation-duration: 0.3s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.slide-out-to-left {
-  animation-name: slideOutToLeft;
-  animation-delay: 0s;
-  animation-duration: 0.3s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.slide-in-from-bottom {
-  animation-name: slideInFromBottom;
-  animation-delay: 0s;
-  animation-duration: 0.3s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.slide-out-to-bottom {
-  animation-name: slideOutToBottom;
-  animation-delay: 0s;
-  animation-duration: 0.3s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
 @media (prefers-reduced-motion) {
   .a-drawer {
     transition: none;
-  }
-}
-
-@keyframes slideInFromRight {
-  0% {
-    transform: translateX(100%);
-  }
-  100% {
-    transform: translateX(0);
-  }
-}
-
-@keyframes slideOutToRight {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
-
-@keyframes slideInFromLeft {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(0);
-  }
-}
-
-@keyframes slideOutToLeft {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(-100%);
-  }
-}
-
-@keyframes slideInFromBottom {
-  0% {
-    transform: translateY(100%);
-  }
-  100% {
-    transform: translateY(0);
-  }
-}
-
-@keyframes slideOutToBottom {
-  0% {
-    transform: translateY(0);
-  }
-  100% {
-    transform: translateY(100%);
   }
 }

--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -60,12 +60,12 @@ function testPropagation(testComponent) {
     cy.mount(testComponent);
 
     // Open accordion; make sure modal is not opened
-    cy.getByDataTestId("toggle-accordion-btn").click();
+    cy.getByDataTestId("toggle-accordion-btn").click(10, 10); // set click position to not also click modal button
     getModalContent().should("not.exist");
     cy.getByDataTestId("accordion-content").should("be.visible");
 
     // Close accordion
-    cy.getByDataTestId("toggle-accordion-btn").click();
+    cy.getByDataTestId("toggle-accordion-btn").click(10, 10); // set click position to not also click modal button
 
     // Open modal; should _not_ also open the accordion
     cy.getByDataTestId("modal-trigger").click();
@@ -79,12 +79,12 @@ function testPropagation(testComponent) {
     cy.mount(testComponent);
 
     // Open accordion; make sure modal is not opened
-    cy.getByDataTestId("toggle-accordion-btn").click();
+    cy.getByDataTestId("toggle-accordion-btn").click(10, 10); // set click position to not also click modal button
     getModalContent().should("not.exist");
     cy.getByDataTestId("accordion-content").should("be.visible");
 
     // Close accordion
-    cy.getByDataTestId("toggle-accordion-btn").click();
+    cy.getByDataTestId("toggle-accordion-btn").click(10, 10); // set click position to not also click modal button
 
     // Open modal; should _not_ also open the accordion
     cy.getByDataTestId("modal-trigger").click();
@@ -121,6 +121,19 @@ describe("<AModal />", () => {
     );
     testPropagation(
       <AMount>
+        <WithAccordionTest />
+      </AMount>
+    );
+  });
+
+  describe("when rendered within another <AMount /> component that has experimental wrapping", () => {
+    testCoreFunctionality(
+      <AMount withNewWrappingContext={true}>
+        <ModalTest />
+      </AMount>
+    );
+    testPropagation(
+      <AMount withNewWrappingContext={true}>
         <WithAccordionTest />
       </AMount>
     );

--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -25,6 +25,20 @@ import useAToaster from "../AToaster/useAToaster";
 const getModalContent = () => cy.getByDataTestId("modal-content");
 const openModal = () => cy.getByDataTestId("modal-trigger").click();
 
+/**
+ * Tests core modal functionality assuming the component to be tested contains the following `data-testids`:
+ *    `modal-trigger` - the element that opens the modal
+ *
+ *    `close-modal-trigger` - the element that closes the modal
+ *
+ *    `focusable-child-1` - the first child of the modal that can receive focus
+ *
+ *    `focusable-child-2` - the second child of the modal that can receive focus
+ *
+ *    `focusable-child-3` - the third child of the modal that can receive focus
+ *
+ * @param {React Component} testComponent
+ */
 function testCoreFunctionality(testComponent) {
   it("focuses on the first element", () => {
     cy.mount(testComponent);
@@ -55,6 +69,22 @@ function testCoreFunctionality(testComponent) {
   });
 }
 
+/**
+ * Test modal propagation assuming the component to be tested contains the following `data-testids`:
+ *    `modal-trigger` - the element that opens the modal
+ *
+ *    `toggle-accordion-btn` - an element that opens/closes an accordion
+ *
+ *    `accordion-content` - the element that is rendered with the accordion is opened
+ *
+ *    `focusable-child-1` - the first child of the modal that can receive focus
+ *
+ *    `focusable-child-2` - the second child of the modal that can receive focus
+ *
+ *    `focusable-child-3` - the third child of the modal that can receive focus
+ *
+ * @param {React Component} testComponent
+ */
 function testPropagation(testComponent) {
   it("should not propagate click events outside of the modal", () => {
     cy.mount(testComponent);

--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -157,9 +157,19 @@ describe("<AModal />", () => {
         <ModalTest />
       </AMount>
     );
+    testCoreFunctionality(
+      <AMount>
+        <ModalTest withOverlay={false} />
+      </AMount>
+    );
     testPropagation(
       <AMount>
         <WithAccordionTest />
+      </AMount>
+    );
+    testPropagation(
+      <AMount>
+        <WithAccordionTest withOverlay={false} />
       </AMount>
     );
   });
@@ -170,9 +180,19 @@ describe("<AModal />", () => {
         <ModalTest />
       </AMount>
     );
+    testCoreFunctionality(
+      <AMount withNewWrappingContext={true}>
+        <ModalTest withOverlay={false} />
+      </AMount>
+    );
     testPropagation(
       <AMount withNewWrappingContext={true}>
         <WithAccordionTest />
+      </AMount>
+    );
+    testPropagation(
+      <AMount withNewWrappingContext={true}>
+        <WithAccordionTest withOverlay={false} />
       </AMount>
     );
   });

--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -25,6 +25,10 @@ import useAToaster from "../AToaster/useAToaster";
 const getModalContent = () => cy.getByDataTestId("modal-content");
 const openModal = () => cy.getByDataTestId("modal-trigger").click();
 
+/* -------------------------------------------------------------------------- */
+/*                                 Test suites                                */
+/* -------------------------------------------------------------------------- */
+
 /**
  * Tests core modal functionality assuming the component to be tested contains the following `data-testids`:
  *    `modal-trigger` - the element that opens the modal
@@ -124,6 +128,10 @@ function testPropagation(testComponent) {
     cy.getByDataTestId("accordion-content").should("not.be.visible");
   });
 }
+
+/* -------------------------------------------------------------------------- */
+/*                               Test assertions                              */
+/* -------------------------------------------------------------------------- */
 
 describe("<AModal />", () => {
   it("renders", () => {
@@ -230,6 +238,10 @@ describe("<AModal />", () => {
     });
   });
 });
+
+/* -------------------------------------------------------------------------- */
+/*                             Components to test                             */
+/* -------------------------------------------------------------------------- */
 
 function ContentSetup({onCloseBtnClick}) {
   return (

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -58,21 +58,27 @@ const AModal = forwardRef(
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
 
-    const shouldRender = useDelayUnmount(isOpen, delayMount);
+    const shouldRenderChildren = useDelayUnmount({
+      isOpen,
+      delayTime: delayMount,
+      isEnabled: withAnimations || delayMount
+    });
 
     useFocusTrap({
       rootRef: _ref,
-      isEnabled: trapFocus && shouldRender
+      isEnabled: trapFocus && shouldRenderChildren
     });
 
     useEffect(() => {
-      shouldRender && lockScroll ? preventBodyScroll() : allowBodyScroll();
+      shouldRenderChildren && lockScroll
+        ? preventBodyScroll()
+        : allowBodyScroll();
       return allowBodyScroll;
-    }, [lockScroll, shouldRender]);
+    }, [lockScroll, shouldRenderChildren]);
 
     let visibilityClass = "";
 
-    if (!shouldRender) {
+    if (!shouldRenderChildren) {
       visibilityClass += "a-modal--hidden";
     }
 
@@ -103,13 +109,11 @@ const AModal = forwardRef(
     }
 
     /**
-     * In the case where `AModal` is rendered inside
-     * a clickable element, like a button component,
-     * we want to prevent clicks and certain keydown
-     * presses from bubbling outside the modal, which
-     * could cause unintended side effects (like closing
-     * an accordion). This is why we call `stopPropagation`
-     * below.
+     * In the case where `AModal` is rendered inside a clickable element
+     * like a button component, we want to prevent clicks and certain
+     * keydown presses from bubbling outside the modal, which could cause
+     * unintended side effects (like closing an accordion). This is why we
+     * call `stopPropagation` below.
      *
      * @example
      * <AButton>
@@ -150,43 +154,40 @@ const AModal = forwardRef(
             className={contentClassName}
             {...rest}
           >
-            {shouldRender && children}
+            {shouldRenderChildren && children}
           </Component>
         </APageOverlay>,
         appendTo || appRef.current
       );
     }
 
-    return (
-      shouldRender &&
-      ReactDOM.createPortal(
-        <Component
-          role="dialog"
-          aria-modal="true"
-          className={`${contentClassName}`}
-          ref={handleMultipleRefs(_ref, ref)}
-          onKeyDown={(e) => {
-            if (shouldStopPropagation(e)) {
-              e.stopPropagation();
-            }
-            const {onKeyDown: propsOnKeyDown} = rest;
-            if (typeof propsOnKeyDown === "function") {
-              propsOnKeyDown(e);
-            }
-          }}
-          onClick={(e) => {
+    return ReactDOM.createPortal(
+      <Component
+        role="dialog"
+        aria-modal="true"
+        className={`${contentClassName}`}
+        ref={handleMultipleRefs(_ref, ref)}
+        onKeyDown={(e) => {
+          if (shouldStopPropagation(e)) {
             e.stopPropagation();
-            const {onClick: propsOnClick} = rest;
-            if (typeof propsOnClick === "function") {
-              propsOnClick(e);
-            }
-          }}
-          {...rest}
-        >
-          {children}
-        </Component>,
-        appendTo || appRef.current
-      )
+          }
+          const {onKeyDown: propsOnKeyDown} = rest;
+          if (typeof propsOnKeyDown === "function") {
+            propsOnKeyDown(e);
+          }
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          const {onClick: propsOnClick} = rest;
+          if (typeof propsOnClick === "function") {
+            propsOnClick(e);
+          }
+        }}
+        {...rest}
+      >
+        {shouldRenderChildren && children}
+      </Component>,
+      appendTo || appRef.current
     );
   }
 );

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -48,7 +48,6 @@ const AModal = forwardRef(
       large,
       xlarge,
       onClickOutside,
-      alwaysRenderChildren,
       centerContent = true,
       ...rest
     },

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -36,6 +36,7 @@ const AModal = forwardRef(
       appendTo = null,
       as = "div",
       className: propsClassName,
+      delayMount = 100,
       children,
       lockScroll = true,
       withOverlay = true,
@@ -57,7 +58,7 @@ const AModal = forwardRef(
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
 
-    const shouldRender = useDelayUnmount(isOpen, 100);
+    const shouldRender = useDelayUnmount(isOpen, delayMount);
 
     useFocusTrap({
       rootRef: _ref,

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -40,7 +40,7 @@ const AModal = forwardRef(
       children,
       lockScroll = true,
       withOverlay = true,
-      withAnimations = true,
+      withTransitions = true,
       trapFocus = true,
       isOpen: propsIsOpen,
       small,
@@ -49,6 +49,7 @@ const AModal = forwardRef(
       xlarge,
       onClickOutside,
       alwaysRenderChildren,
+      centerContent = true,
       ...rest
     },
     ref
@@ -62,7 +63,7 @@ const AModal = forwardRef(
     const shouldRenderChildren = useDelayUnmount({
       isOpen,
       delayTime: delayUnmount,
-      isEnabled: withAnimations || delayUnmount
+      isEnabled: withTransitions || delayUnmount
     });
 
     useFocusTrap({
@@ -86,7 +87,7 @@ const AModal = forwardRef(
     let overlayClassName = "";
     let contentClassName = `a-modal-container ${visibilityClass}`;
 
-    if (withAnimations) {
+    if (withTransitions) {
       contentClassName += " a-modal-container--transitions";
       overlayClassName += " a-modal--transitions";
     }
@@ -108,20 +109,16 @@ const AModal = forwardRef(
       contentClassName += " a-modal-container--xlarge";
     }
 
+    if (centerContent) {
+      contentClassName += " a-modal-container--center";
+    }
+
     if (propsClassName) {
       contentClassName += ` ${propsClassName}`;
     }
 
     if (!appendTo && !appRef.current) {
       return null;
-    }
-
-    let resolvedChildren;
-
-    if (alwaysRenderChildren) {
-      resolvedChildren = children;
-    } else {
-      resolvedChildren = shouldRenderChildren ? children : null;
     }
 
     /**
@@ -170,7 +167,7 @@ const AModal = forwardRef(
             className={contentClassName}
             {...rest}
           >
-            {resolvedChildren}
+            {shouldRenderChildren ? children : null}
           </Component>
         </APageOverlay>,
         appendTo || appRef.current
@@ -201,7 +198,7 @@ const AModal = forwardRef(
         }}
         {...rest}
       >
-        {resolvedChildren}
+        {shouldRenderChildren ? children : null}
       </Component>,
       appendTo || appRef.current
     );
@@ -298,7 +295,7 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   /**
    * Determines if the modal should open and close with CSS animations.
    */
-  withAnimations: PropTypes.bool
+  withTransitions: PropTypes.bool
 };
 
 AModal.displayName = "AModal";

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -36,7 +36,7 @@ const AModal = forwardRef(
       appendTo = null,
       as = "div",
       className: propsClassName,
-      delayMount = 100,
+      delayMount = 200,
       children,
       lockScroll = true,
       withOverlay = true,
@@ -48,6 +48,7 @@ const AModal = forwardRef(
       large,
       xlarge,
       onClickOutside,
+      alwaysRenderChildren,
       ...rest
     },
     ref
@@ -86,8 +87,15 @@ const AModal = forwardRef(
     let contentClassName = `a-modal-container ${visibilityClass}`;
 
     if (withAnimations) {
-      overlayClassName = isOpen ? "animation-fade-in" : "animation-fade-out";
-      contentClassName += isOpen ? " animation-grow" : " animation-shrink";
+      contentClassName += " a-modal-container--transitions";
+      overlayClassName += " a-modal--transitions";
+    }
+
+    if (shouldRenderChildren) {
+      overlayClassName += isOpen ? " a-modal--show" : " a-modal--hide";
+      contentClassName += isOpen
+        ? " a-modal-container--grow"
+        : " a-modal-container--shrink";
     }
 
     if (small) {
@@ -106,6 +114,14 @@ const AModal = forwardRef(
 
     if (!appendTo && !appRef.current) {
       return null;
+    }
+
+    let resolvedChildren;
+
+    if (alwaysRenderChildren) {
+      resolvedChildren = children;
+    } else {
+      resolvedChildren = shouldRenderChildren ? children : null;
     }
 
     /**
@@ -127,7 +143,7 @@ const AModal = forwardRef(
     if (withOverlay) {
       return ReactDOM.createPortal(
         <APageOverlay
-          className={`${visibilityClass} ${overlayClassName}`}
+          className={`a-modal ${visibilityClass} ${overlayClassName}`}
           onKeyDown={(e) => {
             if (shouldStopPropagation(e)) {
               e.stopPropagation();
@@ -154,7 +170,7 @@ const AModal = forwardRef(
             className={contentClassName}
             {...rest}
           >
-            {shouldRenderChildren && children}
+            {resolvedChildren}
           </Component>
         </APageOverlay>,
         appendTo || appRef.current
@@ -185,7 +201,7 @@ const AModal = forwardRef(
         }}
         {...rest}
       >
-        {shouldRenderChildren && children}
+        {resolvedChildren}
       </Component>,
       appendTo || appRef.current
     );

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -36,7 +36,7 @@ const AModal = forwardRef(
       appendTo = null,
       as = "div",
       className: propsClassName,
-      delayMount = 200,
+      delayUnmount = 200,
       children,
       lockScroll = true,
       withOverlay = true,
@@ -61,8 +61,8 @@ const AModal = forwardRef(
 
     const shouldRenderChildren = useDelayUnmount({
       isOpen,
-      delayTime: delayMount,
-      isEnabled: withAnimations || delayMount
+      delayTime: delayUnmount,
+      isEnabled: withAnimations || delayUnmount
     });
 
     useFocusTrap({

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -39,6 +39,7 @@ const AModal = forwardRef(
       children,
       lockScroll = true,
       withOverlay = true,
+      withAnimations = true,
       trapFocus = true,
       isOpen: propsIsOpen,
       small,
@@ -56,7 +57,7 @@ const AModal = forwardRef(
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
 
-    const shouldRender = useDelayUnmount(isOpen, 300);
+    const shouldRender = useDelayUnmount(isOpen, 100);
 
     useFocusTrap({
       rootRef: _ref,
@@ -68,17 +69,19 @@ const AModal = forwardRef(
       return allowBodyScroll;
     }, [lockScroll, shouldRender]);
 
-    const animationClassName = isOpen
-      ? "animation-fade-in"
-      : "animation-fade-out";
-
     let visibilityClass = "";
 
     if (!shouldRender) {
       visibilityClass += "a-modal--hidden";
     }
 
+    let overlayClassName = "";
     let contentClassName = `a-modal-container ${visibilityClass}`;
+
+    if (withAnimations) {
+      overlayClassName = isOpen ? "animation-fade-in" : "animation-fade-out";
+      contentClassName += isOpen ? " animation-grow" : " animation-shrink";
+    }
 
     if (small) {
       contentClassName += " a-modal-container--small";
@@ -119,8 +122,7 @@ const AModal = forwardRef(
     if (withOverlay) {
       return ReactDOM.createPortal(
         <APageOverlay
-          //style={isOpen ? mountedStyle : unmountedStyle}
-          className={`${visibilityClass} ${animationClassName}`}
+          className={`${visibilityClass} ${overlayClassName}`}
           onKeyDown={(e) => {
             if (shouldStopPropagation(e)) {
               e.stopPropagation();
@@ -160,7 +162,7 @@ const AModal = forwardRef(
         <Component
           role="dialog"
           aria-modal="true"
-          className={`${contentClassName} ${animationClassName}`}
+          className={`${contentClassName}`}
           ref={handleMultipleRefs(_ref, ref)}
           onKeyDown={(e) => {
             if (shouldStopPropagation(e)) {
@@ -273,7 +275,12 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   /**
    * If not using the `usePopupQuickExit` hook, pass in a function to handle clicking outside of the modal event. `withOverlay` prop must be set to true.
    */
-  onClickOutside: PropTypes.func
+  onClickOutside: PropTypes.func,
+
+  /**
+   * Determines if the modal should open and close with CSS animations.
+   */
+  withAnimations: PropTypes.bool
 };
 
 AModal.displayName = "AModal";

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -38,17 +38,17 @@ const AModal = forwardRef(
       className: propsClassName,
       delayUnmount = 200,
       children,
-      lockScroll = true,
-      withOverlay = true,
-      withTransitions = true,
-      trapFocus = true,
       isOpen: propsIsOpen,
       small,
       medium,
       large,
       xlarge,
       onClickOutside,
-      centerContent = true,
+      withCenteredContent = true,
+      withFocusTrap = true,
+      withOverlay = true,
+      withScrollLock = true,
+      withTransitions = true,
       ...rest
     },
     ref
@@ -67,15 +67,18 @@ const AModal = forwardRef(
 
     useFocusTrap({
       rootRef: _ref,
-      isEnabled: trapFocus && shouldRenderChildren
+      isEnabled: withFocusTrap && shouldRenderChildren
     });
 
     useEffect(() => {
-      shouldRenderChildren && lockScroll
+      shouldRenderChildren && withScrollLock
         ? preventBodyScroll()
         : allowBodyScroll();
-      return allowBodyScroll;
-    }, [lockScroll, shouldRenderChildren]);
+
+      if (withScrollLock) {
+        return allowBodyScroll;
+      }
+    }, [withScrollLock, shouldRenderChildren]);
 
     let visibilityClass = "";
 
@@ -108,7 +111,7 @@ const AModal = forwardRef(
       contentClassName += " a-modal-container--xlarge";
     }
 
-    if (centerContent) {
+    if (withCenteredContent) {
       contentClassName += " a-modal-container--center";
     }
 
@@ -245,23 +248,6 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   className: PropTypes.string,
 
   /**
-   * Prevents the user from scrolling when the modal is open.
-   */
-  lockScroll: PropTypes.bool,
-
-  /**
-   * Determines if focus should be trapped when the modal is opened.
-   */
-  trapFocus: PropTypes.bool,
-
-  /**
-   * Renders the modal with a backdrop over the content behind the modal.
-   * To render your own custom backdrop, specify `withOverlay` as false,
-   * and render your own overlay as a child to the Modal content.
-   */
-  withOverlay: PropTypes.bool,
-
-  /**
    * Determines if the modal is opened or closed.
    */
   isOpen: PropTypes.bool,
@@ -290,6 +276,33 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
    * If not using the `usePopupQuickExit` hook, pass in a function to handle clicking outside of the modal event. `withOverlay` prop must be set to true.
    */
   onClickOutside: PropTypes.func,
+
+  /**
+   * Determines if the content rendered underneath the modal should
+   * automatically be centered vertically and horizontally.
+   */
+  withCenteredContent: PropTypes.bool,
+
+  /**
+   * Determines if focus should be trapped when the modal is opened.
+   */
+  withFocusTrap: PropTypes.bool,
+
+  /**
+   * Determines if the modal should render with an faded backdrop.
+   */
+  withOverlay: PropTypes.bool,
+
+  /**
+   * Determines if focus should be "trapped" inside the modal when
+   * it is opened (encouraged and recommended).
+   */
+  withScrollLock: PropTypes.bool,
+
+  /**
+   * Determines if the modal should open and close with CSS transitions.
+   */
+  withTransitions: PropTypes.bool,
 
   /**
    * Determines if the modal should open and close with CSS animations.

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -140,7 +140,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
-### Without Animations
+### Without CSS Transitions
 
 <Playground
   fullWidthPreview
@@ -159,7 +159,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
             Open Modal
         </AButton>
         <AModal
-            withAnimations={false}
+            withTransitions={false}
             aria-labelledby='modal-title'
             isOpen={open}>
             <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -140,6 +140,49 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+### Without Animations
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+    const [open, setOpen] = useState(false);
+    const ref = useRef();
+    usePopupQuickExit({
+      popupRef: ref,
+      isEnabled: open,
+      onExit: () => setOpen(false)
+    });
+    return (
+      <div>
+        <AButton
+            onClick={() => setOpen(true)}>
+            Open Modal
+        </AButton>
+        <AModal
+            withAnimations={false}
+            aria-labelledby='modal-title'
+            isOpen={open}>
+            <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
+              <APanelHeader>
+                <APanelTitle id='modal-title'>No Animations</APanelTitle>
+                <AButton aria-label="Close modal 1" onClick={() => setOpen(false)} tertiaryAlt icon>
+                  <AIcon>close</AIcon>
+                </AButton>
+              </APanelHeader>
+              <APanelBody>
+                Modal content goes here.
+              </APanelBody>
+              <APanelFooter>
+                <AButton>Action</AButton>
+              </APanelFooter>
+            </APanel>
+        </AModal>
+      </div>
+    )
+  }
+`}
+/>
+
 ### Form Example
 
 <Playground

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -101,23 +101,71 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 
 ### Without Scroll Locking
 
+<AAlert className="mb-2" level="warning" dismissable={false}>
+  Because content outside of a modal is inaccessible, it would be considered an
+  anti-pattern to allow the document body to scroll while a modal is opened.
+  Rendering a modal `withLockFocus={false}` should only be used in cases where
+  you need to provide your own body scrolling functionality, like the in the
+  example below.
+</AAlert>
+
 <Playground
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
     const ref = useRef();
+    const lastScrollPos = useRef();
     usePopupQuickExit({
       popupRef: ref,
       isEnabled: open,
       onExit: () => setOpen(false)
     });
+
+    /**
+      * The code below has not been verified nor
+      * tested for a production environment. It is
+      * used for the purposes of this demonstration.
+      */
+    useEffect(() => {
+      const scrollPosition = window.pageYOffset;
+      const sidebar = document.querySelector(".root-sidebar");
+      const sidebarPosition = sidebar.scrollTop;
+      const container = document.querySelector('.a-app');
+      const body = document.body;
+
+      const disableScrolling = () => {
+        lastScrollPos.current = scrollPosition;
+        container.style.top = -scrollPosition + "px";
+        container.style.position = "relative";
+        sidebar.style.top = sidebarPosition;
+        sidebar.style.position = "relative";
+        body.style.position = "fixed";
+        body.style.top = "0";
+        body.style.left = "0";
+        body.style.height = "100%";
+        body.style.width = "100%";
+      }
+
+      const enableScrolling = () => {
+        container.style.top = "0";
+        container.style.position = "unset";
+        sidebar.style.top = "0";
+        sidebar.style.position = "unset";
+        body.style.position = "unset";
+        window.scrollTo({
+          top: lastScrollPos.current,
+          behavior: 'instant'
+        });
+      }
+
+      open ? disableScrolling() : enableScrolling();
+    }, [open]);
     return (
       <div>
         <AButton onClick={() => setOpen(true)}>Open Modal</AButton>
         <AModal
             aria-labelledby='modal-title'
-            lockScroll={false}
-            withOverlay={false}
+            withScrollLock={false}
             isOpen={open}>
           <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
             <APanelHeader>
@@ -136,11 +184,12 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
         </AModal>
       </div>
     )
-  }
+
+}
 `}
 />
 
-### Without Centering Modal content
+### Without Centered Content
 
 <Playground
   fullWidthPreview
@@ -159,7 +208,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
             Open Modal
         </AButton>
         <AModal
-            centerContent={false}
+            withCenteredContent={false}
             aria-labelledby='modal-title'
             isOpen={open}>
             <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
@@ -207,7 +256,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
             isOpen={open}>
             <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
               <APanelHeader>
-                <APanelTitle id='modal-title'>No Animations</APanelTitle>
+                <APanelTitle id='modal-title'>Modal Demo</APanelTitle>
                 <AButton aria-label="Close modal 1" onClick={() => setOpen(false)} tertiaryAlt icon>
                   <AIcon>close</AIcon>
                 </AButton>
@@ -372,7 +421,9 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 
 ### Size variants
 
-_This assumes a single direct child, such as `APanel`, as the modal content._
+<AAlert className="mb-2" level="info" dismissable={false}>
+  This assumes a single direct child, such as `APanel`, as the modal content.
+</AAlert>
 
 <Playground
   fullWidthPreview
@@ -430,7 +481,9 @@ _This assumes a single direct child, such as `APanel`, as the modal content._
 
 ### With onClickOutside
 
-_`withOverlay` must be true for the `onClickOutside` prop to take effect._
+<AAlert className="mb-2" level="info" dismissable={false}>
+  `withOverlay` must be true for the `onClickOutside` prop to take effect.
+</AAlert>
 
 <Playground
   fullWidthPreview
@@ -513,4 +566,4 @@ Additinoally, `AModal` components are assigned the `aria-modal` attribute to ind
 
 ### Focus Management
 
-When `AModal` is open, only its child elements are focusable, meaning content outside the modal is not keyboard accessible. More often than not, this is all you will need when rendering an accessible modal. However, if you need more refined focus management, you can disable this default implementation by passing `AModal` a `trapFocus` prop value of `false` in order to implement your own solution.
+When `AModal` is open, only its child elements are focusable, meaning content outside the modal is not keyboard accessible. More often than not, this is all you will need when rendering an accessible modal. However, if you need more refined focus management, you can disable this default implementation by passing `AModal` a `withFocusTrap` prop value of `false` in order to implement your own solution.

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -140,6 +140,49 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+### Without Centering Modal content
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+    const [open, setOpen] = useState(false);
+    const ref = useRef();
+    usePopupQuickExit({
+      popupRef: ref,
+      isEnabled: open,
+      onExit: () => setOpen(false)
+    });
+    return (
+      <div>
+        <AButton
+            onClick={() => setOpen(true)}>
+            Open Modal
+        </AButton>
+        <AModal
+            centerContent={false}
+            aria-labelledby='modal-title'
+            isOpen={open}>
+            <APanel ref={ref} style={{ minWidth: '400px' }} type="dialog">
+              <APanelHeader>
+                <APanelTitle id='modal-title'>Modal Demo</APanelTitle>
+                <AButton aria-label="Close modal 1" onClick={() => setOpen(false)} tertiaryAlt icon>
+                  <AIcon>close</AIcon>
+                </AButton>
+              </APanelHeader>
+              <APanelBody>
+                Modal content goes here.
+              </APanelBody>
+              <APanelFooter>
+                <AButton>Action</AButton>
+              </APanelFooter>
+            </APanel>
+        </AModal>
+      </div>
+    )
+  }
+`}
+/>
+
 ### Without CSS Transitions
 
 <Playground

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -124,6 +124,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
       * The code below has not been verified nor
       * tested in a production environment. It is
       * used for the purposes of this demonstration.
+      * Use with caution.
       */
     useEffect(() => {
       const scrollPosition = window.pageYOffset;
@@ -481,7 +482,11 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 ### With onClickOutside
 
 <AAlert className="mb-2" level="info" dismissable={false}>
-  `withOverlay` must be true for the `onClickOutside` prop to take effect.
+  `withOverlay` must be true for the `onClickOutside` prop to take effect. If
+  you would like to integrate an outside click handler with a non-overlayed
+  `AModal`, consider using the{" "}
+  <a href="/hooks/use-outside-click#description">`useOutsideClick` hook</a>{" "}
+  alongside the `AModal`.
 </AAlert>
 
 <Playground

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -104,9 +104,8 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 <AAlert className="mb-2" level="warning" dismissable={false}>
   Because content outside of a modal is inaccessible, it would be considered an
   anti-pattern to allow the document body to scroll while a modal is opened.
-  Rendering a modal `withLockFocus={false}` should only be used in cases where
-  you need to provide your own body scrolling functionality, like the in the
-  example below.
+  Passing `withLockFocus={false}` should only be used in cases where you need to
+  provide your own body scrolling functionality, like in the example below.
 </AAlert>
 
 <Playground
@@ -123,7 +122,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 
     /**
       * The code below has not been verified nor
-      * tested for a production environment. It is
+      * tested in a production environment. It is
       * used for the purposes of this demonstration.
       */
     useEffect(() => {

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -99,7 +99,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
-### Without Scroll Locking
+### Custom Scroll Locking
 
 <AAlert className="mb-2" level="warning" dismissable={false}>
   Because content outside of a modal is inaccessible, it would be considered an

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -16,6 +16,8 @@
 
 .a-modal-container {
   position: fixed;
+  top: 0;
+  left: 0;
 
   &--center {
     width: 100vw;

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -18,11 +18,14 @@
   position: fixed;
   left: 0;
   top: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100vw;
-  height: 100vh;
+
+  &--center {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 
   &--transitions {
     transform: scale(0);

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -41,7 +41,7 @@
 .animation-fade-in {
   animation-name: fadeIn;
   animation-delay: 0s;
-  animation-duration: 0.3s;
+  animation-duration: 0.15s;
   animation-timing-function: ease-in-out;
   animation-fill-mode: forwards;
 }
@@ -49,9 +49,43 @@
 .animation-fade-out {
   animation-name: fadeOut;
   animation-delay: 0s;
-  animation-duration: 0.3s;
+  animation-duration: 0.15s;
   animation-timing-function: ease-in-out;
   animation-fill-mode: forwards;
+}
+
+.animation-grow {
+  animation-name: grow;
+  animation-delay: 0s;
+  animation-duration: 0.15s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.animation-shrink {
+  animation-name: shrink;
+  animation-delay: 0s;
+  animation-duration: 0.15s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+@keyframes grow {
+  from {
+    transform: scale(0);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes shrink {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0);
+  }
 }
 
 @keyframes fadeIn {

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -16,8 +16,6 @@
 
 .a-modal-container {
   position: fixed;
-  left: 0;
-  top: 0;
 
   &--center {
     width: 100vw;

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -7,6 +7,7 @@
   align-items: center;
   width: 100vw;
   height: 100vh;
+  animation-delay: 0s;
 
   .a-panel {
     &__title {
@@ -35,4 +36,56 @@
 
 .a-modal--hidden {
   visibility: hidden;
+}
+
+.animation-fade-in {
+  animation-name: fadeIn;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+.animation-fade-out {
+  animation-name: fadeOut;
+  animation-delay: 0s;
+  animation-duration: 0.3s;
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes slideIn {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slideOut {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
 }

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -1,3 +1,19 @@
+.a-modal {
+  opacity: 0;
+
+  &--transitions {
+    transition: opacity 0.2s;
+  }
+
+  &--show {
+    opacity: 1;
+  }
+
+  &--hide {
+    opacity: 0;
+  }
+}
+
 .a-modal-container {
   position: fixed;
   left: 0;
@@ -7,7 +23,19 @@
   align-items: center;
   width: 100vw;
   height: 100vh;
-  animation-delay: 0s;
+
+  &--transitions {
+    transform: scale(0);
+    transition: transform 0.2s;
+  }
+
+  &--grow.a-modal-container--transitions {
+    transform: scale(1);
+  }
+
+  &--shrink.a-modal-container--transitions {
+    transform: scale(0);
+  }
 
   .a-panel {
     &__title {
@@ -37,89 +65,9 @@
 .a-modal--hidden {
   visibility: hidden;
 }
-
-.animation-fade-in {
-  animation-name: fadeIn;
-  animation-delay: 0s;
-  animation-duration: 0.15s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
+.a-modal--grow {
+  transform: scale(1);
 }
-
-.animation-fade-out {
-  animation-name: fadeOut;
-  animation-delay: 0s;
-  animation-duration: 0.15s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.animation-grow {
-  animation-name: grow;
-  animation-delay: 0s;
-  animation-duration: 0.15s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-.animation-shrink {
-  animation-name: shrink;
-  animation-delay: 0s;
-  animation-duration: 0.15s;
-  animation-timing-function: ease-in-out;
-  animation-fill-mode: forwards;
-}
-
-@keyframes grow {
-  from {
-    transform: scale(0);
-  }
-  to {
-    transform: scale(1);
-  }
-}
-
-@keyframes shrink {
-  from {
-    transform: scale(1);
-  }
-  to {
-    transform: scale(0);
-  }
-}
-
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes fadeOut {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes slideIn {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
-
-@keyframes slideOut {
-  0% {
-    transform: translateX(100%);
-  }
-  100% {
-    transform: translateX(-100%);
-  }
+.a-modal--shrink {
+  transform: scale(0);
 }

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -1,4 +1,4 @@
-import {useEffect, useLayoutEffect, useRef} from "react";
+import {useEffect, useLayoutEffect, useRef, useState} from "react";
 
 export const useCombinedRefs = (...refs) => {
   const targetRef = useRef();
@@ -20,3 +20,21 @@ export const useCombinedRefs = (...refs) => {
 
 export const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export const useDelayUnmount = (isOpen, delayTime) => {
+  const timeout = useRef();
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useLayoutEffect(() => {
+    if (isOpen && !shouldRender) {
+      setShouldRender(true);
+    } else if (!isOpen && shouldRender) {
+      timeout.current = setTimeout(() => {
+        setShouldRender(false);
+        clearTimeout(timeout.current);
+      }, delayTime);
+    }
+    return () => clearTimeout(timeout.current);
+  }, [isOpen, delayTime, shouldRender]);
+  return shouldRender;
+};

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -21,11 +21,14 @@ export const useCombinedRefs = (...refs) => {
 export const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
-export const useDelayUnmount = (isOpen, delayTime) => {
+export const useDelayUnmount = ({isEnabled = true, isOpen, delayTime}) => {
   const timeout = useRef();
   const [shouldRender, setShouldRender] = useState(false);
 
   useLayoutEffect(() => {
+    if (!isEnabled) {
+      return;
+    }
     if (isOpen && !shouldRender) {
       setShouldRender(true);
     } else if (!isOpen && shouldRender) {
@@ -35,6 +38,7 @@ export const useDelayUnmount = (isOpen, delayTime) => {
       }, delayTime);
     }
     return () => clearTimeout(timeout.current);
-  }, [isOpen, delayTime, shouldRender]);
-  return shouldRender;
+  }, [isOpen, delayTime, shouldRender, isEnabled]);
+
+  return isEnabled ? shouldRender : isOpen;
 };


### PR DESCRIPTION
### ⚠️ This introduces breaking changes for both `AModal` and `ADrawer`

~~I would feel better merging this after #321.~~ Done

[Demo](https://magna-react-git-refactor-drawer-mounting-transitions.securex-preview.app/components/modal#usage)

## `AModal` Updates

### `AModal`: New Props

There are two new props to make `AModal` more flexible for integrating applications.

*  `withCenteredContent`: Determines if the content rendered in the modal should automatically be centered vertically and horizontally.
* `withTransitions`: Determines if the modal will open and close with the fade-in and grow transitions

### `AModal`: Prop Changes
Props are changing to keep naming consistency with the other `AModal` props, making it easier to remember what can be passed.

* `trapFocus` renamed to `withFocusTrap`
* `lockScroll` renamed to `withScrollLock`

### `AModal`:  UX Changes

* CSS transitions for both the open and close states

### `AModal`: Breaking Changes

<details>
<summary>:warning: Children of <code>AModal</code> will mount and remount each time <code>isOpen</code> is toggled</summary>
<br />
Each time the modal is opened and closed, the children passed to `AModal` will always mount and unmount. This means that the state within this component will always reinitialize, as well as reinitiate React's lifecycle, resulting in extra calls to hooks like `useEffect`, `useLayoutEffect`, etc.
</details>

<details>
<summary>:warning: Prop renaming</summary>
<br />

* `trapFocus`  -> `withFocusTrap`
* `lockScroll` ->  `withScrollLock`
</details>

## `ADrawer` Updates

[Demo](https://magna-react-git-refactor-drawer-mounting-transitions.securex-preview.app/components/drawer#usage)

### `ADrawer`: New Props

One new prop to toggle CSS transitions

* `withTransitions`: Determines if the drawer will open and close with the slide-in and slide-out transitions

### `ADrawer`: Breaking Changes

Because `ADrawer` is composed of `AModal`, it inherits the same breaking changes. For clarity:

<details>
<summary>:warning: Children of <code>ADrawer</code> will mount and remount each time <code>isOpen</code> is toggled</summary>
<br />
Each time the drawer is opened and closed, the children passed to `ADrawer` will always mount and unmount. This means that the state within this component will always reinitialize, as well as reinitiate React's lifecycle, resulting in extra calls to hooks like `useEffect`, `useLayoutEffect`, etc.
</details>

<details>
<summary>:warning: Modal props passed to drawers will need to align to <code>AModal</code> prop changes</summary>
<br />
If `ADrawer` is being rendered as a modal (which it is by default), then any props previously being passed to `ADrawer` to toggle modal behavior will need to be updated to match the prop name changes mentioned in the `AModal` breaking changes:

* `trapFocus`  -> `withFocusTrap`
* `lockScroll` ->  `withScrollLock`
</details>
