### PR TITLE
fix(ATriggerTooltip): import ATooltip as named import

### DIFF
--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, {useEffect, useRef} from "react";
 
-import ATooltip from "../ATooltip";
+import {ATooltip} from "../ATooltip";
 import useToggle from "../../hooks/useToggle/useToggle";
 import useOutsideClick from "../../hooks/useOutsideClick/useOutsideClick";
 import {handleMultipleRefs} from "../../utils/helpers";


### PR DESCRIPTION
Properly imports `ATooltip` as a result of #316 