### PR TITLE
Added AListItemGroup to be able to group list items into unified set #318

### DIFF
--- a/framework/components/AList/AList.mdx
+++ b/framework/components/AList/AList.mdx
@@ -1,7 +1,7 @@
 ---
 name: Lists
 route: /components/list
-components: AList, AListItem, AListItemAvatar, AListItemSubtitle, AListItemAction, AListItemContent
+components: AList, AListItem, AListItemAction, AListItemAvatar, AListItemContent, AListItemGroup, AListItemSubtitle, AListItemTitle
 ---
 
 # Lists
@@ -14,11 +14,12 @@ Integrate with your build to [auto-import](/#integrating), or add an import in y
 import {
   AList,
   AListItem,
+  AListItemAction
   AListItemAvatar,
+  AListItemContent,
+  AListItemGroup,
   AListItemSubtitle,
   AListItemTitle,
-  AListItemContent,
-  AListItemAction
 } from "@cisco-sbg-ui/magna-react";
 ```
 
@@ -27,7 +28,7 @@ import {
 <Playground
   fullWidthPreview
   code={`<div className="d-flex align-start">
-  <AList className="mr-2" style={{flexBasis: "33%"}}>
+  <AList className="mr-2" style={{flexBasis: "25%"}}>
     <AListItem twoLine>
       <AListItemAvatar>
         <AIcon size={16} className="status-red--text">
@@ -50,7 +51,7 @@ import {
     <ADivider light className="ma-0" />
     <AListItem onClick={() => {}}>Logout</AListItem>
   </AList>
-  <AList className="ml-2 mr-2 pl-2" style={{flexBasis: "33%"}}>
+  <AList className="ml-2 mr-2 pl-2" style={{flexBasis: "25%"}}>
     <AListItem twoLine>
       <AListItemAvatar className="ma-2 ml-0">
         <div
@@ -95,7 +96,7 @@ import {
       </AListItemContent>
     </AListItem>
   </AList>
-  <AList className="ml-2" style={{flexBasis: "33%"}}>
+  <AList className="ml-2" style={{flexBasis: "25%"}}>
     <AListItem href="#" target="_blank">
       One
     </AListItem>
@@ -108,6 +109,17 @@ import {
       </AListItemAvatar>
       <AListItemContent>Log Out</AListItemContent>
     </AListItem>
+  </AList>
+  <AList className="ml-2" style={{flexBasis: "25%"}}>
+    <AListItemGroup title={"Category 1"}>
+        <AListItem>Category item 1</AListItem>
+        <AListItem>Category item 2</AListItem>
+        <AListItem>Category item 3</AListItem>
+    </AListItemGroup>
+    <AListItemGroup title={"Category 2"}>
+        <AListItem>Category item 4</AListItem>
+        <AListItem>Category item 5</AListItem>
+    </AListItemGroup>
   </AList>
 </div>
 `}

--- a/framework/components/AList/AList.mdx
+++ b/framework/components/AList/AList.mdx
@@ -49,7 +49,7 @@ import {
         </AButton>
       </AListItemAction>
     </AListItem>
-    <ADivider light className="ma-0" />
+    <AListItemDivider className="ma-0" />
     <AListItem onClick={() => {}}>Logout</AListItem>
   </AList>
   <AList className="ml-2 mr-2 pl-2" style={{flexBasis: "25%"}}>
@@ -74,7 +74,7 @@ import {
         </AListItemSubtitle>
       </AListItemContent>
     </AListItem>
-    <ADivider light className="ma-0" />
+    <AListItemDivider light className="ma-0" />
     <AListItem twoLine>
       <AListItemAvatar className="ma-2 ml-0">
         <div

--- a/framework/components/AList/AList.mdx
+++ b/framework/components/AList/AList.mdx
@@ -17,6 +17,7 @@ import {
   AListItemAction
   AListItemAvatar,
   AListItemContent,
+  AListItemDivider,
   AListItemGroup,
   AListItemSubtitle,
   AListItemTitle,
@@ -116,6 +117,7 @@ import {
         <AListItem>Category item 2</AListItem>
         <AListItem>Category item 3</AListItem>
     </AListItemGroup>
+    <AListItemDivider />
     <AListItemGroup title={"Category 2"}>
         <AListItem>Category item 4</AListItem>
         <AListItem>Category item 5</AListItem>
@@ -137,11 +139,35 @@ The `AListItem` component inherits passed props.
 
 <Props of="AListItem" />
 
+## List Item Action Props
+
+The `AListItemAction` component inherits passed props.
+
+<Props of="AListItemAction" />
+
 ## List Item Avatar Props
 
 The `AListItemAvatar` component inherits passed props.
 
 <Props of="AListItemAvatar" />
+
+## List Item Content Props
+
+The `AListItemContent` component inherits passed props.
+
+<Props of="AListItemContent" />
+
+## List Item Divider Props
+
+The `AListItemDivider` component inherits passed props. You can use [ADivider](/components/divider#divider-props) props to configure it.
+
+<Props of="AListItemDivider" />
+
+## List Item Group Props
+
+The `AListItemGroup` component inherits passed props.
+
+<Props of="AListItemGroup" />
 
 ## List Item Subtitle Props
 
@@ -155,17 +181,6 @@ The `AListItemTitle` component inherits passed props.
 
 <Props of="AListItemTitle" />
 
-## List Item Content Props
-
-The `AListItemContent` component inherits passed props.
-
-<Props of="AListItemContent" />
-
-## List Item Action Props
-
-The `AListItemAction` component inherits passed props.
-
-<Props of="AListItemAction" />
 
 ## Router Integrations
 

--- a/framework/components/AList/AList.scss
+++ b/framework/components/AList/AList.scss
@@ -135,19 +135,3 @@
     }
   }
 }
-
-.a-list-item__group {
-  &-title {
-    font-size: $font-size--xs;
-    padding: 6px 10px;
-    color: map-get($grey, "darken-2");
-  }
-
-  .a-list-item {
-    padding: 8px 16px 8px 16px;
-  }
-
-  & ~ .a-divider {
-    margin: 4px 0;
-  }
-}

--- a/framework/components/AList/AList.scss
+++ b/framework/components/AList/AList.scss
@@ -135,3 +135,15 @@
     }
   }
 }
+
+.a-list-item__group {
+  &-title {
+    font-size: $font-size--xs;
+    padding: 6px 10px;
+    color: map-get($grey, "darken-2");
+  }
+
+  .a-list-item {
+    padding: 8px 10px 8px 16px;
+  }
+}

--- a/framework/components/AList/AList.scss
+++ b/framework/components/AList/AList.scss
@@ -144,6 +144,10 @@
   }
 
   .a-list-item {
-    padding: 8px 10px 8px 16px;
+    padding: 8px 16px 8px 16px;
+  }
+
+  & ~ .a-divider {
+    margin: 4px 0;
   }
 }

--- a/framework/components/AList/AListItem.js
+++ b/framework/components/AList/AListItem.js
@@ -1,5 +1,11 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useEffect, useRef, useState} from "react";
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from "react";
 
 import {useCombinedRefs} from "../../utils/hooks";
 import {keyCodes} from "../../utils/helpers";
@@ -13,7 +19,7 @@ const AListItem = forwardRef(
       component,
       href,
       onClick: propsOnClick,
-      onKeyDown,
+      onKeyDown: propsOnKeyDown,
       role,
       selected,
       disabled,
@@ -26,13 +32,29 @@ const AListItem = forwardRef(
     const [roleValue, setRoleValue] = useState(role);
     const listItemRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, listItemRef);
-    const onClick = (e) => {
-      if (disabled) {
-        return;
-      }
 
-      propsOnClick && propsOnClick(e);
-    };
+    const onClick = useCallback(
+      (e) => {
+        if (disabled) {
+          return;
+        }
+
+        propsOnClick && propsOnClick(e);
+      },
+      [disabled, propsOnClick]
+    );
+
+    const onKeyDown = useCallback(
+      (e) => {
+        if (onClick && e.keyCode === keyCodes.enter) {
+          e.preventDefault();
+          onClick(e);
+        }
+
+        propsOnKeyDown && propsOnKeyDown(e);
+      },
+      [onClick, propsOnKeyDown]
+    );
 
     useEffect(() => {
       if (
@@ -69,14 +91,7 @@ const AListItem = forwardRef(
       className,
       disabled,
       onClick,
-      onKeyDown: (e) => {
-        if (onClick && e.keyCode === keyCodes.enter) {
-          e.preventDefault();
-          onClick(e);
-        }
-
-        onKeyDown && onKeyDown(e);
-      },
+      onKeyDown,
       role: roleValue
     };
 

--- a/framework/components/AList/AListItemDivider.js
+++ b/framework/components/AList/AListItemDivider.js
@@ -1,0 +1,20 @@
+import React, {forwardRef} from "react";
+
+import ADivider from "../ADivider";
+import "./AListItemDivider.scss";
+
+const AListItemDivider = forwardRef(
+  ({className: propsClassName, ...rest}, ref) => {
+    let className = "a-list-item__divider";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return <ADivider {...rest} ref={ref} className={className} />;
+  }
+);
+
+AListItemDivider.displayName = "AListItemDivider";
+
+export default AListItemDivider;

--- a/framework/components/AList/AListItemDivider.scss
+++ b/framework/components/AList/AListItemDivider.scss
@@ -1,0 +1,4 @@
+.a-list-item__divider.a-divider {
+  margin: 8px 0;
+  border-width: 1px 0 0 0;
+}

--- a/framework/components/AList/AListItemGroup.js
+++ b/framework/components/AList/AListItemGroup.js
@@ -1,0 +1,33 @@
+import React, {forwardRef} from "react";
+
+import "./AList.scss";
+import PropTypes from "prop-types";
+
+const AListItemGroup = forwardRef(
+  ({children, title, className: propsClassName, ...rest}, ref) => {
+    let className = "a-list-item__group";
+    let titleClassName = "a-list-item__group-title";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return (
+      <div {...rest} ref={ref} className={className}>
+        <div className={titleClassName}>{title}</div>
+        {children}
+      </div>
+    );
+  }
+);
+
+AListItemGroup.displayName = "AListItemGroup";
+
+AListItemGroup.propTypes = {
+  /**
+   * Sets the title for the group
+   */
+  title: PropTypes.string
+};
+
+export default AListItemGroup;

--- a/framework/components/AList/AListItemGroup.js
+++ b/framework/components/AList/AListItemGroup.js
@@ -1,6 +1,6 @@
 import React, {forwardRef} from "react";
 
-import "./AList.scss";
+import "./AListItemGroup.scss";
 import PropTypes from "prop-types";
 
 const AListItemGroup = forwardRef(
@@ -25,9 +25,9 @@ AListItemGroup.displayName = "AListItemGroup";
 
 AListItemGroup.propTypes = {
   /**
-   * Sets the title for the group
+   * Sets the title for the group, string or other component
    */
-  title: PropTypes.string
+  title: PropTypes.node
 };
 
 export default AListItemGroup;

--- a/framework/components/AList/AListItemGroup.scss
+++ b/framework/components/AList/AListItemGroup.scss
@@ -11,8 +11,4 @@
     padding-left: 16px;
     padding-right: 16px;
   }
-
-  & ~ .a-divider {
-    margin: 8px 0;
-  }
 }

--- a/framework/components/AList/AListItemGroup.scss
+++ b/framework/components/AList/AListItemGroup.scss
@@ -1,0 +1,18 @@
+@import "../../styles";
+
+@include theme(a-list-item__group) using($theme) {
+  &-title {
+    font-size: $font-size--xs;
+    padding: 6px 10px;
+    color: map-deep-get($theme, "list", "group-title-color");
+  }
+
+  .a-list-item {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  & ~ .a-divider {
+    margin: 8px 0;
+  }
+}

--- a/framework/components/AList/index.js
+++ b/framework/components/AList/index.js
@@ -2,6 +2,7 @@ import AList from "./AList";
 import AListItem from "./AListItem";
 import AListItemAvatar from "./AListItemAvatar";
 import AListItemContent from "./AListItemContent";
+import AListItemGroup from "./AListItemGroup";
 import AListItemSubtitle from "./AListItemSubtitle";
 import AListItemTitle from "./AListItemTitle";
 import AListItemAction from "./AListItemAction";
@@ -11,6 +12,7 @@ export {
   AListItem,
   AListItemAvatar,
   AListItemContent,
+  AListItemGroup,
   AListItemSubtitle,
   AListItemTitle,
   AListItemAction

--- a/framework/components/AList/index.js
+++ b/framework/components/AList/index.js
@@ -2,6 +2,7 @@ import AList from "./AList";
 import AListItem from "./AListItem";
 import AListItemAvatar from "./AListItemAvatar";
 import AListItemContent from "./AListItemContent";
+import AListItemDivider from "./AListItemDivider";
 import AListItemGroup from "./AListItemGroup";
 import AListItemSubtitle from "./AListItemSubtitle";
 import AListItemTitle from "./AListItemTitle";
@@ -12,6 +13,7 @@ export {
   AListItem,
   AListItemAvatar,
   AListItemContent,
+  AListItemDivider,
   AListItemGroup,
   AListItemSubtitle,
   AListItemTitle,

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -36,10 +36,10 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
   const [menu4Selected, setMenu4Selected] = useState(2);
   return (
     <div className="d-flex" style={{
-        "row-gap": "10px",
-        "column-gap": "20px",
-        "flex-wrap": "wrap",
-        "justify-content": "space-evenly"
+        rowGap: "10px",
+        columnGap: "20px",
+        flexWrap: "wrap",
+        justifyContent: "space-evenly"
       }}>
       <div>
         <AButton
@@ -214,14 +214,13 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
         open={open6}
         compact
         placement="bottom-left"
-        onClose={() => setOpen6(false)}
-        style={{borderRadius: 0}}>
+        onClose={() => setOpen6(false)}>
           <AListItemGroup title={"Category 1"}>
               <AListItem onClick={() => {}}>Category item 1</AListItem>
               <AListItem onClick={() => {}}>Category item 2</AListItem>
               <AListItem onClick={() => {}}>Category item 3</AListItem>
           </AListItemGroup>
-          <ADivider style={{margin: 0}}/>
+          <ADivider />
           <AListItemGroup title={"Category 2"}>
               <AListItem onClick={() => {}}>Category item 4</AListItem>
               <AListItem onClick={() => {}}>Category item 5</AListItem>

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -11,7 +11,7 @@ components: AMenu
 Integrate with your build to [auto-import](/#integrating), or add an import in your component:
 
 ```
-import {AMenu, ADivider} from "@cisco-sbg-ui/magna-react";
+import {AMenu, AListItemDivider} from "@cisco-sbg-ui/magna-react";
 ```
 
 It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
@@ -108,7 +108,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
          <AListItem onClick={() => alert("should not fire")} className="pl-3 py-1" disabled>
           Disabled Item
         </AListItem>
-        <ADivider className="mb-0 mt-3" />
+        <AListItemDivider className="mb-0 mt-3" />
         <AListItem twoLine>
           <AListItemContent className="pb-0">
             <a onClick={() => alert("alert3")}>Connect</a>
@@ -141,7 +141,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
             <a onClick={() => alert("alert warning")}>Action</a>
           </AListItemAction>
         </AListItem>
-        <ADivider className="ma-0" />
+        <AListItemDivider className="ma-0" />
         <AListItem twoLine>
           <AListItemAvatar>
             <AIcon size={16} className="status-orange--text">
@@ -186,13 +186,13 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
         <AListItem onClick={() => alert("should not fire")} disabled>
           Disabled Item
         </AListItem>
-        <ADivider style={{margin: 0}}/>
+        <AListItemDivider style={{margin: 0}}/>
         <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
         <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
-         <ADivider style={{margin: 0}}/>
+        <AListItemDivider style={{margin: 0}}/>
         <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
         <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
-         <ADivider style={{margin: 0}}/>
+        <AListItemDivider style={{margin: 0}}/>
         <AListItem onClick={() => {setMenu4Selected(3)}} selected={3 === menu4Selected}>Status</AListItem>
       </AMenu>
       <AMenu
@@ -203,7 +203,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
         onClose={() => setOpen5(false)}>
         <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
         <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
-         <ADivider style={{margin: 0}}/>
+        <AListItemDivider style={{margin: 0}}/>
         <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
         <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
       </AMenu>

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -26,15 +26,22 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
   const button3Ref = useRef(null);
   const button4Ref = useRef(null);
   const button5Ref = useRef(null);
+  const button6Ref = useRef(null);
   const [open1, setOpen1] = useState(false);
   const [open2, setOpen2] = useState(false);
   const [open3, setOpen3] = useState(false);
   const [open4, setOpen4] = useState(false);
   const [open5, setOpen5] = useState(false);
+  const [open6, setOpen6] = useState(false);
   const [menu4Selected, setMenu4Selected] = useState(2);
   return (
-    <div className="d-flex">
-      <div style={{flexBasis: "20%"}}>
+    <div className="d-flex" style={{
+        "row-gap": "10px",
+        "column-gap": "20px",
+        "flex-wrap": "wrap",
+        "justify-content": "space-evenly"
+      }}>
+      <div>
         <AButton
           ref={button1Ref}
           onClick={() => setOpen1(!open1)}
@@ -42,7 +49,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
           Pivot Menu
         </AButton>
       </div>
-      <div style={{flexBasis: "20%"}}>
+      <div>
         <AButton
           ref={button2Ref}
           onClick={() => setOpen2(!open2)}
@@ -50,7 +57,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
           Alert Notification Menu
         </AButton>
       </div>
-      <div style={{flexBasis: "20%", marginRight: "20px"}}>
+      <div>
         <AButton
           ref={button3Ref}
           onClick={() => setOpen3(!open3)}
@@ -58,7 +65,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
           Drop Down Menu
         </AButton>
       </div>
-      <div style={{flexBasis: "20%", marginRight: "20px"}}>
+      <div>
         <AButton
           ref={button4Ref}
           onClick={() => setOpen4(!open4)}
@@ -66,12 +73,20 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
           More Menu
         </AButton>
       </div>
-      <div style={{flexBasis: "20%", marginRight: "20px"}}>
+      <div>
         <AButton
           ref={button5Ref}
           onClick={() => setOpen5(!open5)}
           aria-haspopup="true">
           Compact Menu
+        </AButton>
+      </div>
+      <div>
+        <AButton
+          ref={button6Ref}
+          onClick={() => setOpen6(!open6)}
+          aria-haspopup="true">
+          Menu With Groups
         </AButton>
       </div>
       <AMenu
@@ -194,8 +209,25 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
         <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
         <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
       </AMenu>
+      <AMenu
+        anchorRef={button6Ref}
+        open={open6}
+        compact
+        placement="bottom-left"
+        onClose={() => setOpen6(false)}
+        style={{borderRadius: 0}}>
+          <AListItemGroup title={"Category 1"}>
+              <AListItem onClick={() => {}}>Category item 1</AListItem>
+              <AListItem onClick={() => {}}>Category item 2</AListItem>
+              <AListItem onClick={() => {}}>Category item 3</AListItem>
+          </AListItemGroup>
+          <ADivider style={{margin: 0}}/>
+          <AListItemGroup title={"Category 2"}>
+              <AListItem onClick={() => {}}>Category item 4</AListItem>
+              <AListItem onClick={() => {}}>Category item 5</AListItem>
+          </AListItemGroup>
+      </AMenu>
     </div>
-
 );
 }
 `}

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -218,7 +218,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
               <AListItem onClick={() => {}}>Category item 2</AListItem>
               <AListItem onClick={() => {}}>Category item 3</AListItem>
           </AListItemGroup>
-          <ADivider />
+          <AListItemDivider />
           <AListItemGroup title={"Category 2"}>
               <AListItem onClick={() => {}}>Category item 4</AListItem>
               <AListItem onClick={() => {}}>Category item 5</AListItem>

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -166,8 +166,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
         anchorRef={button3Ref}
         open={open3}
         placement="bottom-left"
-        onClose={() => setOpen3(false)}
-        style={{borderRadius: 0}}>
+        onClose={() => setOpen3(false)}>
         <AListItem onClick={() => {}}>Selection 1</AListItem>
         <AListItem onClick={() => {}}>Selection 2</AListItem>
         <AListItem onClick={() => {}}>Selection 3</AListItem>
@@ -201,8 +200,7 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
         open={open5}
         compact
         placement="bottom-left"
-        onClose={() => setOpen5(false)}
-        style={{borderRadius: 0}}>
+        onClose={() => setOpen5(false)}>
         <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
         <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
          <ADivider style={{margin: 0}}/>

--- a/framework/index.js
+++ b/framework/index.js
@@ -33,11 +33,12 @@ import {AContainer, ARow, ACol, ASpacer} from "./components/ALayout";
 import {
   AList,
   AListItem,
+  AListItemAction,
   AListItemAvatar,
-  AListItemSubtitle,
-  AListItemTitle,
   AListItemContent,
-  AListItemAction
+  AListItemGroup,
+  AListItemSubtitle,
+  AListItemTitle
 } from "./components/AList";
 import {
   ACiscoLoader,
@@ -145,6 +146,7 @@ export {
   AListItemAction,
   AListItemAvatar,
   AListItemContent,
+  AListItemGroup,
   AListItemSubtitle,
   AListItemTitle,
   AMenuBase,

--- a/framework/index.js
+++ b/framework/index.js
@@ -36,6 +36,7 @@ import {
   AListItemAction,
   AListItemAvatar,
   AListItemContent,
+  AListItemDivider,
   AListItemGroup,
   AListItemSubtitle,
   AListItemTitle
@@ -146,6 +147,7 @@ export {
   AListItemAction,
   AListItemAvatar,
   AListItemContent,
+  AListItemDivider,
   AListItemGroup,
   AListItemSubtitle,
   AListItemTitle,

--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -236,6 +236,9 @@ $atomic-default: (
     "color--disabled": map-get($mds-light-theme, "supplemental-text"),
     "opacity--disabled": 1
   ),
+  "list": (
+    "group-title-color": map-get($mds-light-theme, "secondary-gray")
+  ),
   "loader": (
     "background-color": map-get($mds-neutral, "neutral-4"),
     "main-color": map-get($mds-blue, "blue-7"),

--- a/framework/styles/theme/dusk.scss
+++ b/framework/styles/theme/dusk.scss
@@ -236,6 +236,9 @@ $atomic-dusk: (
     "color--disabled": map-get($mds-dark-theme, "supplemental-text"),
     "opacity--disabled": 1
   ),
+  "list": (
+    "group-title-color": map-get($mds-dark-theme, "secondary-gray")
+  ),
   "loader": (
     "background-color": map-get($mds-neutral, "neutral-12"),
     "main-color": map-get($mds-blue, "blue-5"),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally
- [x] The component should accept a class name as a prop, if appropriate
- [x] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?**

This PR introduces new feature to group list items (`AListItem`) under one unifying title as requested in Magnetic design. 

 Closes #318 

**What is the current behavior?** 

Current behaviour doesn't support such grouping. 



**What is the new behavior (if this is a feature change)?**

New behaviour supports grouping using `AListItemGroup` component. Docs was updated and contains this new component usage for "Lists" as well as "Menus".


**Does this PR introduce a breaking change?** 

No, this change should be backward compatible.



