### PR TITLE
feat(AMount): allow children to determine edge detection menu calculations

### DIFF
--- a/docs/mock_modules.js
+++ b/docs/mock_modules.js
@@ -1,17 +1,18 @@
+import {useEffect, useState} from "react";
 /**
  * These are modules that can be used inside of documentation
  * to provide more enriching examples. The purpose of keeping
  * these functions in this file is to abstract away unnecessary
  * implementation details for setting up an example in an effort
  * to focus more on the component's usage itself.
- * 
+ *
  * @example using the randomColors in documentation
  * const randomColors = mockImport('randomColors');
  * randomColors.get().then(randomColors => // use random colors);
  */
 const modules = {
-  randomColors: (function() {
-    const getHex = (num) => num.toString(16).padStart(2, '0');
+  randomColors: (function () {
+    const getHex = (num) => num.toString(16).padStart(2, "0");
     const getRandomRgb = () => {
       const r = Math.floor(Math.random() * 256);
       const g = Math.floor(Math.random() * 256);
@@ -19,8 +20,10 @@ const modules = {
       return {r, g, b};
     };
     const rgbToHex = ({r, g, b}) => {
-      const rHex = getHex(r), gHex = getHex(g), bHex = getHex(b);
-      return '#' + rHex + gHex + bHex;
+      const rHex = getHex(r),
+        gHex = getHex(g),
+        bHex = getHex(b);
+      return "#" + rHex + gHex + bHex;
     };
     const generateRandomColors = (maxColors = 25) => {
       const colors = [];
@@ -29,9 +32,9 @@ const modules = {
         const hex = rgbToHex(rgb);
         colors.push({
           ...rgb,
-          hex,
+          hex
         });
-      };
+      }
       return colors;
     };
     const get = (num = 25) => {
@@ -39,9 +42,46 @@ const modules = {
         setTimeout(() => resolve(generateRandomColors(num)), 1000);
       });
     };
-    return { get };
+    return {get};
   })(),
-}
+  useDraggable: (function () {
+    const useDraggable = (el) => {
+      const [{dx, dy}, setOffset] = useState({dx: 0, dy: 0});
+      useEffect(() => {
+        if (!el.current) return;
+        const draggableEl = el.current;
+        draggableEl.style.position = "relative";
+        const handleMouseDown = (event) => {
+          const startX = event.pageX - dx;
+          const startY = event.pageY - dy;
+          const handleMouseMove = (event) => {
+            const newDx = event.pageX - startX;
+            const newDy = event.pageY - startY;
+            setOffset({dx: newDx, dy: newDy});
+          };
+          document.addEventListener("mousemove", handleMouseMove);
+          document.addEventListener(
+            "mouseup",
+            () => {
+              document.removeEventListener("mousemove", handleMouseMove);
+            },
+            {once: true}
+          );
+        };
+        draggableEl.addEventListener("mousedown", handleMouseDown);
+        return () => {
+          if (!draggableEl) return;
+          draggableEl.removeEventListener("mousedown", handleMouseDown);
+        };
+      }, [dx, dy, el]);
+
+      useEffect(() => {
+        el.current.style.transform = `translate3d(${dx}px, ${dy}px, 0)`;
+      }, [dx, dy, el]);
+    };
+    return {useDraggable};
+  })()
+};
 
 function mockImport(moduleName) {
   const requestedModule = modules[moduleName];

--- a/framework/components/AMenuBase/AMenuBase.cy.js
+++ b/framework/components/AMenuBase/AMenuBase.cy.js
@@ -120,7 +120,7 @@ describe("<AMenuBase />", () => {
     getMenuContent().should("be.visible");
   });
 
-  describe.only("when rendered with a custom <AMount /> component", () => {
+  describe("when rendered with a custom <AMount /> component", () => {
     it("should not hide content when close to the left edge", () => {
       cy.mount(<CustomEdgeDetectionMenuTest edge="eft" placement="left" />);
 

--- a/framework/components/AMenuBase/AMenuBase.cy.js
+++ b/framework/components/AMenuBase/AMenuBase.cy.js
@@ -1,6 +1,8 @@
 import {useState, useRef} from "react";
 import AButton from "../AButton/AButton";
 import AMenuBase from "./AMenuBase";
+import AMount from "../AMount/AMount";
+import {getRoundedBoundedClientRect} from "../../utils/helpers";
 
 const getAnchor = () => cy.getByDataTestId("menu-trigger");
 const openMenu = () => cy.getByDataTestId("menu-trigger").click();
@@ -21,7 +23,10 @@ const getAnchorAndMenu = () => {
 const getAnchorAndMenuPositions = () => {
   return getAnchorAndMenu().then((els) => {
     const [anchorEl, menuEl] = els;
-    return [anchorEl.getBoundingClientRect(), menuEl.getBoundingClientRect()];
+    return [
+      getRoundedBoundedClientRect(anchorEl),
+      getRoundedBoundedClientRect(menuEl)
+    ];
   });
 };
 
@@ -114,6 +119,71 @@ describe("<AMenuBase />", () => {
 
     getMenuContent().should("be.visible");
   });
+
+  describe.only("when rendered with a custom <AMount /> component", () => {
+    it("should not hide content when close to the left edge", () => {
+      cy.mount(<CustomEdgeDetectionMenuTest edge="eft" placement="left" />);
+
+      openMenu();
+      getMenuContent().should("be.visible");
+    });
+
+    it("should not push content outside the custom <AMount /> when close to the left edge", () => {
+      cy.mount(<CustomEdgeDetectionMenuTest edge="eft" placement="left" />);
+
+      getAnchorAndMenuPositions().then(([anchorPos, menuPos]) => {
+        expect(menuPos.left === anchorPos.left).to.equal(true);
+      });
+    });
+
+    it("should not hide content when close to the right edge", () => {
+      cy.mount(<CustomEdgeDetectionMenuTest edge="right" placement="right" />);
+      openMenu();
+      getMenuContent().should("be.visible");
+    });
+
+    it("should not push content outside the custom <AMount /> when close to the right edge", () => {
+      cy.mount(<CustomEdgeDetectionMenuTest edge="right" placement="right" />);
+
+      getAnchorAndMenuPositions().then(([anchorPos, menuPos]) => {
+        expect(menuPos.right === anchorPos.right).to.equal(true);
+      });
+    });
+
+    it("should not hide content when close to the bottom edge", () => {
+      cy.mount(
+        <CustomEdgeDetectionMenuTest edge="bottom" placement="bottom" />
+      );
+
+      openMenu();
+      getMenuContent().should("be.visible");
+    });
+
+    it("should not push content outside the custom <AMount /> when close to the bottom edge", () => {
+      cy.mount(
+        <CustomEdgeDetectionMenuTest edge="bottom" placement="bottom" />
+      );
+
+      getAnchorAndMenuPositions().then(([anchorPos, menuPos]) => {
+        expect(menuPos.top === anchorPos.top).to.equal(true);
+      });
+    });
+
+    it("should not hide content when close to the top edge", () => {
+      cy.mount(<CustomEdgeDetectionMenuTest edge="top" placement="top" />);
+
+      openMenu();
+      getMenuContent().should("be.visible");
+    });
+
+    it("should not push content outside the custom <AMount /> when close to the top edge", () => {
+      cy.mount(<CustomEdgeDetectionMenuTest edge="top" placement="top" />);
+
+      getAnchorAndMenuPositions().then(([anchorPos, menuPos]) => {
+        expect(menuPos.top === anchorPos.top).to.equal(true);
+      });
+    });
+  });
 });
 
 function MenuTest(menuBaseProps) {
@@ -172,6 +242,46 @@ function EdgeDetectionMenuTest({edge, ...menuBaseProps}) {
       >
         <div style={{background: "white", padding: "10px"}}>test</div>
       </AMenuBase>
+    </div>
+  );
+}
+
+function CustomEdgeDetectionMenuTest({edge, ...menuBaseProps}) {
+  const btnRef = useRef();
+  const [isOpen, setIsOpen] = useState(menuBaseProps?.open);
+  const justifyStyle = `justify-${edge === "right" ? "end" : "left"}`;
+  const alignStyle = `align-${
+    edge === "bottom" ? "end" : edge === "top" ? "start" : "center"
+  }`;
+  return (
+    <div
+      data-testid="test-container"
+      className="d-flex justify-center align-center"
+      style={{height: "100vh", width: "100vw"}}
+    >
+      <AMount withNewWrappingContext={true}>
+        <div
+          className={`d-flex ${justifyStyle} ${alignStyle} mds-green--green-4`}
+          style={{height: "350px", width: "350px"}}
+          data-testid="edge-container"
+        >
+          <AButton
+            data-testid="menu-trigger"
+            ref={btnRef}
+            onClick={() => setIsOpen((state) => !state)}
+          >
+            {isOpen ? "close" : "open"}
+          </AButton>
+          <AMenuBase
+            {...menuBaseProps}
+            onClose={() => setIsOpen(false)}
+            anchorRef={btnRef}
+            open={isOpen}
+          >
+            <div style={{background: "white", padding: "10px"}}>test</div>
+          </AMenuBase>
+        </div>
+      </AMount>
     </div>
   );
 }

--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -22,7 +22,8 @@ const calculateMenuPosition = (
   setMenuLeft,
   setMenuTop,
   setInvisible,
-  removeSpacer = false
+  removeSpacer = false,
+  withNewWrappingContext
 ) => {
   if (!combinedRef.current) return;
 
@@ -116,23 +117,34 @@ const calculateMenuPosition = (
     window.getComputedStyle(combinedRef.current).marginTop
   );
 
-  const xOffset = appRef.current.offsetParent?.isSameNode(document.body)
-    ? window.pageXOffset
-    : wrapRef.current.offsetLeft - appRef.current.scrollLeft;
-  const yOffset = appRef.current.offsetParent?.isSameNode(document.body)
-    ? window.pageYOffset
-    : wrapRef.current.offsetTop - appRef.current.scrollTop;
+  const isAppWrappedByBody = appRef.current.offsetParent?.isSameNode(
+    document.body
+  );
 
-  const pageWidth = appRef.current.offsetParent?.isSameNode(document.body)
-    ? document.documentElement.clientWidth +
+  let xOffset, yOffset, pageWidth, pageHeight;
+
+  if (isAppWrappedByBody || !withNewWrappingContext) {
+    // Calculate positioning relative to viewport
+    xOffset = window.pageXOffset;
+    yOffset = window.pageYOffset;
+
+    pageWidth =
+      document.documentElement.clientWidth +
       xOffset -
-      wrapRef.current.offsetLeft
-    : wrapCoords.width;
-  const pageHeight = appRef.current.offsetParent?.isSameNode(document.body)
-    ? document.documentElement.clientHeight +
+      wrapRef.current.offsetLeft;
+
+    pageHeight =
+      document.documentElement.clientHeight +
       yOffset -
-      wrapRef.current.offsetTop
-    : wrapCoords.height;
+      wrapRef.current.offsetTop;
+  } else {
+    // Calculate positioning relative to `AMenuBase`
+    xOffset = wrapRef.current.offsetLeft - appRef.current.scrollLeft;
+    yOffset = wrapRef.current.offsetTop - appRef.current.scrollTop;
+
+    pageWidth = wrapCoords.width;
+    pageHeight = wrapCoords.height;
+  }
 
   // Edge detection: max x
   if (baseLeft + menuCoords.width + marginLeft > pageWidth) {
@@ -225,7 +237,7 @@ const AMenuBase = forwardRef(
     },
     ref
   ) => {
-    const {appRef, wrapRef} = useContext(AAppContext);
+    const {appRef, wrapRef, withNewWrappingContext} = useContext(AAppContext);
     const menuRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, menuRef);
     const [menuLeft, setMenuLeft] = useState(0);
@@ -244,7 +256,8 @@ const AMenuBase = forwardRef(
         setMenuLeft,
         setMenuTop,
         setInvisible,
-        removeSpacer
+        removeSpacer,
+        withNewWrappingContext
       );
     }, [
       open,
@@ -253,7 +266,8 @@ const AMenuBase = forwardRef(
       placement,
       appRef,
       wrapRef,
-      removeSpacer
+      removeSpacer,
+      withNewWrappingContext
     ]);
 
     useEffect(() => {
@@ -278,7 +292,8 @@ const AMenuBase = forwardRef(
           setMenuLeft,
           setMenuTop,
           setInvisible,
-          removeSpacer
+          removeSpacer,
+          withNewWrappingContext
         );
       };
 
@@ -289,7 +304,15 @@ const AMenuBase = forwardRef(
         window.removeEventListener("resize", screenChangeHandler);
         window.removeEventListener("fullscreenchange", screenChangeHandler);
       };
-    }, [anchorRef, combinedRef, placement, appRef, wrapRef, removeSpacer]);
+    }, [
+      anchorRef,
+      combinedRef,
+      placement,
+      appRef,
+      wrapRef,
+      removeSpacer,
+      withNewWrappingContext
+    ]);
 
     useEffect(() => {
       const screenChangeHandler = () => {
@@ -302,7 +325,8 @@ const AMenuBase = forwardRef(
           setMenuLeft,
           setMenuTop,
           setInvisible,
-          removeSpacer
+          removeSpacer,
+          withNewWrappingContext
         );
       };
 
@@ -311,7 +335,15 @@ const AMenuBase = forwardRef(
       return () => {
         window.removeEventListener("resize", screenChangeHandler);
       };
-    }, [anchorRef, combinedRef, placement, appRef, wrapRef, removeSpacer]);
+    }, [
+      anchorRef,
+      combinedRef,
+      placement,
+      appRef,
+      wrapRef,
+      removeSpacer,
+      withNewWrappingContext
+    ]);
 
     useEffect(() => {
       const clickOutsideHandler = (e) => {

--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -118,15 +118,21 @@ const calculateMenuPosition = (
 
   const xOffset = appRef.current.offsetParent?.isSameNode(document.body)
     ? window.pageXOffset
-    : wrapCoords.left - appCoords.scrollLeft;
+    : wrapRef.current.offsetLeft - appRef.current.scrollLeft;
   const yOffset = appRef.current.offsetParent?.isSameNode(document.body)
     ? window.pageYOffset
-    : wrapCoords.top - appCoords.scrollTop;
+    : wrapRef.current.offsetTop - appRef.current.scrollTop;
 
-  const pageWidth =
-    document.documentElement.clientWidth + xOffset - wrapRef.current.offsetLeft;
-  const pageHeight =
-    document.documentElement.clientHeight + yOffset - wrapRef.current.offsetTop;
+  const pageWidth = appRef.current.offsetParent?.isSameNode(document.body)
+    ? document.documentElement.clientWidth +
+      xOffset -
+      wrapRef.current.offsetLeft
+    : wrapCoords.width;
+  const pageHeight = appRef.current.offsetParent?.isSameNode(document.body)
+    ? document.documentElement.clientHeight +
+      yOffset -
+      wrapRef.current.offsetTop
+    : wrapCoords.height;
 
   // Edge detection: max x
   if (baseLeft + menuCoords.width + marginLeft > pageWidth) {

--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -117,13 +117,16 @@ const calculateMenuPosition = (
     window.getComputedStyle(combinedRef.current).marginTop
   );
 
-  const isAppWrappedByBody = appRef.current.offsetParent?.isSameNode(
-    document.body
-  );
-
   let xOffset, yOffset, pageWidth, pageHeight;
 
-  if (isAppWrappedByBody || !withNewWrappingContext) {
+  if (withNewWrappingContext) {
+    // Calculate positioning relative to `AMenuBase`
+    xOffset = wrapRef.current.offsetLeft - appRef.current.scrollLeft;
+    yOffset = wrapRef.current.offsetTop - appRef.current.scrollTop;
+
+    pageWidth = wrapCoords.width;
+    pageHeight = wrapCoords.height;
+  } else {
     // Calculate positioning relative to viewport
     xOffset = window.pageXOffset;
     yOffset = window.pageYOffset;
@@ -137,13 +140,6 @@ const calculateMenuPosition = (
       document.documentElement.clientHeight +
       yOffset -
       wrapRef.current.offsetTop;
-  } else {
-    // Calculate positioning relative to `AMenuBase`
-    xOffset = wrapRef.current.offsetLeft - appRef.current.scrollLeft;
-    yOffset = wrapRef.current.offsetTop - appRef.current.scrollTop;
-
-    pageWidth = wrapCoords.width;
-    pageHeight = wrapCoords.height;
   }
 
   // Edge detection: max x

--- a/framework/components/AModal/AModal.scss
+++ b/framework/components/AModal/AModal.scss
@@ -1,5 +1,7 @@
 .a-modal-container {
   position: fixed;
+  left: 0;
+  top: 0;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/framework/components/AMount/AMount.js
+++ b/framework/components/AMount/AMount.js
@@ -14,6 +14,7 @@ const AMount = forwardRef(
       className: propsClassName,
       component,
       wrapClassName: propsWrapClassName,
+      withNewWrappingContext = false,
       ...rest
     },
     ref
@@ -25,6 +26,9 @@ const AMount = forwardRef(
     const [toasts2, setToasts2] = useState([]);
 
     let className = "a-mount";
+    if (withNewWrappingContext) {
+      className += ` ${className}--withNewWrappingContext`;
+    }
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
@@ -40,7 +44,8 @@ const AMount = forwardRef(
       appRef: combinedRef,
       wrapRef: newWrapRef,
       toasts: toasts || toasts2,
-      setToasts: setToasts || setToasts2
+      setToasts: setToasts || setToasts2,
+      withNewWrappingContext
     };
 
     const hasToastPlate =

--- a/framework/components/AMount/AMount.js
+++ b/framework/components/AMount/AMount.js
@@ -5,6 +5,8 @@ import AAppContext from "../AApp/AAppContext";
 import {AToastPlate} from "../AToaster";
 import {useCombinedRefs} from "../../utils/hooks";
 
+import "./AMount.scss";
+
 const AMount = forwardRef(
   (
     {

--- a/framework/components/AMount/AMount.js
+++ b/framework/components/AMount/AMount.js
@@ -14,6 +14,7 @@ const AMount = forwardRef(
       className: propsClassName,
       component,
       wrapClassName: propsWrapClassName,
+      // @todo remove and make this default in next major version
       withNewWrappingContext = false,
       ...rest
     },

--- a/framework/components/AMount/AMount.mdx
+++ b/framework/components/AMount/AMount.mdx
@@ -60,6 +60,38 @@ It is necessary for `AMount` to be a descendant of `AApp`.
 `}
 />
 
+### With A New Wrapping Context (AKA Boundary)
+
+In the example below, `AMount` creates a new boundary for any children that render menu content.
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+    const ENTER_PLACEMENT_HERE = "bottom";
+
+    const { useDraggable } = mockImport("useDraggable");
+
+    const anchorRef = useRef();
+    useDraggable(anchorRef);
+
+    const { open, close, isOpen } = useToggle(0, 0);
+
+    return (
+      <AMount withNewWrappingContext={true}>
+        <div className="d-flex align-center justify-center" style={{height: "200px"}}>
+          <AButton ref={anchorRef} onMouseDown={close} onMouseUp={open}>
+            Drag Me
+          </AButton>
+          <AMenu anchorRef={anchorRef} open={isOpen} onClose={close} placement={ENTER_PLACEMENT_HERE}>
+            <APanelBody>Hello world</APanelBody>
+          </AMenu>
+        </div>
+      </AMount>
+    )
+
+}`}
+/>
+
 ## Props
 
 `AMount` inherits passed props.

--- a/framework/components/AMount/AMount.mdx
+++ b/framework/components/AMount/AMount.mdx
@@ -62,10 +62,10 @@ It is necessary for `AMount` to be a descendant of `AApp`.
 
 ### With A New Wrapping Context (AKA Boundary)
 
-In the example below, `AMount` creates a new boundary for any children that render menu content.
+In the example below, `AMount` creates a new boundary for any children that render menu content. If you drag the button outside of the green box, notice how the menu will stay within the playground area (since we wrapped the container in this demo with `AMount`).
 
 <Playground
-  fullWidthPreview
+  
   code={`() => {
     const ENTER_PLACEMENT_HERE = "bottom";
 
@@ -78,7 +78,7 @@ In the example below, `AMount` creates a new boundary for any children that rend
 
     return (
       <AMount withNewWrappingContext={true}>
-        <div className="d-flex align-center justify-center" style={{height: "200px"}}>
+        <div className="d-flex align-center justify-center mds-green--green-4" style={{height: "350px", width: '350px'}}>
           <AButton ref={anchorRef} onMouseDown={close} onMouseUp={open}>
             Drag Me
           </AButton>

--- a/framework/components/AMount/AMount.scss
+++ b/framework/components/AMount/AMount.scss
@@ -9,5 +9,7 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
  */
 .a-mount {
-  position: relative;
+  &--withNewWrappingContext {
+    position: relative;
+  }
 }

--- a/framework/components/AMount/AMount.scss
+++ b/framework/components/AMount/AMount.scss
@@ -11,5 +11,9 @@
 .a-mount {
   &--withNewWrappingContext {
     position: relative;
+
+    & .a-mount--wrap {
+      width: fit-content;
+    }
   }
 }

--- a/framework/components/AMount/AMount.scss
+++ b/framework/components/AMount/AMount.scss
@@ -1,0 +1,13 @@
+/**
+ * Needed for properly calculating menu positions within Magna React since
+ * the calculations depend on the `HTMLElement.offsetParent` property for
+ * its calculations.
+ * 
+ * In order for our menu positions to be correct, we need to set this element
+ * to something non statically-positioned.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+ */
+.a-mount {
+  position: relative;
+}

--- a/pages/[[...route]]/index.js
+++ b/pages/[[...route]]/index.js
@@ -4,7 +4,14 @@ import {serialize} from "next-mdx-remote/serialize";
 import {MDXRemote} from "next-mdx-remote";
 import React from "react";
 
-import {AApp, AAutoTheme, ACol, AContainer, ARow} from "../../framework";
+import {
+  AApp,
+  AAutoTheme,
+  ACol,
+  AContainer,
+  ARow,
+  AMount
+} from "../../framework";
 import HiddenFontSwatches from "../../docs/HiddenFontSwatches";
 import Sidebar from "../../docs/Sidebar";
 import PropsContext from "../../docs/PropsContext";
@@ -36,11 +43,16 @@ export default function TestPage({currentDoc, menus, propsInfo}) {
               <ACol style={{maxWidth: 330}}>
                 <Sidebar currentDoc={currentDoc} menus={menus} />
               </ACol>
-              <ACol className="pa-8" style={{maxWidth: "calc(100vw - 347px)"}}>
-                <PropsContext.Provider value={propsInfo}>
-                  <MDXRemote {...currentDoc.source} components={components} />
-                </PropsContext.Provider>
-              </ACol>
+              <AMount>
+                <ACol
+                  className="pa-8"
+                  style={{maxWidth: "calc(100vw - 347px)"}}
+                >
+                  <PropsContext.Provider value={propsInfo}>
+                    <MDXRemote {...currentDoc.source} components={components} />
+                  </PropsContext.Provider>
+                </ACol>
+              </AMount>
             </ARow>
           </AContainer>
         </AAutoTheme>

--- a/pages/[[...route]]/index.js
+++ b/pages/[[...route]]/index.js
@@ -43,7 +43,7 @@ export default function TestPage({currentDoc, menus, propsInfo}) {
               <ACol style={{maxWidth: 330}}>
                 <Sidebar currentDoc={currentDoc} menus={menus} />
               </ACol>
-              <AMount>
+              <AMount withNewWrappingContext={true}>
                 <ACol
                   className="pa-8"
                   style={{maxWidth: "calc(100vw - 347px)"}}


### PR DESCRIPTION
This PR allows a child of `AMount` to determine the edge detection settings by passing `withNewWrappingContext={true}` to the component.

Example:

```jsx
<AMount>
    <div> {/* <-- this div is the new edge determinator */}
        Is this PR a feature or fix? Probably a feafix or fixeat.
    </div>
</AMount>
```

This is better demonstrated on the [example docs](https://magna-react-pfy3lvsn7.securex-preview.app/components/mount).