### PR TITLE
feat: #337 add options to ASelect to handle long menu items

### DIFF
--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -96,7 +96,7 @@ const AMenu = forwardRef(
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
-
+    console.log(rest);
     return (
       <AList
         {...rest}

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -96,7 +96,6 @@ const AMenu = forwardRef(
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
-    console.log(rest);
     return (
       <AList
         {...rest}

--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -362,7 +362,6 @@ const AMenuBase = forwardRef(
       pointerStyle.top = pointerTop;
     }
 
-    console.log("style", style);
     return (
       (open &&
         appRef.current &&

--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -24,7 +24,9 @@ const calculateMenuPosition = (
   setInvisible,
   removeSpacer = false
 ) => {
-  if (!combinedRef.current) return;
+  if (!combinedRef.current) {
+    return;
+  }
 
   const appCoords = getRoundedBoundedClientRect(appRef.current);
   const wrapCoords = getRoundedBoundedClientRect(wrapRef.current);
@@ -161,13 +163,17 @@ const calculatePointerPosition = (
   setPointerLeft,
   setPointerTop
 ) => {
-  if (!combinedRef.current) return;
+  if (!combinedRef.current) {
+    return;
+  }
 
   const anchorCoords = getRoundedBoundedClientRect(anchorRef.current);
   const menuCoords = getRoundedBoundedClientRect(combinedRef.current);
 
   // Pointer
-  if (!pointer) return;
+  if (!pointer) {
+    return;
+  }
 
   switch (placement) {
     case "top":
@@ -356,6 +362,7 @@ const AMenuBase = forwardRef(
       pointerStyle.top = pointerTop;
     }
 
+    console.log("style", style);
     return (
       (open &&
         appRef.current &&

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -422,7 +422,10 @@ const ASelect = forwardRef(
 
                   if (truncateMenuItems) {
                     itemProps.children = (
-                      <span className="a-select__menu-item-wrap">
+                      <span
+                        title={itemProps.children}
+                        className="a-select__menu-item-wrap"
+                      >
                         {itemProps.children}
                       </span>
                     );
@@ -439,7 +442,10 @@ const ASelect = forwardRef(
 
                   if (truncateMenuItems) {
                     itemProps.children = (
-                      <span className="a-select__menu-item-wrap">
+                      <span
+                        title={item[itemText]}
+                        className="a-select__menu-item-wrap"
+                      >
                         {itemProps.children}
                       </span>
                     );

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -47,6 +47,8 @@ const ASelect = forwardRef(
       useTemplateForSelectedItem = false,
       selectedDisplayTemplate,
       selectedDisplayItem,
+      textWrapMenuItems,
+      truncateMenuItems,
       ...rest
     },
     ref
@@ -152,7 +154,9 @@ const ASelect = forwardRef(
     };
 
     const getPreviousItem = (selectedIndex) => {
-      if (items.every((x) => x[itemDisabled])) return null;
+      if (items.every((x) => x[itemDisabled])) {
+        return null;
+      }
 
       let newItem = items[selectedIndex - 1];
       if (!newItem) {
@@ -167,7 +171,9 @@ const ASelect = forwardRef(
     };
 
     const getNextItem = (selectedIndex) => {
-      if (items.every((x) => x[itemDisabled])) return null;
+      if (items.every((x) => x[itemDisabled])) {
+        return null;
+      }
 
       let newItem = items[selectedIndex + 1];
       if (!newItem) {
@@ -297,6 +303,12 @@ const ASelect = forwardRef(
       menuClassName += ` ${dropdownClassName}`;
     }
 
+    if (textWrapMenuItems) {
+      menuClassName += " a-select__menu-items--text-wrap-menu-items";
+    } else if (truncateMenuItems) {
+      menuClassName += " a-select__menu-items--truncate-menu-items";
+    }
+
     const menuComponentProps = {
       anchorRef: inputBaseSurfaceRef,
       className: menuClassName,
@@ -408,6 +420,14 @@ const ASelect = forwardRef(
                     selectItem(item);
                   };
 
+                  if (truncateMenuItems) {
+                    itemProps.children = (
+                      <span className="a-select__menu-item-wrap">
+                        {itemProps.children}
+                      </span>
+                    );
+                  }
+
                   if (item === selectedItem) {
                     itemProps.className += " a-select__menu-item--selected";
                     itemProps["aria-selected"] = true;
@@ -416,6 +436,15 @@ const ASelect = forwardRef(
                 } else if (typeof item === "object") {
                   itemProps.value = item[itemValue];
                   itemProps.children = item[itemText];
+
+                  if (truncateMenuItems) {
+                    itemProps.children = (
+                      <span className="a-select__menu-item-wrap">
+                        {itemProps.children}
+                      </span>
+                    );
+                  }
+
                   if (item[itemDisabled]) {
                     itemProps["aria-disabled"] = true;
                     itemProps.onClick = (e) => {
@@ -571,8 +600,19 @@ ASelect.propTypes = {
    * Sets a React component to use when rendering the selected menu item. The component will be sent the following props: `item`. This overrides `useTemplateForSelectedItem`.
    */
   selectedDisplayTemplate: PropTypes.elementType,
-  /** If set, uses a custom item rather than the selectedItem when using `selectedDisplayTemplate` */
-  selectedDisplayItem: PropTypes.object
+  /**
+   * If set, uses a custom item rather than the selectedItem when using `selectedDisplayTemplate` */
+  selectedDisplayItem: PropTypes.object,
+  /**
+   * If item display is a string (no template), set white-space:normal on each
+   * item and limit width of the menu.
+   */
+  textWrapMenuItems: PropTypes.bool,
+  /**
+   * If item display is a string (no template), truncate the display string with
+   * ellipsis and limit width of the menu.
+   */
+  truncateMenuItems: PropTypes.bool
 };
 
 ASelect.displayName = "ASelect";

--- a/framework/components/ASelect/ASelect.mdx
+++ b/framework/components/ASelect/ASelect.mdx
@@ -44,13 +44,63 @@ import {ASelect} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+### Truncating Select Options
+
+<Playground
+  code={`() => {
+      const items = [
+        "Magic: Casting various combat and utility spells",
+        "Runecraft: Creating runes used for casting Magic",
+        "Crafting: 	Creating items such as jewellery, pottery, and ranged armour",
+        "Agility: Traversing shortcuts and increases the rate at which energy recharges",
+      ];
+      const [selectedItem, setSelectedItem] = useState(items[2]);
+      return (
+        <div style={{ minHeight: 220, width: 375, marginRight: 20 }}>
+          <ASelect
+            label="RuneScape Skills"
+            items={items}
+            truncateMenuItems
+            placeholder="Runecraft"
+            onSelected={(item) => setSelectedItem(item)}
+          />
+        </div>
+      );
+  
+  }`}
+/>
+
+### Wrapping Long Select Options
+
+<Playground
+  code={`() => {
+      const items = [
+        "Magic: Casting various combat and utility spells",
+        "Runecraft: Creating runes used for casting Magic",
+        "Crafting: 	Creating items such as jewellery, pottery, and ranged armour",
+        "Agility: Traversing shortcuts and increases the rate at which energy recharges",
+      ];
+      const [selectedItem, setSelectedItem] = useState(items[2]);
+      return (
+        <div style={{ minHeight: 220, width: 375, marginRight: 20 }}>
+          <ASelect
+            label="RuneScape Skills"
+            items={items}
+            textWrapMenuItems
+            placeholder="Runecraft"
+            onSelected={(item) => setSelectedItem(item)}
+          />
+        </div>
+      );
+  
+  }`}
+/>
+
 ## Select Props
 
 The `ASelect` component inherits passed props.
 
 <Props of="ASelect" />
-
-
 
 ## Many Dropdown Options
 
@@ -125,7 +175,6 @@ The `ASelect` component inherits passed props.
 }
 `}
 />
-
 
 ## Validation
 

--- a/framework/components/ASelect/ASelect.scss
+++ b/framework/components/ASelect/ASelect.scss
@@ -138,5 +138,8 @@ $select-padding: 6px;
   overflow-y: auto;
   .a-list-item.a-select__menu-item {
     white-space: normal;
+    text-indent: unset;
+    /* preserve the original 4px padding and add the negated text-indent */
+    padding-left: calc(4px + $select-padding);
   }
 }

--- a/framework/components/ASelect/ASelect.scss
+++ b/framework/components/ASelect/ASelect.scss
@@ -119,3 +119,24 @@ $select-padding: 6px;
     cursor: not-allowed;
   }
 }
+
+.a-select__menu-items--truncate-menu-items {
+  min-width: unset !important;
+  .a-list-item.a-select__menu-item {
+    overflow: hidden;
+  }
+  .a-select__menu-item-wrap {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.a-select__menu-items--text-wrap-menu-items {
+  min-width: unset !important;
+  max-height: 400px;
+  overflow-y: auto;
+  .a-list-item.a-select__menu-item {
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
Adds two props to ASelect

textWrapMenuItems | If item display is a string (no template), set white-space:normal on each item and limit width of the menu.Boolean | null
-- | -- | --
truncateMenuItems | If item display is a string (no template), truncate the display string with ellipsis and limit width of the menu.Boolean | null


Resolves #337 
