### PR TITLE
feat: Pause toast timeout on hover

### DIFF
--- a/framework/components/AToaster/customTimeout.js
+++ b/framework/components/AToaster/customTimeout.js
@@ -1,0 +1,43 @@
+class PausableTimeout {
+  constructor(callback, delay) {
+    this.callback = callback;
+    this.delay = delay;
+    this.remaining = delay;
+
+    this.start();
+  }
+
+  start() {
+    this.running = true;
+    this.started = new Date();
+    this.id = setTimeout(() => {
+      this.callback();
+    }, this.remaining);
+  }
+
+  pause() {
+    this.running = false;
+    clearTimeout(this.id);
+    this.remaining -= new Date() - this.started;
+  }
+
+  clear() {
+    this.running = false;
+    clearTimeout(this.id);
+  }
+
+  getTimeLeft() {
+    if (this.running) {
+      this.pause();
+      this.start();
+    }
+
+    return this.remaining;
+  }
+
+  getStateRunning() {
+    return this.running;
+  }
+}
+
+export default PausableTimeout;

--- a/framework/components/AToaster/useAToaster.js
+++ b/framework/components/AToaster/useAToaster.js
@@ -2,6 +2,7 @@ import React, {forwardRef, useContext, useEffect, useRef} from "react";
 
 import AAppContext from "../AApp/AAppContext";
 import AToast from "../AToast";
+import PausableTimeout from "./customTimeout";
 import "./AToaster.scss";
 
 let toastId = 1;
@@ -16,14 +17,13 @@ const AToasterToast = forwardRef(
         clearTimeout(timeoutRef.current);
       }
 
-      if (!timeout || timeout === -1) return;
-      timeoutRef.current = setTimeout(
-        () =>
-          setToasts((current) =>
-            current.filter((x) => x.id !== toasterToastId)
-          ),
-        timeout
-      );
+      if (!timeout || timeout === -1) {
+        return;
+      }
+
+      timeoutRef.current = new PausableTimeout(() => {
+        setToasts((current) => current.filter((x) => x.id !== toasterToastId));
+      }, timeout);
     }, [timeout, setToasts, toasterToastId]);
 
     let className = "a-toaster__toast";
@@ -43,6 +43,20 @@ const AToasterToast = forwardRef(
         onClose={() =>
           setToasts((current) => current.filter((x) => x.id !== toasterToastId))
         }
+        onMouseEnter={() => {
+          if (!timeoutRef.current) {
+            return;
+          }
+
+          timeoutRef.current.pause();
+        }}
+        onMouseLeave={() => {
+          if (!timeoutRef.current) {
+            return;
+          }
+
+          timeoutRef.current.start();
+        }}
       />
     );
   }

--- a/framework/components/AToaster/useAToaster.js
+++ b/framework/components/AToaster/useAToaster.js
@@ -1,8 +1,7 @@
 import React, {forwardRef, useContext, useEffect, useRef} from "react";
-
+import PausableTimeout from "../../utils/PausableTimeout";
 import AAppContext from "../AApp/AAppContext";
 import AToast from "../AToast";
-import PausableTimeout from "./customTimeout";
 import "./AToaster.scss";
 
 let toastId = 1;
@@ -55,7 +54,7 @@ const AToasterToast = forwardRef(
             return;
           }
 
-          timeoutRef.current.start();
+          timeoutRef.current.resume();
         }}
       />
     );

--- a/framework/utils/PausableTimeout.js
+++ b/framework/utils/PausableTimeout.js
@@ -4,10 +4,10 @@ class PausableTimeout {
     this.delay = delay;
     this.remaining = delay;
 
-    this.start();
+    this.resume();
   }
 
-  start() {
+  resume() {
     this.running = true;
     this.started = new Date();
     this.id = setTimeout(() => {
@@ -23,13 +23,14 @@ class PausableTimeout {
 
   clear() {
     this.running = false;
+    this.remaining = this.delay;
     clearTimeout(this.id);
   }
 
   getTimeLeft() {
     if (this.running) {
       this.pause();
-      this.start();
+      this.resume();
     }
 
     return this.remaining;

--- a/framework/utils/PausableTimeout.js
+++ b/framework/utils/PausableTimeout.js
@@ -7,6 +7,11 @@ class PausableTimeout {
     this.resume();
   }
 
+  restart() {
+    this.clear();
+    this.resume();
+  }
+
   resume() {
     this.running = true;
     this.started = new Date();


### PR DESCRIPTION
Based on the pabst-components Notifier functionality, this will pause the dismiss timeout of an `AToast` generated by `useAToaster` when the user hovers over the toast message. 

Originally this was a request from users and UX to give more time to read some notifications.

Functionality:

1. Toast message is generated with a default 6 second timeout (#336)
2. User hovers over toast after 2 seconds
3. Timeout is paused indefinitely until user hovers away
4. Timeout resumes with 4 seconds left
5. Toast dismisses after 4 seconds