### PR TITLE
feat: allow DOMRect objects to be passed to anchorRef props

### DIFF
--- a/framework/components/AContextualNotificationMenu/AContextualNotificationMenu.js
+++ b/framework/components/AContextualNotificationMenu/AContextualNotificationMenu.js
@@ -36,11 +36,17 @@ const AContextualNotificationMenu = forwardRef(
     }, [open, combinedRef, focusOnOpen]);
 
     const closeHandler = (e) => {
+      if (anchorRef instanceof DOMRect) {
+        return;
+      }
       anchorRef.current && anchorRef.current.focus();
       onClose && onClose(e);
     };
 
     const keyDownHandler = (e) => {
+      if (anchorRef instanceof DOMRect) {
+        return;
+      }
       if (onClose && e.keyCode === keyCodes.esc) {
         e.preventDefault();
         closeHandler(e);
@@ -73,7 +79,8 @@ const AContextualNotificationMenu = forwardRef(
         anchorRef={anchorRef}
         pointer={true}
         variant={variant}
-        tabIndex={-1}>
+        tabIndex={-1}
+      >
         {children}
       </AContextualNotification>
     );
@@ -82,11 +89,22 @@ const AContextualNotificationMenu = forwardRef(
 
 AContextualNotificationMenu.propTypes = {
   /**
-   * The reference to the menu anchor.
+   * The reference to the menu anchor. Can either be a React ref or a DOMRect object.
    */
   anchorRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
+    PropTypes.shape({current: PropTypes.any}),
+    // DOMRect shape
+    PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number
+    })
   ]).isRequired,
   /**
    * Toggles the behavior of focusing the menu on open.

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -62,11 +62,17 @@ const AMenu = forwardRef(
     };
 
     const closeHandler = (e) => {
+      if (anchorRef instanceof DOMRect) {
+        return;
+      }
       anchorRef.current && anchorRef.current.focus();
       onClose && onClose(e);
     };
 
     const keyDownHandler = (e) => {
+      if (anchorRef instanceof DOMRect) {
+        return;
+      }
       if (onClose && e.keyCode === keyCodes.esc) {
         e.preventDefault();
         closeHandler(e);
@@ -127,11 +133,22 @@ const AMenu = forwardRef(
 
 AMenu.propTypes = {
   /**
-   * The reference to the menu anchor.
+   * The reference to the menu anchor. Can either be a React ref or a DOMRect object.
    */
   anchorRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
+    PropTypes.shape({current: PropTypes.any}),
+    // DOMRect shape
+    PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number
+    })
   ]).isRequired,
   /**
    * Toggles the behavior of closing the menu on click.

--- a/framework/components/AMenuBase/AMenuBase.cy.js
+++ b/framework/components/AMenuBase/AMenuBase.cy.js
@@ -120,6 +120,19 @@ describe("<AMenuBase />", () => {
     getMenuContent().should("be.visible");
   });
 
+  it("should allow an DOMRect object to be passed instead of a React ref", () => {
+    const anchorDOMRect = new DOMRect(
+      window.innerWidth / 2, // middle x-axis
+      window.innerHeight / 2 // middle y-axis
+    );
+
+    cy.mount(<MenuTest anchorRef={anchorDOMRect} />);
+
+    // Open menu
+    openMenu();
+    cy.get(".a-menu-base").should("exist");
+  });
+
   describe("when rendered with a custom <AMount /> component", () => {
     it("should not hide content when close to the left edge", () => {
       cy.mount(<CustomEdgeDetectionMenuTest edge="eft" placement="left" />);
@@ -203,10 +216,10 @@ function MenuTest(menuBaseProps) {
         {isOpen ? "close" : "open"}
       </AButton>
       <AMenuBase
-        {...menuBaseProps}
         onClose={() => setIsOpen(false)}
         anchorRef={btnRef}
         open={isOpen}
+        {...menuBaseProps}
       >
         <div style={{background: "white", padding: "10px"}}>test</div>
       </AMenuBase>
@@ -235,10 +248,10 @@ function EdgeDetectionMenuTest({edge, ...menuBaseProps}) {
         {isOpen ? "close" : "open"}
       </AButton>
       <AMenuBase
-        {...menuBaseProps}
         onClose={() => setIsOpen(false)}
         anchorRef={btnRef}
         open={isOpen}
+        {...menuBaseProps}
       >
         <div style={{background: "white", padding: "10px"}}>test</div>
       </AMenuBase>
@@ -273,10 +286,10 @@ function CustomEdgeDetectionMenuTest({edge, ...menuBaseProps}) {
             {isOpen ? "close" : "open"}
           </AButton>
           <AMenuBase
-            {...menuBaseProps}
             onClose={() => setIsOpen(false)}
             anchorRef={btnRef}
             open={isOpen}
+            {...menuBaseProps}
           >
             <div style={{background: "white", padding: "10px"}}>test</div>
           </AMenuBase>

--- a/framework/components/AMenuBase/AMenuBase.js
+++ b/framework/components/AMenuBase/AMenuBase.js
@@ -17,7 +17,7 @@ const calculateMenuPosition = (
   combinedRef,
   appRef,
   wrapRef,
-  anchorRef,
+  anchorRef, // Can be either a React Ref or DOMRect
   placement,
   setMenuLeft,
   setMenuTop,
@@ -31,7 +31,10 @@ const calculateMenuPosition = (
 
   const appCoords = getRoundedBoundedClientRect(appRef.current);
   const wrapCoords = getRoundedBoundedClientRect(wrapRef.current);
-  const anchorCoords = getRoundedBoundedClientRect(anchorRef.current);
+  const anchorCoords =
+    anchorRef instanceof DOMRect
+      ? anchorRef
+      : getRoundedBoundedClientRect(anchorRef.current);
   const menuCoords = getRoundedBoundedClientRect(combinedRef.current);
   const magneticSpacer = removeSpacer ? 0 : 4;
 
@@ -171,7 +174,7 @@ const calculateMenuPosition = (
 
 const calculatePointerPosition = (
   combinedRef,
-  anchorRef,
+  anchorRef, // Can be either a React Ref or DOMRect
   pointer,
   placement,
   setPointerLeft,
@@ -181,7 +184,10 @@ const calculatePointerPosition = (
     return;
   }
 
-  const anchorCoords = getRoundedBoundedClientRect(anchorRef.current);
+  const anchorCoords =
+    anchorRef instanceof DOMRect
+      ? anchorRef
+      : getRoundedBoundedClientRect(anchorRef.current);
   const menuCoords = getRoundedBoundedClientRect(combinedRef.current);
 
   // Pointer
@@ -349,6 +355,10 @@ const AMenuBase = forwardRef(
 
     useEffect(() => {
       const clickOutsideHandler = (e) => {
+        if (anchorRef instanceof DOMRect) {
+          return;
+        }
+
         if (
           anchorRef.current &&
           combinedRef.current &&
@@ -421,11 +431,22 @@ const AMenuBase = forwardRef(
 
 AMenuBase.propTypes = {
   /**
-   * The reference to the menu anchor.
+   * The reference to the menu anchor. Can either be a React ref or a DOMRect object.
    */
   anchorRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
+    PropTypes.shape({current: PropTypes.any}),
+    // DOMRect shape
+    PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number
+    })
   ]).isRequired,
   /**
    * Handles the request to close the menu.

--- a/framework/components/APopover/APopover.js
+++ b/framework/components/APopover/APopover.js
@@ -11,6 +11,7 @@ const APopover = forwardRef(
   (
     {
       anchorRef,
+      anchorDOMRect,
       children,
       className: propsClassName,
       focusOnOpen = true,
@@ -40,6 +41,9 @@ const APopover = forwardRef(
     };
 
     const keyDownHandler = (e) => {
+      if (anchorRef instanceof DOMRect) {
+        return;
+      }
       if (onClose && e.keyCode === keyCodes.esc) {
         e.preventDefault();
         closeHandler(e);
@@ -72,7 +76,8 @@ const APopover = forwardRef(
         anchorRef={anchorRef}
         pointer={true}
         type="dialog"
-        tabIndex={-1}>
+        tabIndex={-1}
+      >
         {children}
       </APanel>
     );
@@ -81,11 +86,22 @@ const APopover = forwardRef(
 
 APopover.propTypes = {
   /**
-   * The reference to the menu anchor.
+   * The reference to the menu anchor. Can either be a React ref or a DOMRect object.
    */
   anchorRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
+    PropTypes.shape({current: PropTypes.any}),
+    // DOMRect shape
+    PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number
+    })
   ]).isRequired,
   /**
    * Toggles the behavior of focusing the menu on open.

--- a/framework/components/ATooltip/ATooltip.js
+++ b/framework/components/ATooltip/ATooltip.js
@@ -53,11 +53,22 @@ const ATooltip = forwardRef(
 
 export const ATooltipPropTypes = {
   /**
-   * The reference to the menu anchor.
+   * The reference to the menu anchor. Can either be a React ref or a DOMRect object.
    */
   anchorRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
+    PropTypes.shape({current: PropTypes.any}),
+    // DOMRect shape
+    PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+      top: PropTypes.number,
+      right: PropTypes.number,
+      bottom: PropTypes.number,
+      left: PropTypes.number
+    })
   ]).isRequired,
   /**
    * Handles the request to close the menu.


### PR DESCRIPTION
Resolves #357 

Usage:

```jsx
const x = 100;
const y = 250;

<ATooltip anchorRef={new DOMRect(x, y)} />
```

I updated prop-types for this, too. It might be annoying having the `DOMRect` properties copied for each component that requires an `anchorRef` prop-type declaration, but I can't do `PropTypes.instanceOf(DOMRect)` because the `window` is only available at runtime.

I have also gone ahead and added conditional checks for any components expecting `anchorRef` to be a React `ref`, e.g., when trying to call the `focus` method on a DOM node. In this case I can explicitly do an `anchorRef instanceof DOMRect` check.