### PR TITLE
fix: button spinner color

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -444,6 +444,13 @@ $btn-transition: color $transition-duration--extra-fast
     stroke: currentColor;
   }
 
+  .a-spinner {
+    margin-right: 2px;
+    circle {
+      stroke: currentColor !important;
+    }
+  }
+
   .a-icon.a-icon--dots-three,
   .a-icon.a-icon--dots-six,
   .a-icon.a-icon--dots-nine {


### PR DESCRIPTION
Closes #359

Quick fix on button loader colors:

![Screenshot 2023-04-25 at 2 21 47 PM](https://user-images.githubusercontent.com/112431822/234367532-647e815c-7c86-4eb4-acb9-d2ac6a3a6ff1.png)
![Screenshot 2023-04-25 at 2 21 39 PM](https://user-images.githubusercontent.com/112431822/234367544-062ef5c3-1658-47ca-bb0c-3d345df94060.png)

Note* Thinking since it looks like the button loaders are standardized in magnetic, magna could probably handle it all through a loading prop.
