### PR TITLE
style: make sure 0 margin on icons

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -476,6 +476,7 @@ $btn-transition: color $transition-duration--extra-fast
   &--icon {
     padding: 10px !important;
     height: auto !important;
+    margin: 0 !important;
   }
 
   &.disabled,


### PR DESCRIPTION
Small change to make sure extra margin doesn't get added on icons.

Note for using AButton as an icon, one must pass the icon prop for icon styles, otherwise you'll get regular button styles.  I see a few places in ribbon where this will need to be specified.

Example tertiary button as an "icon button":
![Screenshot 2023-05-04 at 10 10 01 AM](https://user-images.githubusercontent.com/112431822/236233579-5b9af494-d2b7-4200-b96f-0b97a1897645.png)
