### PR TITLE
feat: add tooltip prop for AInlineInputBase

### DIFF
--- a/framework/components/AInlineInputBase/AInlineInputBase.js
+++ b/framework/components/AInlineInputBase/AInlineInputBase.js
@@ -5,6 +5,7 @@ import {AForm} from "../AForm";
 import AIcon from "../AIcon";
 import ATextInput from "../ATextInput";
 import ATextarea from "../ATextarea";
+import ATriggerTooltip from "../ATriggerTooltip";
 import "./AInlineInputBase.scss";
 
 const baseClass = "a-inline-input";
@@ -23,6 +24,7 @@ const AInlineInputBase = forwardRef(
       small,
       medium,
       large,
+      showTooltip = false,
       ...rest
     },
     ref
@@ -37,7 +39,8 @@ const AInlineInputBase = forwardRef(
         onBlur: propsOnBlur,
         onClick: propsOnClick,
         onKeyDown: propsOnKeyDown
-      } = rest;
+      } = rest,
+      tooltipDisabled = !showTooltip || !displayValue || isEditing;
 
     // Re-sync display if props changed, for example API update fails
     useEffect(() => {
@@ -79,7 +82,9 @@ const AInlineInputBase = forwardRef(
       setDisplayValue(editingValue);
       setIsEditing(false);
 
-      onChange && onChange(editingValue);
+      if (value !== editingValue) {
+        onChange && onChange(editingValue);
+      }
     };
 
     let content;
@@ -131,7 +136,9 @@ const AInlineInputBase = forwardRef(
     } else {
       content = (
         <div className={displayClass}>
-          <div className={valueClass}>{displayValue || placeholder}</div>
+          <ATriggerTooltip content={displayValue} disabled={tooltipDisabled}>
+            <div className={valueClass}>{displayValue || placeholder}</div>
+          </ATriggerTooltip>
           <div className={editIconClass}>
             <AIcon>pencil-simple</AIcon>
           </div>
@@ -239,7 +246,11 @@ export const AInlineInputBasePropTypes = {
   /**
    * Sets widget size to magnetic small
    */
-  small: PropTypes.bool
+  small: PropTypes.bool,
+  /**
+   * Show a tooltip on the displayed value
+   */
+  showTooltip: PropTypes.bool
 };
 
 AInlineInputBase.propTypes = AInlineInputBasePropTypes;

--- a/framework/components/AInlineTextInput/AInlineTextInput.js
+++ b/framework/components/AInlineTextInput/AInlineTextInput.js
@@ -1,10 +1,10 @@
-import React from "react";
+import React, {forwardRef} from "react";
 import AInlineInputBase, {AInlineInputBasePropTypes} from "../AInlineInputBase";
 import ATextInput from "../ATextInput";
 
-const AInlineTextInput = (props) => {
-  return <AInlineInputBase {...props} inputComponent={ATextInput} />;
-};
+const AInlineTextInput = forwardRef((props, ref) => {
+  return <AInlineInputBase ref={ref} {...props} inputComponent={ATextInput} />;
+});
 
 AInlineTextInput.displayName = "AInlineTextInput";
 

--- a/framework/components/AInlineTextarea/AInlineTextarea.js
+++ b/framework/components/AInlineTextarea/AInlineTextarea.js
@@ -1,10 +1,10 @@
-import React from "react";
+import React, {forwardRef} from "react";
 import AInlineInputBase, {AInlineInputBasePropTypes} from "../AInlineInputBase";
 import ATextarea from "../ATextarea";
 
-const AInlineTextarea = (props) => {
-  return <AInlineInputBase {...props} inputComponent={ATextarea} />;
-};
+const AInlineTextarea = forwardRef((props, ref) => {
+  return <AInlineInputBase ref={ref} {...props} inputComponent={ATextarea} />;
+});
 
 AInlineTextarea.propTypes = AInlineInputBasePropTypes;
 


### PR DESCRIPTION
Adds a prop `showTooltip` to add a tooltip of the display value to the value when the inline edit is not active