### PR TITLE
docs(AModal): document delayUnmount prop

### DIFF
--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -248,6 +248,15 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   className: PropTypes.string,
 
   /**
+   * When the modal is rendered `withTransitions`, there is technically a
+   * delay from when you set `isOpen` to `false` to when the component
+   * actually unmounts from the DOM. This is done to preserve the transition.
+   *
+   * You can adjust that delay with this prop.
+   */
+  delayUnmount: PropTypes.number,
+
+  /**
    * Determines if the modal is opened or closed.
    */
   isOpen: PropTypes.bool,


### PR DESCRIPTION
I forgot to add documentation for the `delayUnmount`. This adds that in the prop types.

Just to note; this prop is very unlikely to be used, but I figured it's definitely better to document it than not.