### PR TITLE
feat: replace icon only button icon with spinner if loading

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -115,7 +115,7 @@ const AButton = forwardRef(
     return (
       <TagName {...props}>
         {loading && <ASpinner size="small" />}
-        {children}
+        {(!icon || (icon && !loading)) && children}
       </TagName>
     );
   }

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -166,6 +166,49 @@ The `AButton` component inherits passed props.
       </p>
     </div>
   </div>
+<div className="d-flex"><h3>Loading</h3></div>
+  <div className="d-flex">
+    <div>
+      <p>
+        <AButton data-testid="destructive-test-btn" loading>Ask Google</AButton>
+      </p>
+      <p>
+        <AButton loading>
+          <AIcon left>edit</AIcon>
+          Primary with Icon
+        </AButton>
+      </p>
+      <p>
+        <AButton icon loading>
+          <AIcon>sync</AIcon>
+        </AButton>
+      </p>
+      <p>
+        <AButton primary disabled loading >Primary  Disabled</AButton>
+      </p>
+    </div>
+    <div className="ml-4">
+      <p>
+        <AButton secondary loading>Secondary</AButton>
+      </p>
+      <p>
+        <AButton secondary loading>
+          <AIcon left>edit</AIcon>
+          Secondary with Icon
+        </AButton>
+      </p>
+      <p>
+        <AButton secondary icon loading>
+          <AIcon>sync</AIcon>
+        </AButton>
+      </p>
+      <p>
+        <AButton secondary disabled loading>
+          Secondary Disabled
+        </AButton>
+      </p>
+    </div>
+  </div>  
 </div>
 `}
 />


### PR DESCRIPTION
This adds documentation for the loading button, as well as handles the case where a loading button maybe be rendered within an "icon only" button. In that case, the icon only button's icon gets entirely replaced by the loading spinner. This isn't in the Magnetic specs, but it sorta just "feels right". Let me know if otherwise; I can easily remove.