### PR TITLE
#371 - add onlyIfTrunctated to ATriggerTooltip

### DIFF
--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -152,6 +152,46 @@ return (
 </ATriggerTooltip>
 ); } `} />
 
+## On if anchor is truncated
+
+Use `onlyIfTruncated` to show the tooltip only if the content is truncated.
+
+<Playground
+  code={`() => {
+
+    const longText = "Some text that gets truncated";
+    const noTruncation = "Text that does not get truncated";
+
+return (
+
+<>
+  <ATriggerTooltip
+    placement="top"
+    content="This works on a disabled element"
+    onlyIfTruncated>
+    <div
+      style={{
+        width: "100px",
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        textOverflow: "ellipsis"
+      }}>
+      {longText}
+    </div>
+  </ATriggerTooltip>
+  <br />
+  <br />
+  <br />
+  <br />
+  <ATriggerTooltip
+    placement="top"
+    content="This works on a disabled element"
+    onlyIfTruncated>
+    <div>{noTruncation}</div>
+  </ATriggerTooltip>
+</>
+); } `} />
+
 ## TriggerTooltip Props
 
 The `ATriggerTooltip` component inherits passed props.

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -165,10 +165,7 @@ Use `onlyIfTruncated` to show the tooltip only if the content is truncated.
 return (
 
 <>
-  <ATriggerTooltip
-    placement="top"
-    content="This works on a disabled element"
-    onlyIfTruncated>
+  <ATriggerTooltip placement="top" content={longText} onlyIfTruncated>
     <div
       style={{
         width: "100px",
@@ -183,10 +180,7 @@ return (
   <br />
   <br />
   <br />
-  <ATriggerTooltip
-    placement="top"
-    content="This works on a disabled element"
-    onlyIfTruncated>
+  <ATriggerTooltip placement="top" content={noTruncation} onlyIfTruncated>
     <div>{noTruncation}</div>
   </ATriggerTooltip>
 </>

--- a/framework/hooks/useToggle/useToggle.js
+++ b/framework/hooks/useToggle/useToggle.js
@@ -8,7 +8,6 @@ const useToggle = (openDelay = 400, closeDelay, canOpen) => {
     timeout.current && clearTimeout(timeout.current);
 
     timeout.current = setTimeout(() => {
-      console.log("trying to open?");
       const canTooltipOpen = canOpen ? canOpen() : true;
       canTooltipOpen && setIsOpen(true);
     }, openDelay);

--- a/framework/hooks/useToggle/useToggle.js
+++ b/framework/hooks/useToggle/useToggle.js
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from "react";
 
-const useToggle = (openDelay = 400, closeDelay) => {
+const useToggle = (openDelay = 400, closeDelay, canOpen) => {
   const [isOpen, setIsOpen] = useState(false);
   const timeout = useRef();
 
@@ -8,9 +8,11 @@ const useToggle = (openDelay = 400, closeDelay) => {
     timeout.current && clearTimeout(timeout.current);
 
     timeout.current = setTimeout(() => {
-      setIsOpen(true);
+      console.log("trying to open?");
+      const canTooltipOpen = canOpen ? canOpen() : true;
+      canTooltipOpen && setIsOpen(true);
     }, openDelay);
-  }, [openDelay, timeout]);
+  }, [openDelay, timeout, canOpen]);
 
   const close = useCallback(() => {
     timeout.current && clearTimeout(timeout.current);

--- a/framework/hooks/useToggle/useToggle.mdx
+++ b/framework/hooks/useToggle/useToggle.mdx
@@ -22,6 +22,7 @@ import { useToggle } from "@cisco-sbg-ui/magna-react";
 
 - `openDelay`: Delay before `isOpen` gets set to true
 - `closeDelay`: Delay before `isOpen` gets set to false
+- `canOpen`: A function to check if the tooltip can be opened
 
 ## Usage
 


### PR DESCRIPTION
Adds `onlyIfTrunctated` prop to ATriggerTooltip to only show the tooltip if the content is truncated in some way.

@vdineva I think this will solve your use case, but it might not be a robust enough check. We can tweak it going forward if needed.