### PR TITLE
feat: allow to specify which element to focus when a modal is opened, or opt-out from the autofocus while keeping the trap available

### DIFF
--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -57,15 +57,6 @@ function testCoreFunctionality(TestComponent, props = {}) {
     cy.get("[role='dialog']").should("have.focus");
   });
 
-  it("focuses on the root element if specified to", () => {
-    cy.mount(<TestComponent {...props} focusTrapAutoFocus="root" />);
-
-    // Open modal; root modal element gets the focus
-    cy.getByDataTestId("modal-trigger").focus();
-    cy.getByDataTestId("modal-trigger").click();
-    cy.get("[role='dialog']").should("have.focus");
-  });
-
   it("should trap focus within the modal", () => {
     cy.mount(<TestComponent {...props} />);
 
@@ -88,7 +79,7 @@ function testCoreFunctionality(TestComponent, props = {}) {
   });
 
   it("opts-out from the auto focus while still trapping the focus", () => {
-    cy.mount(<TestComponent {...props} focusTrapAutoFocus="none" />);
+    cy.mount(<TestComponent {...props} autoFocusElementRef={null} />);
 
     // Open modal; the opening trigger keeps the focus
     cy.getByDataTestId("modal-trigger").focus();
@@ -112,7 +103,7 @@ function testCoreFunctionality(TestComponent, props = {}) {
 
   it("opts-out from the auto focus and allows an inner element to autofocus itself", () => {
     cy.mount(
-      <TestComponent {...props} focusTrapAutoFocus="none">
+      <TestComponent {...props} autoFocusElementRef={null}>
         <ATextarea autoFocus />
       </TestComponent>
     );

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -46,7 +46,7 @@ const AModal = forwardRef(
       onClickOutside,
       withCenteredContent = true,
       withFocusTrap = true,
-      focusTrapAutoFocus = "first",
+      focusTrapAutoFocus = "root",
       withOverlay = true,
       withScrollLock = true,
       withTransitions = true,
@@ -302,9 +302,9 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   withFocusTrap: PropTypes.bool,
 
   /**
-   * Specifies what element to autofocus when the modal is opened. Allows to choose between first focusable element, the modal root or opt-opt from element autofocus.
+   * Specifies what element to autofocus when the modal is opened. Allows to choose between the modal root or to opt-opt from element autofocus.
    */
-  focusTrapAutoFocus: PropTypes.oneOf(["first", "root", "none"]),
+  focusTrapAutoFocus: PropTypes.oneOf(["root", "none"]),
 
   /**
    * Determines if the modal should render with an faded backdrop.

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -46,6 +46,7 @@ const AModal = forwardRef(
       onClickOutside,
       withCenteredContent = true,
       withFocusTrap = true,
+      focusTrapAutoFocus = "first",
       withOverlay = true,
       withScrollLock = true,
       withTransitions = true,
@@ -67,7 +68,8 @@ const AModal = forwardRef(
 
     useFocusTrap({
       rootRef: _ref,
-      isEnabled: withFocusTrap && shouldRenderChildren
+      isEnabled: withFocusTrap && shouldRenderChildren,
+      autoFocus: focusTrapAutoFocus
     });
 
     useEffect(() => {
@@ -165,6 +167,7 @@ const AModal = forwardRef(
           <Component
             role="dialog"
             aria-modal="true"
+            tabIndex={-1}
             ref={handleMultipleRefs(_ref, ref)}
             className={contentClassName}
             {...rest}
@@ -180,6 +183,7 @@ const AModal = forwardRef(
       <Component
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
         className={`${contentClassName}`}
         ref={handleMultipleRefs(_ref, ref)}
         onKeyDown={(e) => {
@@ -298,6 +302,11 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   withFocusTrap: PropTypes.bool,
 
   /**
+   * Specifies what element to autofocus when the modal is opened. Allows to choose between first focusable element, the modal root or opt-opt from element autofocus.
+   */
+  focusTrapAutoFocus: PropTypes.oneOf(["first", "root", "none"]),
+
+  /**
    * Determines if the modal should render with an faded backdrop.
    */
   withOverlay: PropTypes.bool,
@@ -310,11 +319,6 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
 
   /**
    * Determines if the modal should open and close with CSS transitions.
-   */
-  withTransitions: PropTypes.bool,
-
-  /**
-   * Determines if the modal should open and close with CSS animations.
    */
   withTransitions: PropTypes.bool
 };

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -1,4 +1,4 @@
-import React, {forwardRef, useContext, useEffect, useRef} from "react";
+import React, {forwardRef, useContext, useEffect, useRef, useMemo} from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 
@@ -46,7 +46,7 @@ const AModal = forwardRef(
       onClickOutside,
       withCenteredContent = true,
       withFocusTrap = true,
-      focusTrapAutoFocus = "root",
+      autoFocusElementRef,
       withOverlay = true,
       withScrollLock = true,
       withTransitions = true,
@@ -66,10 +66,21 @@ const AModal = forwardRef(
       isEnabled: withTransitions || delayUnmount
     });
 
+    const elementRefToAutoFocus = useMemo(() => {
+      if (autoFocusElementRef) {
+        return autoFocusElementRef;
+      } else if (typeof autoFocusElementRef === "undefined") {
+        return _ref;
+      } else {
+        // if (autoFocusElementRef === null) - disable autofocus
+        return undefined;
+      }
+    }, [_ref, autoFocusElementRef]);
+
     useFocusTrap({
       rootRef: _ref,
       isEnabled: withFocusTrap && shouldRenderChildren,
-      autoFocus: focusTrapAutoFocus
+      autoFocusElementRef: elementRefToAutoFocus
     });
 
     useEffect(() => {
@@ -302,9 +313,12 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   withFocusTrap: PropTypes.bool,
 
   /**
-   * Specifies what element to autofocus when the modal is opened. Allows to choose between the modal root or to opt-out from element autofocus.
+   * Specifies what element to autofocus when the modal is opened. By default, when omitted or undefined, the modal root is focused. When null is passed, the modal does not do any autofocus.
    */
-  focusTrapAutoFocus: PropTypes.oneOf(["root", "none"]),
+  autoFocusElementRef: PropTypes.oneOf([
+    null,
+    PropTypes.shape({current: PropTypes.any})
+  ]),
 
   /**
    * Determines if the modal should render with an faded backdrop.

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -302,7 +302,7 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   withFocusTrap: PropTypes.bool,
 
   /**
-   * Specifies what element to autofocus when the modal is opened. Allows to choose between the modal root or to opt-opt from element autofocus.
+   * Specifies what element to autofocus when the modal is opened. Allows to choose between the modal root or to opt-out from element autofocus.
    */
   focusTrapAutoFocus: PropTypes.oneOf(["root", "none"]),
 

--- a/framework/hooks/useFocusTrap/useFocusTrap.cy.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.cy.js
@@ -9,6 +9,7 @@ describe("useFocusTrap()", () => {
   it("should trap focus when tabbing forward", () => {
     cy.mount(<FocusTrapTest />);
 
+    cy.get("#trap").should("have.focus");
     cy.get("body").tab();
     cy.getByDataTestId("trapped-item-1").should("have.focus");
     cy.get("body").tab();
@@ -22,6 +23,7 @@ describe("useFocusTrap()", () => {
   it("should trap focus when tabbing backwards", () => {
     cy.mount(<FocusTrapTest />);
 
+    cy.get("#trap").should("have.focus");
     cy.get("body").tab({shift: true});
     cy.getByDataTestId("trapped-item-1").should("have.focus");
     cy.get("body").tab({shift: true});
@@ -34,7 +36,7 @@ describe("useFocusTrap()", () => {
 
   it("allows inner element to autofocus itself", () => {
     cy.mount(
-      <FocusTrapTest>
+      <FocusTrapTest enableAutofocus={false}>
         <ATextarea autoFocus />
       </FocusTrapTest>
     );
@@ -43,12 +45,12 @@ describe("useFocusTrap()", () => {
   });
 });
 
-const FocusTrapTest = ({children, autoFocus}) => {
+const FocusTrapTest = ({children, enableAutofocus = true}) => {
   const trapRef = useRef();
   useFocusTrap({
     rootRef: trapRef,
     isEnabled: true,
-    autoFocus
+    autoFocusElementRef: enableAutofocus ? trapRef : undefined
   });
   return (
     <>
@@ -64,7 +66,7 @@ const FocusTrapTest = ({children, autoFocus}) => {
         ))}
       </div>
 
-      <div id="trap" ref={trapRef}>
+      <div id="trap" tabIndex={-1} ref={trapRef}>
         <form>
           <label htmlFor="username">Username</label>
           <input data-testid="trapped-item-1" id="username" type="text" />

--- a/framework/hooks/useFocusTrap/useFocusTrap.cy.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.cy.js
@@ -1,11 +1,15 @@
+/* eslint-disable jsx-a11y/no-autofocus */
+
 import {useRef} from "react";
 
 import useFocusTrap from "./useFocusTrap";
+import {ATextarea} from "../../index";
 
 describe("useFocusTrap()", () => {
   it("should trap focus when tabbing forward", () => {
     cy.mount(<FocusTrapTest />);
 
+    cy.get("body").tab();
     cy.getByDataTestId("trapped-item-1").should("have.focus");
     cy.get("body").tab();
     cy.getByDataTestId("trapped-item-2").should("have.focus");
@@ -18,6 +22,7 @@ describe("useFocusTrap()", () => {
   it("should trap focus when tabbing backwards", () => {
     cy.mount(<FocusTrapTest />);
 
+    cy.get("body").tab({shift: true});
     cy.getByDataTestId("trapped-item-1").should("have.focus");
     cy.get("body").tab({shift: true});
     cy.getByDataTestId("trapped-item-3").should("have.focus");
@@ -26,13 +31,24 @@ describe("useFocusTrap()", () => {
     cy.get("body").tab({shift: true});
     cy.getByDataTestId("trapped-item-1").should("have.focus");
   });
+
+  it("allows inner element to autofocus itself", () => {
+    cy.mount(
+      <FocusTrapTest>
+        <ATextarea autoFocus />
+      </FocusTrapTest>
+    );
+
+    cy.get("textarea").should("have.focus");
+  });
 });
 
-function FocusTrapTest() {
+const FocusTrapTest = ({children, autoFocus}) => {
   const trapRef = useRef();
   useFocusTrap({
     rootRef: trapRef,
-    isEnabled: true
+    isEnabled: true,
+    autoFocus
   });
   return (
     <>
@@ -58,6 +74,8 @@ function FocusTrapTest() {
           <br />
           <button data-testid="trapped-item-3">Submit</button>
         </form>
+
+        {children}
       </div>
 
       <div>
@@ -75,4 +93,4 @@ function FocusTrapTest() {
       </div>
     </>
   );
-}
+};

--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -32,7 +32,11 @@ function createTrap(walker) {
   };
 }
 
-export default function useFocusTrap({rootRef, autoFocus, isEnabled = true}) {
+export default function useFocusTrap({
+  rootRef,
+  autoFocusElementRef,
+  isEnabled = true
+}) {
   useEffect(() => {
     if (isEnabled && rootRef.current) {
       const treeWalker = document.createTreeWalker(
@@ -49,25 +53,17 @@ export default function useFocusTrap({rootRef, autoFocus, isEnabled = true}) {
           }
         }
       );
-      let elementToAutoFocus;
-      switch (autoFocus) {
-        case "root":
-          elementToAutoFocus = rootRef.current;
-          break;
-        default:
-          elementToAutoFocus = undefined;
-      }
-      if (elementToAutoFocus) {
+      if (autoFocusElementRef) {
         const animationPromises = rootRef.current
           .getAnimations({subtree: true})
           .map((animation) => animation.finished);
         Promise.allSettled(animationPromises).then(() =>
-          elementToAutoFocus.focus({focusVisible: true})
+          autoFocusElementRef.current.focus({focusVisible: true})
         );
       }
       const trap = createTrap(treeWalker);
       document.addEventListener("keydown", trap);
       return () => document.removeEventListener("keydown", trap);
     }
-  }, [rootRef, autoFocus, isEnabled]);
+  }, [rootRef, autoFocusElementRef, isEnabled]);
 }

--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -51,9 +51,6 @@ export default function useFocusTrap({rootRef, autoFocus, isEnabled = true}) {
       );
       let elementToAutoFocus;
       switch (autoFocus) {
-        case "first":
-          elementToAutoFocus = treeWalker.nextNode();
-          break;
         case "root":
           elementToAutoFocus = rootRef.current;
           break;

--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -32,38 +32,45 @@ function createTrap(walker) {
   };
 }
 
-const useFocusTrap = ({rootRef, isEnabled = true}) => {
+export default function useFocusTrap({rootRef, autoFocus, isEnabled = true}) {
   useEffect(() => {
-    if (!isEnabled || !rootRef.current) {
-      return;
-    }
-    const treeWalker = document.createTreeWalker(
-      rootRef.current,
-      NodeFilter.SHOW_ELEMENT,
-      {
-        acceptNode: (node) => {
-          if (node === rootRef.current) {
-            return NodeFilter.FILTER_ACCEPT;
+    if (isEnabled && rootRef.current) {
+      const treeWalker = document.createTreeWalker(
+        rootRef.current,
+        NodeFilter.SHOW_ELEMENT,
+        {
+          acceptNode: (node) => {
+            if (node === rootRef.current) {
+              return NodeFilter.FILTER_ACCEPT;
+            }
+            return node.tabIndex < 0
+              ? NodeFilter.FILTER_SKIP
+              : NodeFilter.FILTER_ACCEPT;
           }
-          return node.tabIndex < 0
-            ? NodeFilter.FILTER_SKIP
-            : NodeFilter.FILTER_ACCEPT;
         }
-      }
-    );
-    const firstFocusableNode = treeWalker.nextNode();
-    if (firstFocusableNode) {
-      const animationPromises = rootRef.current
-        .getAnimations({subtree: true})
-        .map((animation) => animation.finished);
-      Promise.allSettled(animationPromises).then(() =>
-        firstFocusableNode.focus({focusVisible: true})
       );
+      let elementToAutoFocus;
+      switch (autoFocus) {
+        case "first":
+          elementToAutoFocus = treeWalker.nextNode();
+          break;
+        case "root":
+          elementToAutoFocus = rootRef.current;
+          break;
+        default:
+          elementToAutoFocus = undefined;
+      }
+      if (elementToAutoFocus) {
+        const animationPromises = rootRef.current
+          .getAnimations({subtree: true})
+          .map((animation) => animation.finished);
+        Promise.allSettled(animationPromises).then(() =>
+          elementToAutoFocus.focus({focusVisible: true})
+        );
+      }
+      const trap = createTrap(treeWalker);
+      document.addEventListener("keydown", trap);
+      return () => document.removeEventListener("keydown", trap);
     }
-    const trap = createTrap(treeWalker);
-    document.addEventListener("keydown", trap);
-    return () => document.removeEventListener("keydown", trap);
-  }, [rootRef, isEnabled]);
-};
-
-export default useFocusTrap;
+  }, [rootRef, autoFocus, isEnabled]);
+}

--- a/framework/hooks/useFocusTrap/useFocustrap.mdx
+++ b/framework/hooks/useFocusTrap/useFocustrap.mdx
@@ -26,6 +26,7 @@ A configuration object with the following properites:
 
 - `isEnabled`: If the hook should trap focus within your element
 - `rootRef`: A React ref indicating which element focus should be trapped inside of
+- `autoFocusElementRef`: A React ref indicating which element should be autofocused, if any
 
 ## Usage
 


### PR DESCRIPTION
fix #395, fix #396

For #395, this change allows to opt-out from the implicit auto focus, which is part of the focus trap.

For #396, this change stops focusing the first focusable element and focuses the whole dialog instead.