### PR TITLE
Add a resize observer to the tabs parent container to check if scroll buttons should show/hide

### DIFF
--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -79,6 +79,12 @@ const ATabGroup = forwardRef(
       };
     }, [combinedRef, scrolling]);
 
+    useEffect(() => {
+      if (!showScrolling) {
+        setTranslateX(0);
+      }
+    }, [showScrolling]);
+
     let className = "a-tab-group";
 
     if (oversized) {

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -84,9 +84,7 @@ const ATabGroup = forwardRef(
     }, [combinedRef, scrolling]);
 
     useEffect(() => {
-      if (!showScrolling) {
-        setTranslateX(0);
-      }
+      setTranslateX(0);
     }, [showScrolling]);
 
     let className = "a-tab-group";

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -10,7 +10,7 @@ import React, {
 import AButton from "../AButton";
 import AIcon from "../AIcon";
 import ATabContext from "./ATabContext";
-import {getRoundedBoundedClientRect, debounce} from "../../utils/helpers";
+import {getRoundedBoundedClientRect} from "../../utils/helpers";
 import {useCombinedRefs} from "../../utils/hooks";
 import "./ATabs.scss";
 
@@ -59,7 +59,7 @@ const ATabGroup = forwardRef(
 
       const target = combinedRef.current.parentNode;
 
-      const callback = debounce(() => {
+      const callback = () => {
         const wrapper = combinedRef.current.querySelector(
           ".a-tab-group__tab-wrapper"
         );
@@ -68,7 +68,7 @@ const ATabGroup = forwardRef(
         );
 
         setShowScrolling(content.scrollWidth - wrapper.clientWidth + 1 > 0);
-      });
+      };
 
       const resizeObserver = new ResizeObserver(callback);
 

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -10,19 +10,9 @@ import React, {
 import AButton from "../AButton";
 import AIcon from "../AIcon";
 import ATabContext from "./ATabContext";
-import {getRoundedBoundedClientRect} from "../../utils/helpers";
+import {getRoundedBoundedClientRect, debounce} from "../../utils/helpers";
 import {useCombinedRefs} from "../../utils/hooks";
 import "./ATabs.scss";
-
-const debounce = (func, timeout = 100) => {
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      func.apply(this, args);
-    }, timeout);
-  };
-};
 
 const ATabGroup = forwardRef(
   (

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -60,6 +60,10 @@ const ATabGroup = forwardRef(
       const target = combinedRef.current.parentNode;
 
       const callback = () => {
+        if (!combinedRef.current) {
+          return;
+        }
+
         const wrapper = combinedRef.current.querySelector(
           ".a-tab-group__tab-wrapper"
         );

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -1,5 +1,11 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useEffect, useRef, useState} from "react";
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from "react";
 
 import AButton from "../AButton";
 import AIcon from "../AIcon";
@@ -7,6 +13,16 @@ import ATabContext from "./ATabContext";
 import {getRoundedBoundedClientRect} from "../../utils/helpers";
 import {useCombinedRefs} from "../../utils/hooks";
 import "./ATabs.scss";
+
+const debounce = (func, timeout = 100) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
+};
 
 const ATabGroup = forwardRef(
   (
@@ -45,6 +61,33 @@ const ATabGroup = forwardRef(
         );
       }
     }, [scrolling, combinedRef, children.length]);
+
+    useEffect(() => {
+      if (!combinedRef.current || !scrolling) {
+        return;
+      }
+
+      const target = combinedRef.current.parentNode;
+
+      const callback = debounce(() => {
+        const wrapper = combinedRef.current.querySelector(
+          ".a-tab-group__tab-wrapper"
+        );
+        const content = combinedRef.current.querySelector(
+          ".a-tab-group__tab-content"
+        );
+
+        setShowScrolling(content.scrollWidth - wrapper.clientWidth + 1 > 0);
+      });
+
+      const resizeObserver = new ResizeObserver(callback);
+
+      resizeObserver.observe(target);
+
+      return () => {
+        resizeObserver.unobserve(target);
+      };
+    }, [combinedRef, scrolling]);
 
     let className = "a-tab-group";
 

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -280,3 +280,13 @@ export const isForwardTab = (e) => {
   const isTabbingForward = !isBackwardTab(e) && key === "Tab";
   return isTabbingForward;
 };
+
+export const debounce = (func, timeout = 100) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
+};


### PR DESCRIPTION
When the parent container of ATabGroup changes size, the scrolling feature doesn't recalculate if the buttons should still be showing, or need to appear. This adds a ResizeObserver to check the parent container for size changes and trigger a show/hide of the buttons if needed.