### PR TITLE
fix: disable pointer events

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -34,7 +34,6 @@ const AButton = forwardRef(
     const {selectedValues, toggleValue} = useContext(AButtonGroupContext);
 
     let className = "a-button focus-box-shadow a-button--";
-    let disabledWrapperClass = "a-button--disabled";
 
     if (primary) {
       className += destructive ? "primary-destructive" : "primary";
@@ -113,18 +112,12 @@ const AButton = forwardRef(
       props.value = value;
     }
 
-    const btnComponent = (
+    return (
       <TagName {...props}>
         {loading && <ASpinner size="small" />}
         {(!icon || (icon && !loading)) && children}
       </TagName>
     );
-
-    if (disabled) {
-      return <span className={disabledWrapperClass}>{btnComponent}</span>;
-    }
-
-    return btnComponent;
   }
 );
 

--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -34,7 +34,7 @@ const AButton = forwardRef(
     const {selectedValues, toggleValue} = useContext(AButtonGroupContext);
 
     let className = "a-button focus-box-shadow a-button--";
-    let disabledWrapperClass = "";
+    let disabledWrapperClass = "a-button--disabled";
 
     if (primary) {
       className += destructive ? "primary-destructive" : "primary";
@@ -50,7 +50,6 @@ const AButton = forwardRef(
 
     if (disabled || loading) {
       className += " disabled";
-      disabledWrapperClass = "a-button--disabled";
     }
 
     if (small) {
@@ -114,14 +113,18 @@ const AButton = forwardRef(
       props.value = value;
     }
 
-    return (
-      <span className={disabledWrapperClass}>
-        <TagName {...props}>
-          {loading && <ASpinner size="small" />}
-          {(!icon || (icon && !loading)) && children}
-        </TagName>
-      </span>
+    const btnComponent = (
+      <TagName {...props}>
+        {loading && <ASpinner size="small" />}
+        {(!icon || (icon && !loading)) && children}
+      </TagName>
     );
+
+    if (disabled) {
+      return <span className={disabledWrapperClass}>{btnComponent}</span>;
+    }
+
+    return btnComponent;
   }
 );
 

--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -34,6 +34,7 @@ const AButton = forwardRef(
     const {selectedValues, toggleValue} = useContext(AButtonGroupContext);
 
     let className = "a-button focus-box-shadow a-button--";
+    let disabledWrapperClass = "";
 
     if (primary) {
       className += destructive ? "primary-destructive" : "primary";
@@ -49,6 +50,7 @@ const AButton = forwardRef(
 
     if (disabled || loading) {
       className += " disabled";
+      disabledWrapperClass = "a-button--disabled";
     }
 
     if (small) {
@@ -113,10 +115,12 @@ const AButton = forwardRef(
     }
 
     return (
-      <TagName {...props}>
-        {loading && <ASpinner size="small" />}
-        {(!icon || (icon && !loading)) && children}
-      </TagName>
+      <span className={disabledWrapperClass}>
+        <TagName {...props}>
+          {loading && <ASpinner size="small" />}
+          {(!icon || (icon && !loading)) && children}
+        </TagName>
+      </span>
     );
   }
 );

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -477,11 +477,6 @@ $btn-transition: color $transition-duration--extra-fast
     height: auto;
   }
 
-  &--disabled {
-    //Wrapper class for disabled button to display `cursor: not allowed` when pointer events are disabled
-    cursor: not-allowed;
-    padding-bottom: 10px;
-  }
   &.disabled,
   &:disabled {
     pointer-events: none;

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -477,10 +477,14 @@ $btn-transition: color $transition-duration--extra-fast
     height: auto;
   }
 
+  &--disabled {
+    //Wrapper for cursor allows us to cursor not allowed when pointer events are disabled
+    cursor: not-allowed;
+    padding-bottom: 10px;
+  }
   &.disabled,
   &:disabled {
-    pointer-events: auto;
-    cursor: not-allowed;
+    pointer-events: none;
   }
 
   &.a-button--medium {

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -478,7 +478,7 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   &--disabled {
-    //Wrapper for cursor allows us to cursor not allowed when pointer events are disabled
+    //Wrapper class for disabled button to display `cursor: not allowed` when pointer events are disabled
     cursor: not-allowed;
     padding-bottom: 10px;
   }


### PR DESCRIPTION
**Resolves #406 Prevent button events when disabled.**

**Problem**
`pointer-events: auto` allows click actions on links
`pointer-events: none` will prevent `cursor: not-allowed` from displaying

**Solution** 
Put a wrapper on the button to display `cursor: not-allowed` while preventing click action in child.

**Before**
![alertTest](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/40bcfaf8-6704-4b5a-9492-f6a083c8ed62)

**After**
![afterAlertTest](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/78e8e8b0-1c30-4a74-9184-5fd4278abc82)
