### PR TITLE
fix: fallback to focusing root element when the provided reference is empty

### DIFF
--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -58,7 +58,9 @@ export default function useFocusTrap({
           .getAnimations({subtree: true})
           .map((animation) => animation.finished);
         Promise.allSettled(animationPromises).then(() =>
-          autoFocusElementRef.current?.focus({focusVisible: true})
+          (autoFocusElementRef.current ?? rootRef.current).focus({
+            focusVisible: true
+          })
         );
       }
       const trap = createTrap(treeWalker);

--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -58,7 +58,7 @@ export default function useFocusTrap({
           .getAnimations({subtree: true})
           .map((animation) => animation.finished);
         Promise.allSettled(animationPromises).then(() =>
-          autoFocusElementRef.current.focus({focusVisible: true})
+          autoFocusElementRef.current?.focus({focusVisible: true})
         );
       }
       const trap = createTrap(treeWalker);


### PR DESCRIPTION
regression from #397