### PR TITLE
fix: hide icon when loading

### DIFF
--- a/framework/components/AButton/AButton.cy.js
+++ b/framework/components/AButton/AButton.cy.js
@@ -1,0 +1,29 @@
+import AButton from "./AButton";
+import AIcon from "../AIcon";
+
+describe("<AButton/>", () => {
+  it("should render", () => {
+    cy.mount(<AButton />);
+  });
+
+  it("should not have icon when loading", () => {
+    cy.mount(
+      <AButton loading>
+        <AIcon left>edit</AIcon>
+        test
+      </AButton>
+    );
+    cy.get(".a-button .a-icon").should("be.not.visible");
+  });
+
+  it("should have icon", () => {
+    cy.mount(
+      <AButton>
+        <AIcon left>edit</AIcon>
+        test
+      </AButton>
+    );
+
+    cy.get(".a-button .a-icon").should("be.visible");
+  });
+});

--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -115,7 +115,7 @@ const AButton = forwardRef(
     return (
       <TagName {...props}>
         {loading && <ASpinner size="small" />}
-        {(!icon || (icon && !loading)) && children}
+        {children}
       </TagName>
     );
   }

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -450,6 +450,10 @@ $btn-transition: color $transition-duration--extra-fast
     circle {
       stroke: currentColor !important;
     }
+    //Hide icon if in loading state
+    + .a-icon {
+      display: none;
+    }
   }
 
   .a-icon.a-icon--dots-three,

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -446,7 +446,10 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   .a-spinner {
-    margin-right: 3px;
+    margin-right: 5px;
+    height: 16px;
+    width: 16px;
+
     circle {
       stroke: currentColor !important;
     }
@@ -479,6 +482,9 @@ $btn-transition: color $transition-duration--extra-fast
   &--icon {
     padding: 10px;
     height: auto;
+    .a-spinner {
+      margin-right: unset;
+    }
   }
 
   &.disabled,


### PR DESCRIPTION
Closes #409 - Hide icon when loading. 

*Note I targeted magna icons only, but it works with generic svg as well if we think people wont be passing in magna icons. 

![loading](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/ab7f21c5-f177-47ab-ad66-ac4ad5fce0a2)
