### PR TITLE
feat: submenus

### DIFF
--- a/framework/components/AList/AList.scss
+++ b/framework/components/AList/AList.scss
@@ -62,6 +62,10 @@
       white-space: normal;
     }
 
+    &--submenu {
+      justify-content: space-between;
+    }
+
     &[tabindex] {
       cursor: pointer;
     }

--- a/framework/components/AList/AListItem.js
+++ b/framework/components/AList/AListItem.js
@@ -85,16 +85,17 @@ const AListItem = forwardRef(
           (onClick && e.keyCode === keyCodes.right)
         ) {
           e.preventDefault();
+          e.stopPropagation();
           onClick(e);
-          submenu && handleSubmenu();
-        }
-        if (onClick && e.keyCode === keyCodes.left && submenu) {
-          submenu && handleSubmenu();
+          submenu && setSubMenuOpen(true);
+        } else if (onClick && e.keyCode === keyCodes.left && submenu) {
+          e.stopPropagation();
+          setSubMenuOpen(false);
         }
 
         propsOnKeyDown && propsOnKeyDown(e);
       },
-      [onClick, propsOnKeyDown, submenu, handleSubmenu]
+      [onClick, propsOnKeyDown, submenu, setSubMenuOpen]
     );
 
     useEffect(() => {

--- a/framework/components/AMenu/AMenu.cy.js
+++ b/framework/components/AMenu/AMenu.cy.js
@@ -91,6 +91,21 @@ describe("<AMenu />", () => {
         expect(mockFn.callCount).to.eq(1);
       });
   });
+
+  it("should open submenu on hover", () => {
+    cy.mount(<SubMenuTest />);
+    openMenu();
+    getMenuContent().get(".a-list-item--submenu").trigger("mouseover");
+    cy.get(".a-menu--submenu").should("exist");
+  });
+
+  it("should close submenu after selection", () => {
+    cy.mount(<SubMenuTest />);
+    openMenu();
+    getMenuContent().get(".a-list-item--submenu").trigger("mouseover");
+    cy.getByDataTestId("submenu-item-1").click();
+    cy.get(".a-menu--submenu").should("not.exist");
+  });
 });
 
 function MenuTest(menuProps) {
@@ -111,6 +126,42 @@ function MenuTest(menuProps) {
       <AMenu {...menuProps} open={isOpen} anchorRef={btnRef}>
         <AListItem data-testid="menu-item-1">
           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem data-testid="menu-item-2">Example</AListItem>
+        <AListItem data-testid="menu-item-3">Example</AListItem>
+      </AMenu>
+    </div>
+  );
+}
+
+function SubMenuTest(menuProps) {
+  const btnRef = useRef();
+  const submenuRef = useRef();
+  const [isOpen, setIsOpen] = useState(menuProps?.open);
+  return (
+    <div
+      className="d-flex justify-center align-center"
+      style={{height: "100vh", width: "100vw"}}
+    >
+      <AButton
+        data-testid="menu-trigger"
+        ref={btnRef}
+        onClick={() => setIsOpen((state) => !state)}
+      >
+        {isOpen ? "close" : "open"}
+      </AButton>
+      <AMenu
+        {...menuProps}
+        open={isOpen}
+        anchorRef={btnRef}
+        onClose={() => setIsOpen(false)}
+      >
+        <AListItem ref={submenuRef} submenu data-testid="menu-item-1">
+          <AListItemTitle>Bottom</AListItemTitle>
+          <AMenu submenu anchorRef={submenuRef}>
+            <AListItem data-testid="submenu-item-1">Example</AListItem>
+            <AListItem data-testid="submenu-item-2">Example</AListItem>
+          </AMenu>
         </AListItem>
         <AListItem data-testid="menu-item-2">Example</AListItem>
         <AListItem data-testid="menu-item-3">Example</AListItem>

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -32,20 +32,6 @@ const AMenu = forwardRef(
     const menuRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, menuRef);
 
-    // useEffect(() => {
-    //   console.log("here", ref, menuRef);
-    //   const handleClickOutside = (e) => {
-    //     console.log("here", anchorRef.current);
-    //     if (anchorRef.current && !anchorRef.current.contains(e.target)) {
-    //       closeHandler(e);
-    //     }
-    //   };
-    //   document.addEventListener("click", handleClickOutside, false);
-    //   return () => {
-    //     document.removeEventListener("click", handleClickOutside, false);
-    //   };
-    // });
-
     const getPrevious = () => {
       const items = Array.from(
         combinedRef.current.querySelectorAll(
@@ -151,8 +137,9 @@ const AMenu = forwardRef(
         }}
         onClose={(e) => {
           const isSubmenuActive = Boolean(
-            combinedRef?.current?.querySelector(".a-menu--submenu")
+            document.querySelector(".a-menu--submenu")
           );
+          //If submenu is not active, proceed with unmounting parent amenu
           if (!isSubmenuActive) {
             onClose(e);
           }

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -153,9 +153,9 @@ const AMenu = forwardRef(
           const isSubmenuActive = Boolean(
             combinedRef?.current?.querySelector(".a-menu--submenu")
           );
-          //if (!isSubmenuActive) {
-          onClose(e);
-          //  }
+          if (!isSubmenuActive) {
+            onClose(e);
+          }
         }}
         onKeyDown={(e) => {
           keyDownHandler(e);

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useEffect, useRef} from "react";
+import React, {forwardRef, useEffect, useRef, useCallback} from "react";
 
 import {keyCodes} from "../../utils/helpers";
 import {useCombinedRefs} from "../../utils/hooks";
@@ -24,12 +24,27 @@ const AMenu = forwardRef(
       placement,
       pointer,
       role = "menu",
+      submenu = false,
       ...rest
     },
     ref
   ) => {
     const menuRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, menuRef);
+
+    // useEffect(() => {
+    //   console.log("here", ref, menuRef);
+    //   const handleClickOutside = (e) => {
+    //     console.log("here", anchorRef.current);
+    //     if (anchorRef.current && !anchorRef.current.contains(e.target)) {
+    //       closeHandler(e);
+    //     }
+    //   };
+    //   document.addEventListener("click", handleClickOutside, false);
+    //   return () => {
+    //     document.removeEventListener("click", handleClickOutside, false);
+    //   };
+    // });
 
     useEffect(() => {
       if (open && focusOnOpen) {
@@ -103,10 +118,14 @@ const AMenu = forwardRef(
     if (compact) {
       className += ` compact`;
     }
+    if (submenu) {
+      className += ` a-menu--submenu`;
+    }
 
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
+
     return (
       <AList
         {...rest}
@@ -119,7 +138,14 @@ const AMenu = forwardRef(
           closeOnClick && closeHandler(e);
           onClick && onClick(e);
         }}
-        onClose={onClose}
+        onClose={(e) => {
+          const isSubmenuActive = Boolean(
+            document.querySelector(".a-menu--submenu")
+          );
+          if (!isSubmenuActive) {
+            onClose(e);
+          }
+        }}
         onKeyDown={(e) => {
           keyDownHandler(e);
           onKeyDown && onKeyDown(e);

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -84,6 +84,11 @@ const AMenu = forwardRef(
         e.preventDefault();
         const previous = getPrevious();
         previous && previous.focus();
+      } else if (e.keyCode === keyCodes.right) {
+        //TODO find item
+      } else if (e.keyCode === keyCodes.left) {
+        const previous = getPrevious();
+        previous && previous.focus();
       } else if (e.keyCode === keyCodes.down) {
         e.preventDefault();
         const next = getNext();

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -289,9 +289,6 @@ return (
   const nestedSubmenuRef1 = useRef(null);  
   const [open, setOpen] = useState(false);
   const [open2, setOpen2] = useState(false);
-  const [openSubmenu, setOpenSubmenu] = useState(false);
-  const [openNestedSubmenu, setOpenNestedSubmenu] = useState(false);
-  const [openNestedSubmenu1, setOpenNestedSubmenu1] = useState(false);
 
 return (
 
@@ -322,23 +319,13 @@ return (
     anchorRef={buttonRef}
     open={open}
     placement="bottom-left"
-    onClose={() => {
-      //Allow default closing of main menu if submenus aren't open
-      if (!openSubmenu && !openNestedSubmenu) {
-        setOpen(false);
-      }
-    }}>
+    onClose={() => setOpen(false)}>
     <AListItem onClick={() => alert("Menu alert")}>Selection 1</AListItem>
     <AListItem onClick={() => alert("Menu alert")}>Selection 2</AListItem>
-    <AListItem ref={submenuRef} subMenu subMenuOnClose={setOpenSubmenu}>
+    <AListItem ref={submenuRef} submenu>
       Selection 3
-      <AMenu anchorRef={submenuRef} open={openSubmenu} placement="right-top">
-        <AListItem
-          tabIndex={0}
-          onClick={() => {
-            alert("Submenu alert");
-            setOpen(false);
-          }}>
+      <AMenu submenu anchorRef={submenuRef} placement="right-top">
+        <AListItem tabIndex={0} onClick={() => alert("Submenu alert")}>
           Selection 2(a)
         </AListItem>
       </AMenu>
@@ -347,51 +334,23 @@ return (
   <AMenu
     anchorRef={button2Ref}
     open={open2}
-    placement="bottom-left"
-    onClose={() => {
-      //Allow default closing of main menu if submenus aren't open
-      if (!openSubmenu && !openNestedSubmenu) {
-        setOpen2(false);
-      }
-    }}>
+    onClose={() => setOpen2(false)}
+    placement="bottom-left">
     <AListItem onClick={() => alert("Menu alert")}>Selection 1</AListItem>
     <AListItem onClick={() => {}}>Selection 2</AListItem>
-    <AListItem
-      ref={nestedSubmenuRef}
-      subMenu
-      subMenuOnClose={setOpenNestedSubmenu}>
+    <AListItem ref={nestedSubmenuRef} submenu>
       Selection 3
-      <AMenu
-        anchorRef={nestedSubmenuRef}
-        open={openNestedSubmenu}
-        placement="right-top">
-        <AListItem
-          onClick={() => {
-            alert("Submenu alert");
-            setOpen2(false);
-          }}>
+      <AMenu submenu anchorRef={nestedSubmenuRef} placement="right-top">
+        <AListItem onClick={() => alert("Submenu alert")}>
           Selection 3(a)
         </AListItem>
-        <AListItem
-          ref={nestedSubmenuRef1}
-          subMenu
-          subMenuOnClose={setOpenNestedSubmenu1}>
+        <AListItem ref={nestedSubmenuRef1} submenu>
           Selection 3(b)
-          <AMenu
-            anchorRef={nestedSubmenuRef1}
-            open={openNestedSubmenu1}
-            onClose={() => setOpenNestedSubmenu1(false)}
-            placement="right-top">
-            <AListItem
-              onClick={() => {
-                alert("Nested submenu alert");
-                setOpen2(false);
-              }}>
+          <AMenu submenu anchorRef={nestedSubmenuRef1} placement="right-top">
+            <AListItem onClick={() => alert("Nested submenu alert")}>
               Selection 3(b)-1
             </AListItem>
-            <AListItem onClick={() => setOpen2(false)}>
-              Selection 3(b)-2
-            </AListItem>
+            <AListItem onClick={() => {}}> Selection 3(b)-2 </AListItem>
           </AMenu>
         </AListItem>
       </AMenu>

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -27,207 +27,305 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
   const button4Ref = useRef(null);
   const button5Ref = useRef(null);
   const button6Ref = useRef(null);
+  const button7Ref = useRef(null);
+  const submenu7Ref = useRef(null);
+  const nestedSubmenu7Ref = useRef(null); 
+  const nestedSubmenu7Ref1 = useRef(null);  
   const [open1, setOpen1] = useState(false);
   const [open2, setOpen2] = useState(false);
   const [open3, setOpen3] = useState(false);
   const [open4, setOpen4] = useState(false);
   const [open5, setOpen5] = useState(false);
   const [open6, setOpen6] = useState(false);
-  const [menu4Selected, setMenu4Selected] = useState(2);
-  return (
-    <div className="d-flex" style={{
-        rowGap: "10px",
-        columnGap: "20px",
-        flexWrap: "wrap",
-        justifyContent: "space-evenly"
-      }}>
-      <div>
-        <AButton
-          ref={button1Ref}
-          onClick={() => setOpen1(!open1)}
-          aria-haspopup="true">
-          Pivot Menu
-        </AButton>
-      </div>
-      <div>
-        <AButton
-          ref={button2Ref}
-          onClick={() => setOpen2(!open2)}
-          aria-haspopup="true">
-          Alert Notification Menu
-        </AButton>
-      </div>
-      <div>
-        <AButton
-          ref={button3Ref}
-          onClick={() => setOpen3(!open3)}
-          aria-haspopup="true">
-          Drop Down Menu
-        </AButton>
-      </div>
-      <div>
-        <AButton
-          ref={button4Ref}
-          onClick={() => setOpen4(!open4)}
-          aria-haspopup="true">
-          More Menu
-        </AButton>
-      </div>
-      <div>
-        <AButton
-          ref={button5Ref}
-          onClick={() => setOpen5(!open5)}
-          aria-haspopup="true">
-          Compact Menu
-        </AButton>
-      </div>
-      <div>
-        <AButton
-          ref={button6Ref}
-          onClick={() => setOpen6(!open6)}
-          aria-haspopup="true">
-          Menu With Groups
-        </AButton>
-      </div>
-      <AMenu
-        anchorRef={button1Ref}
-        open={open1}
-        placement="bottom"
-        onClose={() => setOpen1(false)}
-        pointer
-        className="py-3">
-        <AListItem twoLine className="px-3 h3 my-0 pb-1">
-          <AListItemTitle>Bottom</AListItemTitle>
-        </AListItem>
-        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
-          Example
-        </AListItem>
-        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
-          Example
-        </AListItem>
-         <AListItem onClick={() => alert("should not fire")} className="pl-3 py-1" disabled>
-          Disabled Item
-        </AListItem>
-        <AListItemDivider className="mb-0 mt-3" />
-        <AListItem twoLine>
-          <AListItemContent className="pb-0">
-            <a onClick={() => alert("alert3")}>Connect</a>
-          </AListItemContent>
-        </AListItem>
-      </AMenu>
-      <AMenu
-        anchorRef={button2Ref}
-        open={open2}
-        placement="bottom"
-        onClose={() => setOpen2(false)}
-        pointer
-        style={{maxWidth: 450}}>
-        <AListItem twoLine>
-          <AListItemAvatar>
-            <AIcon size={16} className="status-red--text">
-              critical-stop
-            </AIcon>
-          </AListItemAvatar>
-          <AListItemContent>
-            <AListItemTitle>Source Application</AListItemTitle>
-            <AListItemSubtitle>
-              Danger. Text to describe the notification or an issue that needs
-              to be addressed. Very, very, very, very, very long text.
-            </AListItemSubtitle>
-          </AListItemContent>
-          <AListItemAction
-            className="pr-3 align-self-start"
-            style={{paddingTop: 12}}>
-            <a onClick={() => alert("alert warning")}>Action</a>
-          </AListItemAction>
-        </AListItem>
-        <AListItemDivider className="ma-0" />
-        <AListItem twoLine>
-          <AListItemAvatar>
-            <AIcon size={16} className="status-orange--text">
-              warning
-            </AIcon>
-          </AListItemAvatar>
-          <AListItemContent>
-            <AListItemTitle>Source Application</AListItemTitle>
-            <AListItemSubtitle>
-              Warning. Text to describe the notification or an issue that
-              needs to be addressed. Very, very, very, very, very long text.
-            </AListItemSubtitle>
-          </AListItemContent>
-          <AListItemAction
-            className="pr-3 align-self-start"
-            style={{paddingTop: 12}}>
-            <a onClick={() => alert("alert warning")}>Action</a>
-          </AListItemAction>
-        </AListItem>
-      </AMenu>
-      <AMenu
-        anchorRef={button3Ref}
-        open={open3}
-        placement="bottom-left"
-        onClose={() => setOpen3(false)}>
-        <AListItem onClick={() => {}}>Selection 1</AListItem>
-        <AListItem onClick={() => {}}>Selection 2</AListItem>
-        <AListItem onClick={() => {}}>Selection 3</AListItem>
-        <AListItem onClick={() => alert("should not fire")} disabled>
-          Disabled Item
-        </AListItem>
-      </AMenu>
-      <AMenu
-        anchorRef={button4Ref}
-        open={open4}
-        placement="bottom-right"
-        onClose={() => setOpen4(false)}
-        >
-        <AListItem onClick={() => {setMenu4Selected(0)}} selected={0 === menu4Selected}>Selection Uno</AListItem>
-        <AListItem onClick={() => {setMenu4Selected(1)}} selected={1 === menu4Selected}>Selection Dos <AIcon size={12} className="ml-2">judgement</AIcon></AListItem>
-        <AListItem onClick={() => {setMenu4Selected(2)}} selected={2 === menu4Selected}>Selection Tres</AListItem>
-        <AListItem onClick={() => alert("should not fire")} disabled>
-          Disabled Item
-        </AListItem>
-        <AListItemDivider style={{margin: 0}}/>
-        <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
-        <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
-        <AListItemDivider style={{margin: 0}}/>
-        <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
-        <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
-        <AListItemDivider style={{margin: 0}}/>
-        <AListItem onClick={() => {setMenu4Selected(3)}} selected={3 === menu4Selected}>Status</AListItem>
-      </AMenu>
-      <AMenu
-        anchorRef={button5Ref}
-        open={open5}
-        compact
-        placement="bottom-left"
-        onClose={() => setOpen5(false)}>
-        <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
-        <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
-        <AListItemDivider style={{margin: 0}}/>
-        <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
-        <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
-      </AMenu>
-      <AMenu
-        anchorRef={button6Ref}
-        open={open6}
-        compact
-        placement="bottom-left"
-        onClose={() => setOpen6(false)}>
-          <AListItemGroup title={"Category 1"}>
-              <AListItem onClick={() => {}}>Category item 1</AListItem>
-              <AListItem onClick={() => {}}>Category item 2</AListItem>
-              <AListItem onClick={() => {}}>Category item 3</AListItem>
-          </AListItemGroup>
-          <AListItemDivider />
-          <AListItemGroup title={"Category 2"}>
-              <AListItem onClick={() => {}}>Category item 4</AListItem>
-              <AListItem onClick={() => {}}>Category item 5</AListItem>
-          </AListItemGroup>
-      </AMenu>
-    </div>
-);
+  const [open7, setOpen7] = useState(false);
+  const [open7Submenu, setOpen7Submenu] = useState(false);
+  const [open7NestedSubmenu, setOpen7NestedSubmenu] = useState(false);
+  const [open7NestedSubmenu1, setOpen7NestedSubmenu1] = useState(false);
+
+const [menu4Selected, setMenu4Selected] = useState(2);
+
+const closeMainMenu = () => {
+setOpen7(false);
 }
-`}
+
+return (
+
+<div className="d-flex" style={{
+    rowGap: "10px",
+    columnGap: "20px",
+    flexWrap: "wrap",
+    justifyContent: "space-evenly"
+  }}>
+  <div>
+    <AButton
+      ref={button1Ref}
+      onClick={() => setOpen1(!open1)}
+      aria-haspopup="true">
+      Pivot Menu
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button2Ref}
+      onClick={() => setOpen2(!open2)}
+      aria-haspopup="true">
+      Alert Notification Menu
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button3Ref}
+      onClick={() => setOpen3(!open3)}
+      aria-haspopup="true">
+      Drop Down Menu
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button4Ref}
+      onClick={() => setOpen4(!open4)}
+      aria-haspopup="true">
+      More Menu
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button5Ref}
+      onClick={() => setOpen5(!open5)}
+      aria-haspopup="true">
+      Compact Menu
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button6Ref}
+      onClick={() => setOpen6(!open6)}
+      aria-haspopup="true">
+      Menu With Groups
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button7Ref}
+      onClick={() => setOpen7(!open7)}
+      aria-haspopup="true">
+      Menu with Submenus
+    </AButton>
+  </div>
+  <AMenu
+    anchorRef={button1Ref}
+    open={open1}
+    placement="bottom"
+    onClose={() => setOpen1(false)}
+    pointer
+    className="py-3">
+    <AListItem twoLine className="px-3 h3 my-0 pb-1">
+      <AListItemTitle>Bottom</AListItemTitle>
+    </AListItem>
+    <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+      Example
+    </AListItem>
+    <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+      Example
+    </AListItem>
+    <AListItem onClick={() => alert("should not fire")} className="pl-3 py-1" disabled>
+      Disabled Item
+    </AListItem>
+    <AListItemDivider className="mb-0 mt-3" />
+    <AListItem twoLine>
+      <AListItemContent className="pb-0">
+        <a onClick={() => alert("alert3")}>Connect</a>
+      </AListItemContent>
+    </AListItem>
+  </AMenu>
+  <AMenu
+    anchorRef={button2Ref}
+    open={open2}
+    placement="bottom"
+    onClose={() => setOpen2(false)}
+    pointer
+    style={{maxWidth: 450}}>
+    <AListItem twoLine>
+      <AListItemAvatar>
+        <AIcon size={16} className="status-red--text">
+          critical-stop
+        </AIcon>
+      </AListItemAvatar>
+      <AListItemContent>
+        <AListItemTitle>Source Application</AListItemTitle>
+        <AListItemSubtitle>
+          Danger. Text to describe the notification or an issue that needs 
+          to be addressed. Very, very, very, very, very long text.
+        </AListItemSubtitle>
+      </AListItemContent>
+      <AListItemAction
+        className="pr-3 align-self-start"
+        style={{paddingTop: 12}}>
+        <a onClick={() => alert("alert warning")}>Action</a>
+      </AListItemAction>
+    </AListItem>
+    <AListItemDivider className="ma-0" />
+    <AListItem twoLine>
+      <AListItemAvatar>
+        <AIcon size={16} className="status-orange--text">
+          warning
+        </AIcon>
+      </AListItemAvatar>
+      <AListItemContent>
+        <AListItemTitle>Source Application</AListItemTitle>
+        <AListItemSubtitle>
+          Warning. Text to describe the notification or an issue that 
+          needs to be addressed. Very, very, very, very, very long text.
+        </AListItemSubtitle>
+      </AListItemContent>
+      <AListItemAction
+        className="pr-3 align-self-start"
+        style={{paddingTop: 12}}>
+        <a onClick={() => alert("alert warning")}>Action</a>
+      </AListItemAction>
+    </AListItem>
+  </AMenu>
+  <AMenu
+    anchorRef={button3Ref}
+    open={open3}
+    placement="bottom-left"
+    onClose={() => setOpen3(false)}>
+    <AListItem onClick={() => {}}>Selection 1</AListItem>
+    <AListItem onClick={() => {}}>Selection 2</AListItem>
+    <AListItem onClick={() => {}}>Selection 3</AListItem>
+    <AListItem onClick={() => alert("should not fire")} disabled>
+      Disabled Item
+    </AListItem>
+  </AMenu>
+  <AMenu
+    anchorRef={button4Ref}
+    open={open4}
+    placement="bottom-right"
+    onClose={() => setOpen4(false)}
+    >
+    <AListItem onClick={() => {setMenu4Selected(0)}} selected={0 === menu4Selected}>Selection Uno</AListItem>
+    <AListItem onClick={() => {setMenu4Selected(1)}} selected={1 === menu4Selected}>Selection Dos <AIcon size={12} className="ml-2">judgement</AIcon></AListItem>
+    <AListItem onClick={() => {setMenu4Selected(2)}} selected={2 === menu4Selected}>Selection Tres</AListItem>
+    <AListItem onClick={() => alert("should not fire")} disabled>
+      Disabled Item
+    </AListItem>
+    <AListItemDivider style={{margin: 0}}/>
+    <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
+    <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
+    <AListItemDivider style={{margin: 0}}/>
+    <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
+    <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
+    <AListItemDivider style={{margin: 0}}/>
+    <AListItem onClick={() => {setMenu4Selected(3)}} selected={3 === menu4Selected}>Status</AListItem>
+  </AMenu>
+  <AMenu
+    anchorRef={button5Ref}
+    open={open5}
+    compact
+    placement="bottom-left"
+    onClose={() => setOpen5(false)}>
+ <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
+        <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
+        <AListItemDivider style={{margin: 0}}/>
+        <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
+        <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
+  </AMenu>
+  <AMenu
+    anchorRef={button6Ref}
+    open={open6}
+    compact
+    placement="bottom-left"
+    onClose={() => setOpen6(false)}>
+    <AListItemGroup title={"Category 1"}>
+      <AListItem onClick={() => {}}>Category item 1</AListItem>
+      <AListItem onClick={() => {}}>Category item 2</AListItem>
+      <AListItem onClick={() => {}}>Category item 3</AListItem>
+    </AListItemGroup>
+    <AListItemDivider />
+    <AListItemGroup title={"Category 2"}>
+      <AListItem onClick={() => {}}>Category item 4</AListItem>
+      <AListItem onClick={() => {}}>Category item 5</AListItem>
+    </AListItemGroup>
+  </AMenu>
+  <AMenu
+    anchorRef={button7Ref}
+    open={open7}
+    placement="bottom-left"
+    onClose={() => {
+      //Allow default closing of main menu if submenus aren't open
+      if(!open7Submenu && !open7NestedSubmenu) {
+        setOpen7(false);
+      }
+    }}>
+    <AListItem onClick={() => alert("Menu alert")}>
+      Selection 1
+    </AListItem>
+    <AListItem 
+      ref={submenu7Ref}
+      subMenu
+      subMenuOnClose={setOpen7Submenu}
+    >
+      Selection 2
+      <AMenu anchorRef={submenu7Ref} open={open7Submenu} placement="right-top">
+        <AListItem
+           tabIndex={0}
+          onClick={() => {
+            alert("Submenu alert");
+            closeMainMenu();
+          }}>
+          Selection 2(a)
+        </AListItem>
+      </AMenu>
+    </AListItem>
+    <AListItem
+      ref={nestedSubmenu7Ref}
+      subMenu
+      subMenuOnClose={setOpen7NestedSubmenu}>
+      Selection 3
+      <AMenu
+        anchorRef={nestedSubmenu7Ref}
+        open={open7NestedSubmenu}
+        placement="right-top">
+        <AListItem
+          onClick={() => {
+            alert("Submenu alert");
+            closeMainMenu();
+          }}>
+          Selection 3(a)
+        </AListItem>
+        <AListItem
+          ref={nestedSubmenu7Ref1}
+          subMenu
+          subMenuOnClose={setOpen7NestedSubmenu1}>
+          Selection 3(b)
+          <AMenu
+            anchorRef={nestedSubmenu7Ref1}
+            open={open7NestedSubmenu1}
+            onClose={() => setOpen7NestedSubmenu1(false)}
+            placement="right-top">
+            <AListItem
+              onClick={() => {
+                alert("Nested submenu alert");
+                closeMainMenu();
+              }}>
+              Selection 3(b)-1
+            </AListItem>
+            <AListItem onClick={() => closeMainMenu()}>
+              Selection 3(b)-2
+            </AListItem>
+          </AMenu>
+        </AListItem>
+      </AMenu>
+    </AListItem>
+    <AListItem onClick={() => alert("should not fire")} disabled>
+      Disabled Item
+    </AListItem>
+
+  </AMenu>
+</div>
+); 
+} 
+`} 
 />
 
 ## Menu Props

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -27,30 +27,20 @@ It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
   const button4Ref = useRef(null);
   const button5Ref = useRef(null);
   const button6Ref = useRef(null);
-  const button7Ref = useRef(null);
-  const submenu7Ref = useRef(null);
-  const nestedSubmenu7Ref = useRef(null); 
-  const nestedSubmenu7Ref1 = useRef(null);  
   const [open1, setOpen1] = useState(false);
   const [open2, setOpen2] = useState(false);
   const [open3, setOpen3] = useState(false);
   const [open4, setOpen4] = useState(false);
   const [open5, setOpen5] = useState(false);
   const [open6, setOpen6] = useState(false);
-  const [open7, setOpen7] = useState(false);
-  const [open7Submenu, setOpen7Submenu] = useState(false);
-  const [open7NestedSubmenu, setOpen7NestedSubmenu] = useState(false);
-  const [open7NestedSubmenu1, setOpen7NestedSubmenu1] = useState(false);
 
 const [menu4Selected, setMenu4Selected] = useState(2);
 
-const closeMainMenu = () => {
-setOpen7(false);
-}
-
 return (
 
-<div className="d-flex" style={{
+<div
+  className="d-flex"
+  style={{
     rowGap: "10px",
     columnGap: "20px",
     flexWrap: "wrap",
@@ -101,15 +91,7 @@ return (
       ref={button6Ref}
       onClick={() => setOpen6(!open6)}
       aria-haspopup="true">
-      Menu With Groups
-    </AButton>
-  </div>
-  <div>
-    <AButton
-      ref={button7Ref}
-      onClick={() => setOpen7(!open7)}
-      aria-haspopup="true">
-      Menu with Submenus
+      Menu with Groups
     </AButton>
   </div>
   <AMenu
@@ -128,7 +110,10 @@ return (
     <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
       Example
     </AListItem>
-    <AListItem onClick={() => alert("should not fire")} className="pl-3 py-1" disabled>
+    <AListItem
+      onClick={() => alert("should not fire")}
+      className="pl-3 py-1"
+      disabled>
       Disabled Item
     </AListItem>
     <AListItemDivider className="mb-0 mt-3" />
@@ -154,8 +139,8 @@ return (
       <AListItemContent>
         <AListItemTitle>Source Application</AListItemTitle>
         <AListItemSubtitle>
-          Danger. Text to describe the notification or an issue that needs 
-          to be addressed. Very, very, very, very, very long text.
+          Danger. Text to describe the notification or an issue that needs to be
+          addressed. Very, very, very, very, very long text.
         </AListItemSubtitle>
       </AListItemContent>
       <AListItemAction
@@ -174,8 +159,8 @@ return (
       <AListItemContent>
         <AListItemTitle>Source Application</AListItemTitle>
         <AListItemSubtitle>
-          Warning. Text to describe the notification or an issue that 
-          needs to be addressed. Very, very, very, very, very long text.
+          Warning. Text to describe the notification or an issue that needs to
+          be addressed. Very, very, very, very, very long text.
         </AListItemSubtitle>
       </AListItemContent>
       <AListItemAction
@@ -201,22 +186,56 @@ return (
     anchorRef={button4Ref}
     open={open4}
     placement="bottom-right"
-    onClose={() => setOpen4(false)}
-    >
-    <AListItem onClick={() => {setMenu4Selected(0)}} selected={0 === menu4Selected}>Selection Uno</AListItem>
-    <AListItem onClick={() => {setMenu4Selected(1)}} selected={1 === menu4Selected}>Selection Dos <AIcon size={12} className="ml-2">judgement</AIcon></AListItem>
-    <AListItem onClick={() => {setMenu4Selected(2)}} selected={2 === menu4Selected}>Selection Tres</AListItem>
+    onClose={() => setOpen4(false)}>
+    <AListItem
+      onClick={() => {
+        setMenu4Selected(0);
+      }}
+      selected={0 === menu4Selected}>
+      Selection Uno
+    </AListItem>
+    <AListItem
+      onClick={() => {
+        setMenu4Selected(1);
+      }}
+      selected={1 === menu4Selected}>
+      Selection Dos
+      <AIcon size={12} className="ml-2">
+        judgement
+      </AIcon>
+    </AListItem>
+    <AListItem
+      onClick={() => {
+        setMenu4Selected(2);
+      }}
+      selected={2 === menu4Selected}>
+      Selection Tres
+    </AListItem>
     <AListItem onClick={() => alert("should not fire")} disabled>
       Disabled Item
     </AListItem>
-    <AListItemDivider style={{margin: 0}}/>
-    <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
-    <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
-    <AListItemDivider style={{margin: 0}}/>
-    <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
-    <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
-    <AListItemDivider style={{margin: 0}}/>
-    <AListItem onClick={() => {setMenu4Selected(3)}} selected={3 === menu4Selected}>Status</AListItem>
+    <AListItemDivider style={{margin: 0}} />
+    <AListItem onClick={() => {}}>
+      <ARadio checked={true}>Selected</ARadio>
+    </AListItem>
+    <AListItem onClick={() => {}}>
+      <ARadio checked={false}>UnSelected</ARadio>
+    </AListItem>
+    <AListItemDivider style={{margin: 0}} />
+    <AListItem onClick={() => {}}>
+      <ACheckbox checked={true}>Checked</ACheckbox>
+    </AListItem>
+    <AListItem onClick={() => {}}>
+      <ACheckbox checked={false}>UnChecked</ACheckbox>
+    </AListItem>
+    <AListItemDivider style={{margin: 0}} />
+    <AListItem
+      onClick={() => {
+        setMenu4Selected(3);
+      }}
+      selected={3 === menu4Selected}>
+      Status
+    </AListItem>
   </AMenu>
   <AMenu
     anchorRef={button5Ref}
@@ -224,11 +243,19 @@ return (
     compact
     placement="bottom-left"
     onClose={() => setOpen5(false)}>
- <AListItem onClick={() => {}}><ARadio checked={true}>Selected</ARadio></AListItem>
-        <AListItem onClick={() => {}}><ARadio checked={false}>UnSelected</ARadio></AListItem>
-        <AListItemDivider style={{margin: 0}}/>
-        <AListItem onClick={() => {}}><ACheckbox checked={true}>Checked</ACheckbox></AListItem>
-        <AListItem onClick={() => {}}><ACheckbox checked={false}>UnChecked</ACheckbox></AListItem>
+    <AListItem onClick={() => {}}>
+      <ARadio checked={true}>Selected</ARadio>
+    </AListItem>
+    <AListItem onClick={() => {}}>
+      <ARadio checked={false}>UnSelected</ARadio>
+    </AListItem>
+    <AListItemDivider style={{margin: 0}} />
+    <AListItem onClick={() => {}}>
+      <ACheckbox checked={true}>Checked</ACheckbox>
+    </AListItem>
+    <AListItem onClick={() => {}}>
+      <ACheckbox checked={false}>UnChecked</ACheckbox>
+    </AListItem>
   </AMenu>
   <AMenu
     anchorRef={button6Ref}
@@ -247,70 +274,122 @@ return (
       <AListItem onClick={() => {}}>Category item 5</AListItem>
     </AListItemGroup>
   </AMenu>
+</div>
+); } `} />
+
+## Cascading Menus
+
+<Playground
+  fullWidthPreview
+  code={`() => {
+  const buttonRef = useRef(null);
+  const button2Ref = useRef(null);
+  const submenuRef = useRef(null);
+  const nestedSubmenuRef = useRef(null); 
+  const nestedSubmenuRef1 = useRef(null);  
+  const [open, setOpen] = useState(false);
+  const [open2, setOpen2] = useState(false);
+  const [openSubmenu, setOpenSubmenu] = useState(false);
+  const [openNestedSubmenu, setOpenNestedSubmenu] = useState(false);
+  const [openNestedSubmenu1, setOpenNestedSubmenu1] = useState(false);
+
+return (
+
+<div
+  className="d-flex"
+  style={{
+    rowGap: "10px",
+    flexWrap: "wrap",
+    justifyContent: "space-evenly"
+  }}>
+  <div>
+    <AButton
+      ref={buttonRef}
+      onClick={() => setOpen(!open)}
+      aria-haspopup="true">
+      Menu with Submenu
+    </AButton>
+  </div>
+  <div>
+    <AButton
+      ref={button2Ref}
+      onClick={() => setOpen2(!open2)}
+      aria-haspopup="true">
+      Menu with Nested Submenu
+    </AButton>
+  </div>
   <AMenu
-    anchorRef={button7Ref}
-    open={open7}
+    anchorRef={buttonRef}
+    open={open}
     placement="bottom-left"
     onClose={() => {
       //Allow default closing of main menu if submenus aren't open
-      if(!open7Submenu && !open7NestedSubmenu) {
-        setOpen7(false);
+      if (!openSubmenu && !openNestedSubmenu) {
+        setOpen(false);
       }
     }}>
-    <AListItem onClick={() => alert("Menu alert")}>
-      Selection 1
-    </AListItem>
-    <AListItem 
-      ref={submenu7Ref}
-      subMenu
-      subMenuOnClose={setOpen7Submenu}
-    >
-      Selection 2
-      <AMenu anchorRef={submenu7Ref} open={open7Submenu} placement="right-top">
+    <AListItem onClick={() => alert("Menu alert")}>Selection 1</AListItem>
+    <AListItem onClick={() => alert("Menu alert")}>Selection 2</AListItem>
+    <AListItem ref={submenuRef} subMenu subMenuOnClose={setOpenSubmenu}>
+      Selection 3
+      <AMenu anchorRef={submenuRef} open={openSubmenu} placement="right-top">
         <AListItem
-           tabIndex={0}
+          tabIndex={0}
           onClick={() => {
             alert("Submenu alert");
-            closeMainMenu();
+            setOpen(false);
           }}>
           Selection 2(a)
         </AListItem>
       </AMenu>
     </AListItem>
+  </AMenu>
+  <AMenu
+    anchorRef={button2Ref}
+    open={open2}
+    placement="bottom-left"
+    onClose={() => {
+      //Allow default closing of main menu if submenus aren't open
+      if (!openSubmenu && !openNestedSubmenu) {
+        setOpen2(false);
+      }
+    }}>
+    <AListItem onClick={() => alert("Menu alert")}>Selection 1</AListItem>
+    <AListItem onClick={() => {}}>Selection 2</AListItem>
     <AListItem
-      ref={nestedSubmenu7Ref}
+      ref={nestedSubmenuRef}
       subMenu
-      subMenuOnClose={setOpen7NestedSubmenu}>
+      subMenuOnClose={setOpenNestedSubmenu}>
       Selection 3
       <AMenu
-        anchorRef={nestedSubmenu7Ref}
-        open={open7NestedSubmenu}
+        anchorRef={nestedSubmenuRef}
+        open={openNestedSubmenu}
         placement="right-top">
         <AListItem
           onClick={() => {
             alert("Submenu alert");
-            closeMainMenu();
+            setOpen2(false);
           }}>
           Selection 3(a)
         </AListItem>
         <AListItem
-          ref={nestedSubmenu7Ref1}
+          ref={nestedSubmenuRef1}
           subMenu
-          subMenuOnClose={setOpen7NestedSubmenu1}>
+          subMenuOnClose={setOpenNestedSubmenu1}>
           Selection 3(b)
           <AMenu
-            anchorRef={nestedSubmenu7Ref1}
-            open={open7NestedSubmenu1}
-            onClose={() => setOpen7NestedSubmenu1(false)}
+            anchorRef={nestedSubmenuRef1}
+            open={openNestedSubmenu1}
+            onClose={() => setOpenNestedSubmenu1(false)}
             placement="right-top">
             <AListItem
               onClick={() => {
                 alert("Nested submenu alert");
-                closeMainMenu();
+                setOpen2(false);
               }}>
               Selection 3(b)-1
             </AListItem>
-            <AListItem onClick={() => closeMainMenu()}>
+            <AListItem onClick={() => setOpen2(false)}>
               Selection 3(b)-2
             </AListItem>
           </AMenu>
@@ -320,13 +399,9 @@ return (
     <AListItem onClick={() => alert("should not fire")} disabled>
       Disabled Item
     </AListItem>
-
   </AMenu>
 </div>
-); 
-} 
-`} 
-/>
+); } `} />
 
 ## Menu Props
 

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -320,12 +320,12 @@ return (
     open={open}
     placement="bottom-left"
     onClose={() => setOpen(false)}>
-    <AListItem onClick={() => alert("Menu alert")}>Selection 1</AListItem>
-    <AListItem onClick={() => alert("Menu alert")}>Selection 2</AListItem>
+    <AListItem onClick={() => alert("Selection 1")}>Selection 1</AListItem>
+    <AListItem onClick={() => alert("Selection 2")}>Selection 2</AListItem>
     <AListItem ref={submenuRef} submenu>
       Selection 3
       <AMenu submenu anchorRef={submenuRef} placement="right-top">
-        <AListItem tabIndex={0} onClick={() => alert("Submenu alert")}>
+        <AListItem tabIndex={0} onClick={() => alert("Selection 2(a)")}>
           Selection 2(a)
         </AListItem>
       </AMenu>
@@ -336,18 +336,18 @@ return (
     open={open2}
     onClose={() => setOpen2(false)}
     placement="bottom-left">
-    <AListItem onClick={() => alert("Menu alert")}>Selection 1</AListItem>
+    <AListItem onClick={() => alert("Selection 1")}>Selection 1</AListItem>
     <AListItem onClick={() => {}}>Selection 2</AListItem>
     <AListItem ref={nestedSubmenuRef} submenu>
       Selection 3
       <AMenu submenu anchorRef={nestedSubmenuRef} placement="right-top">
-        <AListItem onClick={() => alert("Submenu alert")}>
+        <AListItem onClick={() => alert("Selection 3(a)")}>
           Selection 3(a)
         </AListItem>
         <AListItem ref={nestedSubmenuRef1} submenu>
           Selection 3(b)
           <AMenu submenu anchorRef={nestedSubmenuRef1} placement="right-top">
-            <AListItem onClick={() => alert("Nested submenu alert")}>
+            <AListItem onClick={() => alert("Selection 3(b)-1")}>
               Selection 3(b)-1
             </AListItem>
             <AListItem onClick={() => {}}> Selection 3(b)-2 </AListItem>

--- a/framework/components/AMenu/AMenu.scss
+++ b/framework/components/AMenu/AMenu.scss
@@ -109,6 +109,7 @@ configuration environments.
 
 .a-menu {
   overflow: visible;
+  min-width: 175px;
   > .a-list-item {
     padding: 8px 10px;
     > .a-radio,


### PR DESCRIPTION
Resolved #403 - This provides an option for `AMenus` to display a list of items which may include submenus. Usage of the current components was ideal to allow flexibility,  familiarity, and a lot less duplicate code.  

*I also expanded the width of the menus to be more like magnetic- they were unusually slim.

**Usage**
 To convert a list item into a submenu list item, `<AListItem />` and the nested `<AMenu />` will need these props:

  **AListItem**
 `ref` - Your list item ref
  `submenu` - Boolean which will allow submenu styling and behavior

  **AMenu**
  `anchorRef`  - The target ref
  `submenu` - Boolean which will allow submenu behavior

Once this is provided you may nest as many submenus as your heart desires.  Magentic prefers a limit of 2 cascading menus as described here: https://magnetic.cisco.com/0a43ab5cd/p/321929-dropdown/t/115595

**Typical structure**
 ```js
//Main dropdown
<AMenu anchorRef={buttonRef}>
  //Submenu list item
  <AListItem  ref={listItemRef} submenu>
    Submenu item
    //Your nested submenu with more items
    <AMenu anchorRef={listItemRef} submenu>
      <AListItem />
      <AListItem />
    </AMenu >
   </AListItem >
   <AListItem>  Not a submenu item</AListItem>
 </AMenu>
```

**Samples**

![Screenshot 2023-06-07 at 2 41 40 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/fa9c9036-1bca-4931-af1d-c3d119474141)
![Screenshot 2023-06-07 at 2 41 29 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/3a9e7ffb-5fb7-43bc-902e-5d06525a01b4)

**Demo**
**![nestedMenu](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/116d5206-4183-483f-9ae7-1ca253a68cf3)**


**TODO**
- Tabs and arrow functionality are at only 50% and not very straightforward.  Will add follow up PR to add focus to nested submenus. 
- Will also try to add a couple test cases.