### PR TITLE
feat: sticky header on scroll

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -105,6 +105,7 @@ const ADataTable = forwardRef(
       sort,
       selectedItems,
       truncateHeaders,
+      stickyHeader = false,
       ...rest
     },
     ref
@@ -118,6 +119,9 @@ const ADataTable = forwardRef(
     let className = "a-data-table";
     if (ExpandableComponent) {
       className += " a-data-table--expandable";
+    }
+    if (stickyHeader) {
+      className += " a-data-table--sticky";
     }
     if (truncateHeaders) {
       className += " a-data-table--truncate-headers";
@@ -506,7 +510,11 @@ ADataTable.propTypes = {
   /**
    * Automatically truncate header text with ellipses when applicable
    */
-  truncateHeaders: PropTypes.bool
+  truncateHeaders: PropTypes.bool,
+  /**
+   * Enable sticky header
+   */
+  stickyHeader: PropTypes.bool
 };
 
 ADataTable.displayName = "ADataTable";

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -35,6 +35,11 @@ $hidden-table-col-width: 45px;
       }
     }
   }
+  &--sticky {
+    th {
+      background: map-deep-get($theme, "base", "bg");
+    }
+  }
 
   &__row {
     &--selected {
@@ -48,6 +53,8 @@ $hidden-table-col-width: 45px;
 }
 
 .a-data-table {
+  border-collapse: separate;
+  border-spacing: 0;
   &__header {
     transition: all 0.3s;
 
@@ -119,6 +126,13 @@ $hidden-table-col-width: 45px;
 
   .text-end {
     text-align: end;
+  }
+
+  &--sticky {
+    th {
+      position: sticky;
+      top: 0;
+    }
   }
 
   &--expandable {


### PR DESCRIPTION
Closes #415 Adds a basic sticky header option.

@rwharrisjr  For the fixed pagination request, I feel like that is up to the table height and making sure there is scroll enabled on the table rather than the page.  What are your thoughts on that?

![sticky](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/33dd5a0a-61b3-449c-bdbc-6eb336bbf235)
