### PR TITLE
fix: ressurect table lines

### DIFF
--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -53,8 +53,6 @@ $hidden-table-col-width: 45px;
 }
 
 .a-data-table {
-  border-collapse: separate;
-  border-spacing: 0;
   &__header {
     transition: all 0.3s;
 


### PR DESCRIPTION
Closes #432: Removing this CSS as it caused style issues on current tables depending on the order of the css.  

In the meantime, sticky header will have to go without a bottom border on scroll until we can figure out a better solution to keep a border on to help separate that content.


![Screenshot 2023-06-13 at 2 47 49 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/100b23a6-68d0-42d2-8f56-0fb9c1e334f5)

