### PR TITLE
fix: stabilize width on input fields

### DIFF
--- a/framework/components/AInputBase/AInputBase.scss
+++ b/framework/components/AInputBase/AInputBase.scss
@@ -111,6 +111,7 @@ $input-transition: border-color $transition-duration--extra-fast
 }
 
 .a-input-base {
+  display: block;
   &__surface {
     display: flex;
     box-sizing: border-box;


### PR DESCRIPTION
![anotherone](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/038d21e0-7194-4c03-99c5-9b1433d100e4)


#424 Trying to find the simplest solution here.  So there is a flex on the sibling `a-field-base` which I wanted to avoid because I see that being used elsewhere like checkboxes. So tried just targeting the input base class instead - Looks like it works well in all the various input scenarios that I tested with.  

![avoid-flex](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/d3f8a09b-58d4-4ca6-a68c-dbf6a79b785f)
