### PR TITLE
fix(ATag): set font-weight to 600

### DIFF
--- a/framework/components/ATag/ATag.scss
+++ b/framework/components/ATag/ATag.scss
@@ -5,6 +5,7 @@ $tag-font-size: $font-size--xs;
 $tag-padding: 0 10px;
 $tag-border-radius: 12px;
 $tag-icon-font-size: $font-size--xxs;
+$tag-font-weight: 600;
 
 @include theme(a-tag) using ($theme) {
   background-color: map-deep-get($theme, "tag", "bg-color");
@@ -49,6 +50,7 @@ $tag-icon-font-size: $font-size--xxs;
   vertical-align: middle;
   word-break: break-all;
   cursor: default;
+  font-weight: $tag-font-weight;
 
   &.interactable {
     cursor: pointer;


### PR DESCRIPTION
Looks like the [`font-weight` for Magnetic tags should be set to 600](https://www.figma.com/file/oVZWatImEIbl1c8sjdGxi0/%F0%9F%A7%B2--Magnetic-Design-Library?type=design&node-id=5259-38496&t=8BJFNORf17ilU2MA-0):

![Screenshot 2023-06-15 at 10 59 29 AM](https://github.com/cisco-sbg-ui/magna-react/assets/94568316/db4b7f82-0dd4-4fd5-8219-602a3b18fafb)
