### PR TITLE
Bump AMenuBase z-index to account for modals

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -14,15 +14,15 @@ The purpose of this update was to provide developers with sufficient space for t
 List of components that have a z-index set with a specific value:
 
 | Component    | Subcomponent | `z-index` |
-|:-------------|:-------------|----------:|
+| :----------- | :----------- | --------: |
 | ADatePicker  |              |       100 |
 | ADrawer      |              |       100 |
 | ASlider      |              |       100 |
 | ATimeline    |              |       100 |
 | ATimeline    | Icon         |       200 |
 | ADialog      |              |       600 |
-| AMenuBase    |              |       600 |
 | APageOverlay |              |       700 |
+| AMenuBase    |              |       750 |
 | AToaster     |              |       800 |
 | ATooltip     |              |       800 |
 | ASidebar     |              |      1100 |

--- a/framework/components/AMenuBase/AMenuBase.scss
+++ b/framework/components/AMenuBase/AMenuBase.scss
@@ -1,7 +1,7 @@
 .a-menu-base {
   visibility: hidden;
   position: absolute;
-  z-index: 600;
+  z-index: 750;
   &--active {
     visibility: visible;
   }

--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -282,6 +282,7 @@ describe("<AModal />", () => {
       cy.getByDataTestId("menu-item-1").should("exist");
       // @todo: add screenshot test to ensure menu is not covered by overlay */
       cy.getByDataTestId("menu-item-1").should("be.visible");
+      cy.getByDataTestId("menu-item-1").click();
 
       // Make sure
       getModalContent().should("exist");


### PR DESCRIPTION
Form elements with menus (`ASelect`) inside `AModal` are opening the menu behind the modal


https://magna-react.vercel.app/components/modal

This bumps the `AMenuBase` z-index to 750, which is 50 higher than the new 700 for `APageOverlay`


@guptar8jan fyi