### PR TITLE
feat: add border on scroll

### DIFF
--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -36,7 +36,8 @@ $hidden-table-col-width: 45px;
     }
   }
   &--sticky {
-    th {
+    thead {
+      box-shadow: 0 2.5px 2px -2px map-deep-get($theme, "table", "header-border");
       background: map-deep-get($theme, "base", "bg");
     }
   }
@@ -127,7 +128,7 @@ $hidden-table-col-width: 45px;
   }
 
   &--sticky {
-    th {
+    thead {
       position: sticky;
       top: 0;
     }

--- a/framework/components/ASimpleTable/ASimpleTable.js
+++ b/framework/components/ASimpleTable/ASimpleTable.js
@@ -14,6 +14,7 @@ const ASimpleTable = forwardRef(
       spacious,
       comfy,
       compact,
+      stickyHeader = false,
       ...rest
     },
     ref
@@ -22,6 +23,10 @@ const ASimpleTable = forwardRef(
 
     if (altLinks) {
       className += ` a-simple-table--alt-links`;
+    }
+
+    if (stickyHeader) {
+      className += " a-simple-table--sticky";
     }
 
     if (striped) {
@@ -76,7 +81,11 @@ ASimpleTable.propTypes = {
   /**
    * Toggles the `spacious` display variant. Largest row heights.
    */
-  spacious: PropTypes.bool
+  spacious: PropTypes.bool,
+  /**
+   * Enable sticky header
+   */
+  stickyHeader: PropTypes.bool
 };
 
 ASimpleTable.displayName = "ASimpleTable";

--- a/framework/components/ASimpleTable/ASimpleTable.scss
+++ b/framework/components/ASimpleTable/ASimpleTable.scss
@@ -63,6 +63,13 @@ $table-cell-spacious-padding-top-bottom: math.div(
     border-bottom-color: map-deep-get($theme, "table", "header-border");
   }
 
+  &--sticky {
+    thead {
+      background: map-deep-get($theme, "base", "bg");
+      box-shadow: 0 2.5px 2px -2px map-deep-get($theme, "table", "header-border");
+    }
+  }
+
   tr {
     td {
       color: map-deep-get($theme, "table", "color");
@@ -95,6 +102,13 @@ $table-cell-spacious-padding-top-bottom: math.div(
 
   &__total {
     padding-top: $table__total--padding-top;
+  }
+
+  &--sticky {
+    thead {
+      position: sticky;
+      top: 0;
+    }
   }
 
   tbody {


### PR DESCRIPTION
Follow up to https://github.com/cisco-sbg-ui/magna-react/pull/437 and [#415 ](https://github.com/cisco-sbg-ui/magna-react/pull/421) - a non-invasive way to add "border" on scroll.  Used box-shadow - it's not as thick as the original border on scroll, but it helps.  Also added stickyHeader to `simple-table`.

![stickyHeaderBorder](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/9cbbc597-dea6-43e0-b752-a85ef447858e)
