### PR TITLE
Set line-height on ATag

### DIFF
--- a/framework/components/ATag/ATag.scss
+++ b/framework/components/ATag/ATag.scss
@@ -98,6 +98,7 @@ $colors: "A", "B", "C", "D", "E", "F", "G", "H", "I", "K";
   display: inline-flex;
   font-size: $tag-font-size;
   min-height: $tag-height;
+  line-height: $tag-font-size;
   align-items: center;
   padding: $tag-padding;
   border-radius: $tag-border-radius;
@@ -170,6 +171,7 @@ $colors: "A", "B", "C", "D", "E", "F", "G", "H", "I", "K";
   &--sm {
     min-height: $tag-height-sm;
     padding: $tag-padding-sm;
+
     .a-icon--status {
       width: calc($tag-icon-font-size * 1.143); //12px phosphorus circle
     }
@@ -182,6 +184,7 @@ $colors: "A", "B", "C", "D", "E", "F", "G", "H", "I", "K";
   &--lg {
     min-height: $tag-height-lg;
     font-size: $tag-font-size-lg;
+    line-height: $tag-font-size-lg;
     .a-icon--status {
       width: calc($tag-icon-font-size * 1.524); //16px phosphorus circle
     }


### PR DESCRIPTION
fixes scenarios when parent container sets a line-height that's bigger than the tag size