### PR TITLE
Add focus-visible to AButton; Add focus to AButtonGroup buttons

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -16,10 +16,12 @@ $btn-transition: color $transition-duration--extra-fast
     $transition-timing-function--standard !default;
 
 @include theme(a-button) using ($theme) {
+  /*
   &:focus-visible {
     box-shadow: 0 0 0 2px map-deep-get($theme, "button", "focus-visible", "bg"),
       0 0 0 4px map-deep-get($theme, "button", "focus-visible", "control");
   }
+  */
 
   &--primary {
     color: map-deep-get($theme, "button", "primary", "color");

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -16,7 +16,8 @@ $btn-transition: color $transition-duration--extra-fast
     $transition-timing-function--standard !default;
 
 @include theme(a-button) using ($theme) {
-  /*
+  /* Magnetic didn't have guidance for this at time of the PR, will revisit in
+  * the future.
   &:focus-visible {
     box-shadow: 0 0 0 2px map-deep-get($theme, "button", "focus-visible", "bg"),
       0 0 0 4px map-deep-get($theme, "button", "focus-visible", "control");

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -16,6 +16,11 @@ $btn-transition: color $transition-duration--extra-fast
     $transition-timing-function--standard !default;
 
 @include theme(a-button) using ($theme) {
+  &:focus-visible {
+    box-shadow: 0 0 0 2px map-deep-get($theme, "button", "focus-visible", "bg"),
+      0 0 0 4px map-deep-get($theme, "button", "focus-visible", "control");
+  }
+
   &--primary {
     color: map-deep-get($theme, "button", "primary", "color");
     background-color: map-deep-get($theme, "button", "primary", "bg");

--- a/framework/components/AButtonGroup/AButtonGroup.scss
+++ b/framework/components/AButtonGroup/AButtonGroup.scss
@@ -15,6 +15,7 @@ $btn-group-icon-font-size: rem(1);
         "background-color"
       );
       color: map-deep-get($theme, "button-group", "color--disabled");
+
       &--selected {
         background-color: map-deep-get(
           $theme,
@@ -28,6 +29,10 @@ $btn-group-icon-font-size: rem(1);
         );
       }
     }
+  }
+
+  .a-button-group__wrapper > .a-button:focus-visible {
+    box-shadow: none;
   }
 
   &__wrapper > .a-button {
@@ -57,6 +62,22 @@ $btn-group-icon-font-size: rem(1);
         "background-color--hover"
       );
       border-color: map-deep-get($theme, "button-group", "border-color--hover");
+    }
+
+    &:focus {
+      color: map-deep-get($theme, "button", "secondary", "color--focus");
+      background-color: map-deep-get(
+        $theme,
+        "button",
+        "secondary",
+        "bg--focus"
+      );
+      border-color: map-deep-get(
+        $theme,
+        "button",
+        "secondary",
+        "border--focus"
+      );
     }
 
     &:active {

--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -143,6 +143,10 @@ $atomic-default: (
     ),
     "group": (
       "color": map-get($grey, "darken-7")
+    ),
+    "focus-visible": (
+      bg: map-get($mds-light-theme, "interact-bg-weak-active"),
+      control: map-get($mds-light-theme, "control-border-focus")
     )
   ),
   "button-group": (

--- a/framework/styles/theme/dusk.scss
+++ b/framework/styles/theme/dusk.scss
@@ -138,6 +138,10 @@ $atomic-dusk: (
     ),
     "group": (
       "color": map-get($grey, "lighten-5")
+    ),
+    "focus-visible": (
+      bg: map-get($mds-dark-theme, "interact-bg-weak-active"),
+      control: map-get($mds-dark-theme, "control-border-focus")
     )
   ),
   "card": (

--- a/framework/styles/utilities/palette.scss
+++ b/framework/styles/utilities/palette.scss
@@ -471,7 +471,9 @@ $mds-light-theme: (
   "status-positive-bg": #eaf7e4,
   "status-warning-bg": #fcf5d4,
   "status-negative-bg": #fce2de,
-  "table-border": map-get($mds-neutral, "neutral-11")
+  "table-border": map-get($mds-neutral, "neutral-11"),
+  "interact-bg-weak-active": #cce1ff,
+  "control-border-focus": #3e84e5
 );
 $mds-dark-theme: (
   "background": map-get($mds-neutral, "neutral-17"),
@@ -502,7 +504,9 @@ $mds-dark-theme: (
   "status-positive-bg": darken(#6dc242, 35%),
   "status-warning-bg": rgba(224, 164, 25, 0.302),
   "status-negative-bg": rgba(217, 56, 67, 0.4),
-  "table-border": map-get($mds-neutral, "neutral-7")
+  "table-border": map-get($mds-neutral, "neutral-7"),
+  "interact-bg-weak-active": map-get($mds-interactive, "interactive-7"),
+  "control-border-focus": map-get($mds-interactive, "interactive-9")
 );
 
 $secure-blue: (


### PR DESCRIPTION
Resolves #459 

made a guess at the focus-visible colors for dark theme, since that isn't reflected in the latest figma. The box shadow depth matches the other component set

Focused single button

![Screenshot 2023-07-07 at 11 57 49 AM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/65f19939-0ce0-4f1d-9ff7-680e1ae446c9)


"One" is focused:

![Screenshot 2023-07-07 at 11 57 17 AM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/b99b07a5-afc7-44db-b9b9-fccf96ed9d42)

the box-shadow for :focus-visible does not work well on button groups, so copied in the secondary button focus style