### PR TITLE
fix: locale search filter for AMultiSelect

### DIFF
--- a/framework/components/AMultiSelect/AMultiSelect.js
+++ b/framework/components/AMultiSelect/AMultiSelect.js
@@ -14,7 +14,7 @@ import AMenu from "../AMenu";
 import {AListItem} from "../AList";
 import AEmptyState from "../AEmptyState";
 import {useCombinedRefs} from "../../utils/hooks";
-import {keyCodes} from "../../utils/helpers";
+import {keyCodes, localeIncludes} from "../../utils/helpers";
 import useMenuSpacing from "../AMenuBase/hooks";
 import useOutsideClick from "../../hooks/useOutsideClick/useOutsideClick";
 import usePopupQuickExit from "../../hooks/usePopupQuickExit/usePopupQuickExit";
@@ -79,7 +79,13 @@ const AMultiSelect = forwardRef(
           } else if (typeof item === "object") {
             displayValue = item[itemText];
           }
-          return displayValue && displayValue.toLowerCase().includes(val);
+          return (
+            displayValue &&
+            localeIncludes(displayValue, val, {
+              usage: "search",
+              sensitivity: "base"
+            })
+          );
         };
     const filteredItems = filterValue
       ? items.filter((item) => {

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -280,3 +280,32 @@ export const isForwardTab = (e) => {
   const isTabbingForward = !isBackwardTab(e) && key === "Tab";
   return isTabbingForward;
 };
+
+export const localeIncludes = (
+  string,
+  searchString,
+  {position = 0, locales, ...options} = {}
+) => {
+  if (
+    string === undefined ||
+    string === null ||
+    searchString === undefined ||
+    searchString === null
+  ) {
+    return true;
+  }
+
+  const lengthDiff = string.length - searchString.length;
+
+  for (let i = position; i <= lengthDiff; i++) {
+    if (
+      string
+        .substring(i, i + searchString.length)
+        .localeCompare(searchString, locales, options) === 0
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
Resolves #472

Adds a `localeIncludes` method for filtering/searching by substring, which handles capitalization and accents

![Screenshot 2023-07-20 at 1 15 28 PM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/06a698ab-9a84-4491-ade4-d84f9fca1b86)
