### PR TITLE
fix(useFocusTrap): preserve sequential tab order when initially focused element is overridden

### DIFF
--- a/framework/hooks/useFocusTrap/useFocusTrap.cy.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.cy.js
@@ -44,6 +44,25 @@ describe("useFocusTrap()", () => {
     cy.get("textarea").should("have.focus");
   });
 
+  it("should preserve tab order when an element within the focus trap is explicitly clicked", () => {
+    cy.mount(<FocusTrapTest />);
+
+    cy.get("#trap").should("have.focus");
+
+    cy.getByDataTestId("trapped-item-2").click();
+    cy.getByDataTestId("trapped-item-2").should("have.focus");
+
+    cy.get("body").tab();
+    cy.getByDataTestId("trapped-item-3").should("have.focus");
+
+    cy.get("body").tab();
+    cy.getByDataTestId("trapped-item-1").should("have.focus");
+
+    cy.getByDataTestId("trapped-item-3").click();
+    cy.get("body").tab({shift: true});
+    cy.getByDataTestId("trapped-item-2").should("have.focus");
+  });
+
   it("should preserve tab order when the inner element receives auto focus", () => {
     cy.mount(<AutoInitialFocusTest />);
 
@@ -90,7 +109,9 @@ const FocusTrapTest = ({children, enableAutofocus = true}) => {
           <label htmlFor="password">Password</label>
           <input data-testid="trapped-item-2" type="password" />
           <br />
-          <button data-testid="trapped-item-3">Submit</button>
+          <button data-testid="trapped-item-3" type="button">
+            Submit
+          </button>
         </form>
 
         {children}

--- a/framework/hooks/useFocusTrap/useFocusTrap.cy.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.cy.js
@@ -43,6 +43,22 @@ describe("useFocusTrap()", () => {
 
     cy.get("textarea").should("have.focus");
   });
+
+  it("should preserve tab order when the inner element receives auto focus", () => {
+    cy.mount(<AutoInitialFocusTest />);
+
+    cy.get("textarea").should("have.focus");
+    cy.get("body").tab();
+    cy.getByDataTestId("trapped-item-3").should("have.focus");
+  });
+
+  it("should preserve tab order when another element is passed to set initial focus to", () => {
+    cy.mount(<CustomInitialFocusTest />);
+
+    cy.getByDataTestId("trapped-item-2").should("have.focus");
+    cy.get("body").tab();
+    cy.getByDataTestId("trapped-item-3").should("have.focus");
+  });
 });
 
 const FocusTrapTest = ({children, enableAutofocus = true}) => {
@@ -78,6 +94,111 @@ const FocusTrapTest = ({children, enableAutofocus = true}) => {
         </form>
 
         {children}
+      </div>
+
+      <div>
+        {[...new Array(3).keys()]
+          .map((num) => num + 3)
+          .map((num) => (
+            <a
+              key={num}
+              data-testid={`inaccessible-item-${num}`}
+              href={`#link-${num}`}
+            >
+              link {num}
+            </a>
+          ))}
+      </div>
+    </>
+  );
+};
+
+const CustomInitialFocusTest = () => {
+  const trapContainerRef = useRef();
+  const initialFocusElRef = useRef();
+  useFocusTrap({
+    rootRef: trapContainerRef,
+    isEnabled: true,
+    autoFocusElementRef: initialFocusElRef
+  });
+  return (
+    <>
+      <div>
+        {[...new Array(3).keys()].map((num) => (
+          <a
+            key={num}
+            data-testid={`inaccessible-item-${num}`}
+            href={`#link-${num}`}
+          >
+            link {num}
+          </a>
+        ))}
+      </div>
+
+      <div id="trap" tabIndex={-1} ref={trapContainerRef}>
+        <form>
+          <label htmlFor="username">Username</label>
+          <input data-testid="trapped-item-1" id="username" type="text" />
+          <br />
+          <label htmlFor="password">Password</label>
+          <input
+            ref={initialFocusElRef}
+            data-testid="trapped-item-2"
+            type="password"
+          />
+          <br />
+          <button data-testid="trapped-item-3">Submit</button>
+        </form>
+      </div>
+
+      <div>
+        {[...new Array(3).keys()]
+          .map((num) => num + 3)
+          .map((num) => (
+            <a
+              key={num}
+              data-testid={`inaccessible-item-${num}`}
+              href={`#link-${num}`}
+            >
+              link {num}
+            </a>
+          ))}
+      </div>
+    </>
+  );
+};
+
+const AutoInitialFocusTest = () => {
+  const trapContainerRef = useRef();
+  useFocusTrap({
+    rootRef: trapContainerRef,
+    isEnabled: true,
+    autoFocusElementRef: null
+  });
+  return (
+    <>
+      <div>
+        {[...new Array(3).keys()].map((num) => (
+          <a
+            key={num}
+            data-testid={`inaccessible-item-${num}`}
+            href={`#link-${num}`}
+          >
+            link {num}
+          </a>
+        ))}
+      </div>
+
+      <div id="trap" tabIndex={-1} ref={trapContainerRef}>
+        <form>
+          <label htmlFor="username">Username</label>
+          <input data-testid="trapped-item-1" id="username" type="text" />
+          <br />
+          <label htmlFor="password">Password</label>
+          <ATextarea autoFocus />
+          <br />
+          <button data-testid="trapped-item-3">Submit</button>
+        </form>
       </div>
 
       <div>

--- a/framework/hooks/useFocusTrap/useFocusTrap.cy.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.cy.js
@@ -78,6 +78,21 @@ describe("useFocusTrap()", () => {
     cy.get("body").tab();
     cy.getByDataTestId("trapped-item-3").should("have.focus");
   });
+
+  it("should reset the tab order when a non-focusable element within the focus trap is explicitly clicked", () => {
+    cy.mount(<FocusTrapTest />);
+
+    cy.get("#trap").should("have.focus");
+
+    cy.getByDataTestId("trapped-item-2").click();
+    cy.getByDataTestId("trapped-item-2").should("have.focus");
+
+    cy.get("label").eq(1).click();
+    cy.getByDataTestId("trapped-item-2").should("not.have.focus");
+
+    cy.get("body").tab();
+    cy.getByDataTestId("trapped-item-1").should("have.focus");
+  });
 });
 
 const FocusTrapTest = ({children, enableAutofocus = true}) => {

--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -1,5 +1,9 @@
 import {useCallback, useEffect} from "react";
-import {isBackwardTab, isForwardTab} from "../../utils/helpers";
+import {
+  canNodeReceiveFocus,
+  isBackwardTab,
+  isForwardTab
+} from "../../utils/helpers";
 
 function createTrap(walker) {
   return function trap(e) {
@@ -37,9 +41,9 @@ export default function useFocusTrap({
   autoFocusElementRef,
   isEnabled = true
 }) {
-  const canNodeReceiveFocus = useCallback(
+  const getTreeWalkerNodeDisposition = useCallback(
     (node) => {
-      if (node === rootRef?.current || node.tabIndex >= 0) {
+      if (node === rootRef?.current || canNodeReceiveFocus(node)) {
         return NodeFilter.FILTER_ACCEPT;
       } else {
         return NodeFilter.FILTER_SKIP;
@@ -54,7 +58,7 @@ export default function useFocusTrap({
         rootRef.current,
         NodeFilter.SHOW_ELEMENT,
         {
-          acceptNode: canNodeReceiveFocus
+          acceptNode: getTreeWalkerNodeDisposition
         }
       );
 
@@ -76,7 +80,7 @@ export default function useFocusTrap({
         });
       } else if (
         rootRef?.current.contains(document.activeElement) &&
-        canNodeReceiveFocus(document?.activeElement) ===
+        getTreeWalkerNodeDisposition(document?.activeElement) ===
           NodeFilter.FILTER_ACCEPT
       ) {
         // This covers the situation when a developer passes `autoFocusElement` as a
@@ -91,5 +95,5 @@ export default function useFocusTrap({
       document.addEventListener("keydown", trap);
       return () => document.removeEventListener("keydown", trap);
     }
-  }, [rootRef, autoFocusElementRef, isEnabled, canNodeReceiveFocus]);
+  }, [rootRef, autoFocusElementRef, isEnabled, getTreeWalkerNodeDisposition]);
 }

--- a/framework/hooks/useFocusTrap/useFocusTrap.js
+++ b/framework/hooks/useFocusTrap/useFocusTrap.js
@@ -100,8 +100,16 @@ export default function useFocusTrap({
 
       function resetTreeWalkerHeadOnClick(e) {
         const target = e.target;
+
         if (canNodeReceiveFocus(target)) {
+          // The user is clicking a focusable element within the trap, so
+          // we need to ensure that their next `Tab` or `Shift` + `Tab`
+          // keydown focuses to an element closest to the one just clicked.
           treeWalker.currentNode = target;
+        } else {
+          // The user is clicking a non-focusable element within the trap, so
+          // we should reset the tab order sequence to start from the beginning.
+          treeWalker.currentNode = trapContainerEl;
         }
       }
 

--- a/framework/utils/helpers.cy.js
+++ b/framework/utils/helpers.cy.js
@@ -1,0 +1,51 @@
+import {canNodeReceiveFocus} from "./helpers";
+
+describe("utils tests", () => {
+  describe("canNodeReceiveFocus", () => {
+    it("should return true for form elements", () => {
+      const formElements = ["input", "select", "textarea", "button"];
+
+      formElements.forEach((tagName) => {
+        const node = document.createElement(tagName);
+        expect(canNodeReceiveFocus(node)).to.eq(true);
+      });
+    });
+
+    it("should return false for hidden elements", () => {
+      const hiddenNode = document.createElement("input");
+      hiddenNode.setAttribute("hidden", "");
+
+      expect(canNodeReceiveFocus(hiddenNode)).to.eq(false);
+    });
+
+    it("should return false for disabled elements", () => {
+      const disabledNode = document.createElement("input");
+      disabledNode.setAttribute("disabled", "");
+
+      expect(canNodeReceiveFocus(disabledNode)).to.eq(false);
+    });
+
+    it("should return true for nodes with valid tab indexes", () => {
+      [...new Array(5)].map((_, index) => {
+        const element = document.createElement("div");
+        element.setAttribute("tabindex", index);
+
+        expect(canNodeReceiveFocus(element)).to.eq(true);
+      });
+    });
+
+    it("should return false for nodes with a tab index less than 0", () => {
+      const unFocusableNode = document.createElement("input");
+      unFocusableNode.setAttribute("tabindex", "-1");
+
+      expect(canNodeReceiveFocus(unFocusableNode)).to.eq(false);
+    });
+
+    it("should return true for nodes that are editable", () => {
+      const editableNode = document.createElement("div");
+      editableNode.setAttribute("contenteditable", "true");
+
+      expect(canNodeReceiveFocus(editableNode)).to.eq(true);
+    });
+  });
+});

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -326,3 +326,37 @@ export const copyToClipboard = (value, containerId) => {
   document.execCommand("copy");
   parentEl.removeChild(t);
 };
+
+const isFormControl = (element) => {
+  if (!element?.tagName) {
+    return false;
+  } else {
+    return ["input", "select", "textarea", "button"].includes(
+      element.tagName.toLowerCase()
+    );
+  }
+};
+
+export const canNodeReceiveFocus = (node) => {
+  if (!node) {
+    return false;
+  }
+
+  if (node.hidden || node.disabled) {
+    return false;
+  }
+
+  if (parseInt(node.tabIndex) >= 0) {
+    return true;
+  }
+
+  if (isFormControl(node) && parseInt(node.tabIndex) >= 0) {
+    return true;
+  }
+
+  if (node.isContentEditable) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
* Closes #482 
* Closes #486

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
This preserves sequential tab order for components calling `useFocusTrap` with an override on the element that should be initially focused to.


**What is the current behavior?** <!--(You can also link to an open issue here)-->
When a developer passes an element to set initial focus to within the focus trap, the tab order gets reset to the beginning of the trap on the next sequent `Tab` keydown.


**What is the new behavior (if this is a feature change)?**
Preserves tab order in situations where a developer passes `null` or a React ref to the `autoFocusElementRef`


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->
No
