### PR TITLE
feat: stepper to magnetic design

### DIFF
--- a/framework/components/AStepper/AStep.js
+++ b/framework/components/AStepper/AStep.js
@@ -16,6 +16,8 @@ const AStep = forwardRef(
       stepNumber,
       children,
       setActiveStep,
+      isVertical,
+      dividerStyle,
       ...rest
     },
     ref
@@ -42,7 +44,7 @@ const AStep = forwardRef(
       React.Children.count(children) === 1 ||
       (children[1] && !children[1].props.children)
     ) {
-      style = {margin: "0"};
+      style = {marginTop: "3px"};
     }
 
     const onClick = (e) => {
@@ -63,6 +65,17 @@ const AStep = forwardRef(
         }
       };
 
+    const titleView = isVertical ? (
+      <div className="a-step__content" style={style}>
+        {children}
+      </div>
+    ) : (
+      <>
+        <span className="a-step__divider" style={dividerStyle} />
+        {children[0] || children}
+      </>
+    );
+
     return (
       <div
         {...rest}
@@ -73,18 +86,18 @@ const AStep = forwardRef(
         tabIndex={0}
         role="menuitem"
       >
-        <div className="a-step__icon">
-          {!disabled && visited && showIconOnVisited ? (
-            <AIcon size={12} className="a-step__icon__checkmark">
-              checkmark
-            </AIcon>
-          ) : (
-            stepNumber
-          )}
+        <div className="a-step__icon-container">
+          <div className="a-step__icon">
+            {!disabled && visited && showIconOnVisited ? (
+              <AIcon size={16} className="a-step__icon__checkmark">
+                check
+              </AIcon>
+            ) : (
+              stepNumber
+            )}
+          </div>
         </div>
-        <div className="a-step__content" style={style}>
-          {children}
-        </div>
+        {titleView}
       </div>
     );
   }

--- a/framework/components/AStepper/AStepTitle.js
+++ b/framework/components/AStepper/AStepTitle.js
@@ -9,7 +9,6 @@ const AStepTitle = forwardRef(
     return (
       <div {...rest} ref={ref} className={className}>
         <span className="a-step__title">{children}</span>
-        <hr className="a-step__divider" />
       </div>
     );
   }

--- a/framework/components/AStepper/AStepper.js
+++ b/framework/components/AStepper/AStepper.js
@@ -1,10 +1,15 @@
 import PropTypes from "prop-types";
-import React, {forwardRef} from "react";
+import React, {forwardRef, useRef, useMemo} from "react";
+import {useResizeObserver} from "../../utils/hooks";
 
 import "./AStepper.scss";
 
 const AStepper = forwardRef(
   ({className: propsClassName = "", children, vertical, ...rest}, ref) => {
+    const containerRef = useRef(null);
+    const {width} = useResizeObserver(containerRef);
+    const numberOfSteps = React.Children.count(children);
+
     let className = "a-steps";
     if (vertical) {
       className += " a-steps--orientation-vertical";
@@ -13,9 +18,32 @@ const AStepper = forwardRef(
       className += ` ${propsClassName}`;
     }
 
+    const dividerWidth = useMemo(
+      () => width / numberOfSteps,
+      [width, numberOfSteps]
+    );
+
+    const renderChildren = React.Children.map(children, (child) => {
+      return React.cloneElement(child, {
+        isVertical: vertical,
+        dividerStyle: {width: `${dividerWidth}px`}
+      });
+    });
+
+    const renderItem = React.Children.map(children, (child) => {
+      if (child.props.active) {
+        return child.props.children;
+      }
+    });
+
     return (
-      <div {...rest} ref={ref} className={className}>
-        {children}
+      <div ref={containerRef} className="a-steps-container">
+        <div {...rest} ref={ref} className={className}>
+          {renderChildren}
+        </div>
+        {!vertical && (
+          <div className="a-steps__description">{renderItem[1]}</div>
+        )}
       </div>
     );
   }

--- a/framework/components/AStepper/AStepper.mdx
+++ b/framework/components/AStepper/AStepper.mdx
@@ -29,7 +29,7 @@ import {AStepper, AStep, AStepTitle, AStepDescription} from "@cisco-sbg-ui/magna
       <h3>Stepper</h3>
       <AStepper>
         <AStep stepNumber={1} active={active === 1} visited={active > 1}>
-          <AStepTitle>Title </AStepTitle>
+          <AStepTitle>Stepped modal title 1</AStepTitle>
           <AStepDescription>
             Description of title. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
           </AStepDescription>
@@ -39,13 +39,13 @@ import {AStepper, AStep, AStepTitle, AStepDescription} from "@cisco-sbg-ui/magna
           active={active === 2}
           visited={active > 2}
           disabled={true}>
-          <AStepTitle>Title</AStepTitle>
+          <AStepTitle>Stepped modal title 2</AStepTitle>
           <AStepDescription>
             Description of title. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
           </AStepDescription>
         </AStep>
         <AStep stepNumber={3} active={active === 3} visited={active > 3}>
-          <AStepTitle>Title</AStepTitle>
+          <AStepTitle>Stepped modal title 3</AStepTitle>
           <AStepDescription>
               Description of title. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
           </AStepDescription>
@@ -54,7 +54,7 @@ import {AStepper, AStep, AStepTitle, AStepDescription} from "@cisco-sbg-ui/magna
           stepNumber={4}
           active={active === 4}
           visited={active > 4}>
-          <AStepTitle>Title</AStepTitle>
+          <AStepTitle>Stepped modal title 4</AStepTitle>
           <AStepDescription>
             Description of title. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
           </AStepDescription>
@@ -107,7 +107,7 @@ import {AStepper, AStep, AStepTitle, AStepDescription} from "@cisco-sbg-ui/magna
         {active > data.length ? "Completed" : "Step " + active}
       </div>
       <h3>Stepper with icon:</h3>
-      <AStepper className="AStepper">
+      <AStepper>
         {data.map((item, index) => {
           const stepNumber = index + 1;
           return (
@@ -117,7 +117,6 @@ import {AStepper, AStep, AStepTitle, AStepDescription} from "@cisco-sbg-ui/magna
               active={active === stepNumber}
               visited={active > stepNumber}
               disabled={stepNumber === 2}
-              className="AStep"
               showIconOnVisited={true}>
               <AStepTitle className="AStepTitle">
                 {item.title}

--- a/framework/components/AStepper/AStepper.scss
+++ b/framework/components/AStepper/AStepper.scss
@@ -1,85 +1,106 @@
 @import "../../styles/index.scss";
 
-@include theme(a-steps) using ($theme) {
-  .a-step {
-    &__icon {
-      border: $border-width solid
-        map-deep-get($theme, "steps", "step-main-color");
-      color: map-deep-get($theme, "steps", "step-main-color");
-    }
-    &__label {
-      color: map-deep-get($theme, "base", "color--disabled");
-    }
-    &__active {
-      .a-step__icon {
-        background: map-get($theme, "steps", "step-icon-border-color");
-        color: map-get($theme, "steps", "step-active-color");
-        border: $border-width solid
-          map-get($theme, "steps", "step-icon-border-color");
+@include theme(a-steps-container) using ($theme) {
+  //Typical usage will be in modal, but fallback to same color as panel for icon and container backgrounds.
+  background-color: map-deep-get($theme, "panel", "bg");
+  .a-steps {
+    .a-step {
+      &__icon-container {
+        background-color: map-deep-get($theme, "panel", "bg");
       }
-      .a-step__label {
-        color: map-get($theme, "steps", "step-icon-border-color");
+
+      &__divider {
+        background-color: map-deep-get(
+          $theme,
+          "steps",
+          "step-icon-default-border-color"
+        );
       }
-    }
-    &__divider {
-      background-color: map-deep-get($theme, "steps", "step-main-color");
-    }
-    &__visited {
-      .a-step__divider {
-        height: 2px;
-        background-color: map-get($theme, "steps", "step-icon-border-color");
+      &__label {
+        color: map-deep-get($theme, "base", "color--disabled");
       }
-      .a-step__icon {
-        border: $border-width solid
-          map-get($theme, "steps", "step-icon-border-color");
-        color: map-get($theme, "steps", "step-icon-border-color");
-        &__checkmark {
+      &__hint {
+        color: map-deep-get($theme, "steps", "step-icon-default-color");
+      }
+      &__active {
+        .a-step__icon {
+          background: map-deep-get($theme, "steps", "step-main-color");
+          color: map-get($theme, "steps", "step-active-color");
+          border: $border-width solid
+            map-deep-get($theme, "steps", "step-main-color");
+        }
+        .a-step__label {
           color: map-get($theme, "steps", "step-icon-border-color");
         }
       }
+      &__visited {
+        .a-step__divider {
+          height: 2px;
+          background-color: map-get($theme, "steps", "step-icon-border-color");
+        }
+        .a-step__icon {
+          border: $border-width solid
+            map-get($theme, "steps", "step-icon-border-color");
+          color: map-get($theme, "steps", "step-icon-border-color");
+          &__checkmark {
+            color: map-get($theme, "steps", "step-icon-border-color");
+            stroke: map-get($theme, "steps", "step-icon-border-color");
+            polyline {
+              stroke-width: 35; //Remove if magnetic updates icon
+            }
+          }
+        }
 
-      .a-step__label {
-        color: map-deep-get($theme, "base", "color");
+        .a-step__label {
+          color: map-deep-get($theme, "base", "color");
+        }
+
+        .a-step__title {
+          color: map-deep-get($theme, "steps", "step-visited-title-color");
+        }
+      }
+      &__disabled {
+        .a-step__icon {
+          border: $border-width solid
+            map-deep-get($theme, "steps", "step-icon-disabled-border-color");
+          color: map-deep-get($theme, "steps", "step-icon-disabled-color");
+        }
+        .a-step__title,
+        .a-step__hint {
+          color: map-deep-get($theme, "steps", "step-icon-disabled-color");
+        }
+      }
+      &__default {
+        .a-step__icon {
+          border: $border-width solid
+            map-deep-get($theme, "steps", "step-icon-default-border-color");
+          color: map-deep-get($theme, "steps", "step-icon-default-color");
+        }
+        .a-step__title,
+        .a-step__hint {
+          color: map-deep-get($theme, "steps", "step-icon-default-color");
+        }
       }
 
-      .a-step__title {
-        color: map-deep-get($theme, "steps", "step-visited-title-color");
+      &--cursor {
+        cursor: pointer;
       }
     }
-    &__disabled {
-      .a-step__icon {
-        border: $border-width solid
-          map-deep-get($theme, "base", "color--disabled");
-        color: map-deep-get($theme, "base", "color--disabled");
+    &--orientation-vertical {
+      .a-step__active {
+        border-right: 3px solid;
+        border-color: map-deep-get($theme, "steps", "step-icon-border-color");
       }
-    }
-    &__default {
-      .a-step__icon {
-        border: $border-width solid
-          map-deep-get($theme, "steps", "step-icon-default-border-color");
-        color: map-deep-get($theme, "steps", "step-icon-default-color");
-      }
-      .a-step__title,
-      .a-step__hint {
-        color: map-deep-get($theme, "base", "step-default-color");
-      }
-    }
 
-    &--cursor {
-      cursor: pointer;
+      .a-step__visited {
+        border-color: transparent;
+      }
     }
   }
-  &--orientation-vertical {
-    .a-step__active {
-      border-right: 2px solid;
-      border-color: map-deep-get($theme, "steps", "step-icon-border-color");
-    }
+}
 
-    .a-step__visited {
-      border-right: 2px solid;
-      border-color: map-deep-get($theme, "steps", "step-visited-title-color");
-    }
-  }
+.a-steps-container {
+  padding: 24px 0;
 }
 
 .a-steps {
@@ -87,22 +108,46 @@
   flex: 1;
   align-items: top;
   justify-content: space-around;
-  margin: 0 auto 20px;
-  padding: 20px 0;
+  padding: 0 0 24px;
   text-align: center;
+
+  &__description {
+    padding: 0 28px;
+  }
+
   .a-step {
     position: relative;
-    display: inline-flex;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     flex: 1;
+    max-width: 200px;
+    overflow-wrap: anywhere;
+
+    &__icon-container {
+      z-index: 1;
+      display: inherit;
+      justify-content: center;
+      align-items: center;
+      height: 38px;
+      min-width: 60px;
+    }
+
+    &__divider {
+      height: 1px;
+      position: absolute;
+      top: 19px;
+      left: 60%;
+    }
+
     &__icon {
-      width: 24px;
-      min-width: 24px;
-      max-width: 24px;
-      height: 24px;
+      width: 28px;
+      min-width: 28px;
+      max-width: 28px;
+      height: 28px;
       line-height: $line-height--lg;
       font-size: $font-size--sm;
       font-weight: 600;
-      margin: 10px;
       position: relative;
       display: inline-flex;
       align-items: center;
@@ -119,14 +164,6 @@
       display: flex;
       align-items: center;
       font-weight: 600;
-    }
-    &__divider {
-      flex-grow: 1;
-      border: 0px;
-      height: 1px;
-    }
-    &__title {
-      padding: 0 10px 0 0;
     }
     &__hint {
       color: map-get($grey, "darken-2");
@@ -150,15 +187,27 @@
     text-align: left;
     .a-step {
       display: flex;
-      &__divider {
-        display: none;
-      }
-      .a-step__icon {
-        flex: 1;
+      flex-direction: row;
+      max-width: 100%;
+      align-items: unset;
+
+      &__icon-container {
+        margin-top: 4px;
       }
       &__content {
         flex: 2;
         align-self: center;
+      }
+
+      &__title {
+        padding: 0 10px 0 0;
+      }
+
+      &__hint {
+        font-size: 12px;
+        line-height: 20px;
+        font-weight: 400;
+        padding-right: 24px;
       }
 
       &:last-child {

--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -348,14 +348,16 @@ $atomic-default: (
     "track-color": map-get($mds-neutral, "neutral-7")
   ),
   "steps": (
-    "step-main-color": map-get($mds-interactive, "interactive-8"),
+    "step-main-color": map-get($mds-light-theme, "status-info"),
     "step-active-color": map-get($mds-neutral, "neutral-1"),
-    "step-visited-title-color": map-get($mds-misc, "visited-blue"),
-    "step-icon-border-color": map-get($mds-interactive, "interactive-8"),
+    "step-visited-title-color": map-get($mds-neutral, "neutral-16"),
+    "step-icon-border-color": map-get($mds-interactive, "interactive-11"),
     "step-line-color": map-get($mds-interactive, "interactive-8"),
     "step-default-color": map-get($mds-neutral, "neutral-7"),
-    "step-icon-default-color": map-get($mds-neutral, "neutral-7"),
-    "step-icon-default-border-color": map-get($mds-neutral, "neutral-6")
+    "step-icon-default-color": map-get($mds-neutral, "neutral-12"),
+    "step-icon-default-border-color": map-get($mds-neutral, "neutral-4"),
+    "step-icon-disabled-color": map-get($mds-neutral, "neutral-6"),
+    "step-icon-disabled-border-color": map-get($mds-neutral, "neutral-4")
   ),
   "switch": (
     "bg": map-get($mds-neutral, "neutral-12"),

--- a/framework/styles/theme/dusk.scss
+++ b/framework/styles/theme/dusk.scss
@@ -353,8 +353,10 @@ $atomic-dusk: (
     "step-icon-border-color": map-get($mds-interactive, "interactive-6"),
     "step-line-color": map-get($mds-interactive, "interactive-6"),
     "step-default-color": map-get($mds-neutral, "neutral-7"),
-    "step-icon-default-color": map-get($mds-neutral, "neutral-9"),
-    "step-icon-default-border-color": map-get($mds-neutral, "neutral-16")
+    "step-icon-default-color": map-get($mds-neutral, "neutral-5"),
+    "step-icon-default-border-color": map-get($mds-neutral, "neutral-12"),
+    "step-icon-disabled-color": map-get($mds-neutral, "neutral-11"),
+    "step-icon-disabled-border-color": map-get($mds-neutral, "neutral-13")
   ),
   "switch": (
     "bg": map-get($mds-neutral, "neutral-6"),

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -42,3 +42,31 @@ export const useDelayUnmount = ({isEnabled = true, isOpen, delayTime}) => {
 
   return isEnabled ? shouldRender : isOpen;
 };
+
+export const useResizeObserver = (containerRef) => {
+  const [width, setWidth] = useState();
+  const [height, setHeight] = useState();
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+    const resizeObserver = new ResizeObserver(() => {
+      if (containerRef.current?.offsetWidth !== width) {
+        setWidth(containerRef.current.offsetWidth);
+      }
+      if (containerRef.current?.offsetHeight !== height) {
+        setHeight(containerRef.current.offsetHeight);
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+
+    return function cleanup() {
+      resizeObserver.disconnect();
+    };
+  }, [containerRef, width, height]);
+  return {
+    width,
+    height
+  };
+};


### PR DESCRIPTION
**Closes #480 - Updates to `AStepper` to magnetic design**  

The goal was to limit breaking changes to visual only which required some extra complexity. The benefit to this however is that no changes to props or functionality are introduced for developers.

**Updates include**
- Horizontal layout restructure
- Magnetic color/theme adjustments
- Vertical theme alignment and minor layout updates
- Icon size and checkmark updates

![Screenshot 2023-08-09 at 1 07 36 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/f16fcad9-9982-4c94-b814-f1fffcab9dcd)

![Screenshot 2023-08-09 at 1 07 59 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/576167dc-f1e1-4d19-ad8b-d1ed5b70cee6)


**Responsive**
Handles small mobile screen
![Screenshot 2023-08-09 at 12 49 55 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/8f5cc195-c392-4957-8373-5741edea1d36)


Handles unreasonably ultra wide screen
![Screenshot 2023-08-09 at 12 50 35 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/6f477c25-1170-4d80-8ed8-e8f2f0f8f140)

**In Modal**
![Screenshot 2023-08-09 at 12 53 58 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/abc8efcb-10c5-4a15-9578-48a400bfaf63)


Vertical style updates 
![Screenshot 2023-08-09 at 12 48 52 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/8503f4c7-9e78-41af-8e96-674e4c7fcb7c)
