### PR TITLE
fix: remove extra classname

### DIFF
--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -115,7 +115,7 @@ const ACheckbox = forwardRef(
     };
 
     let className = "a-checkbox",
-      boxClassName = `${className} a-checkbox__box `;
+      boxClassName = `${className}__box`;
 
     if (["danger", "warning"].includes(workingValidationState)) {
       className += ` a-checkbox--${workingValidationState}`;


### PR DESCRIPTION
Closes #488 

Before:
![Screenshot 2023-08-10 at 9 49 17 AM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/aee539fd-d93f-4436-9cf4-e9a22aa62b85)

After:
<img width="62" alt="Screenshot 2023-08-10 at 10 10 39 AM" src="https://github.com/cisco-sbg-ui/magna-react/assets/112431822/571f96ea-141b-46f6-a300-30293fc22bd0">

