### PR TITLE
feat: Add composable drawer components

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -221,15 +221,21 @@ ADrawer.propTypes = {
    */
   slimWidth: PropTypes.string,
   /**
+   * ***DEPRECATED*** (use same prop on ADrawerTitle)
+   *
    * Pass onClose handler for Drawer to handle onClose icon and action.
    * Default: x Icon
    */
   closeBtnOnClick: PropTypes.func,
   /**
+   * ***DEPRECATED*** (use same prop on ADrawerTitle)
+   *
    * Option for close button title instead of default icon
    */
   closeTitle: PropTypes.string,
   /**
+   * ***DEPRECATED*** (use same prop on ADrawerTitle)
+   *
    * Any additional props for close button
    */
   closeBtnProps: PropTypes.oneOfType([

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -23,9 +23,9 @@ const ADrawer = forwardRef(
       slim = false,
       slimHeight,
       slimWidth,
-      closeBtnOnClick,
-      closeTitle,
-      closeBtnProps,
+      closeBtnOnClick, //***DEPRECATED***
+      closeTitle, //***DEPRECATED***
+      closeBtnProps, //***DEPRECATED***
       style: propsStyle,
       withTransitions = true,
       ...rest

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -62,11 +62,19 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='left'
             ref={leftDrawerContentRef}
             isOpen={isLeftOpen}
-            closeBtnOnClick={() => setIsLeftOpen(false)}
             data-test-drawer-left>
-          <ADrawerContent>
-            <h3 id='left-drawer-title' className="mt-1">Left Drawer</h3> <ADivider /> <AButton onClick={() => setIsLeftOpen(false)} data-test-drawer-close-left>Close</AButton>
-          </ADrawerContent>
+          <ADrawerHeader>
+          <ADrawerTitle onCloseButtonClick={() => setIsLeftOpen(false)}>
+            <h1 id='left-drawer-title'>Left Drawer</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsLeftOpen(false)} data-test-drawer-close-left>Close</AButton>
+          </ADrawerFooter>
         </ADrawer>
 
         <p>Right slide-in</p>
@@ -76,11 +84,19 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
-            closeBtnOnClick={() => setIsRightOpen(false)}
             data-test-drawer-right>
-          <ADrawerContent>
-            <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
-          </ADrawerContent>
+           <ADrawerHeader>
+          <ADrawerTitle onCloseButtonClick={() => setIsRightOpen(false)}>
+            <h1 id='left-drawer-title'>Right Drawer</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerFooter>
         </ADrawer>
 
         <p>Bottom slide-in</p>
@@ -90,11 +106,19 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='bottom'
             ref={bottomDrawerContentRef}
             isOpen={isBottomOpen}
-            closeBtnOnClick={() => setIsBottomOpen(false)}
             data-test-drawer-bottom>
-          <ADrawerContent>
-            <h3 id='bottom-drawer-title' className="mt-1">Bottom Drawer</h3> <ADivider /> <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>
-          </ADrawerContent>
+          <ADrawerHeader>
+          <ADrawerTitle onCloseButtonClick={() => setIsBottomOpen(false)}>
+            <h1 id='left-drawer-title'>Bottom Drawer</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>
+          </ADrawerFooter>
         </ADrawer>
       </>
     )
@@ -125,11 +149,18 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
-            closeBtnOnClick={() => setIsRightOpen(false)}
             data-test-drawer-right>
-          <ADrawerContent>
-            <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
-          </ADrawerContent>
+           <ADrawerHeader>
+          <ADrawerTitle onCloseButtonClick={() => setIsRightOpen(false)}>
+            <h1 id='left-drawer-title'>Custom Width Drawer</h1>
+          </ADrawerTitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             This drawer has a custom width of 800px set.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerFooter>
         </ADrawer>
       </>
     )
@@ -255,15 +286,17 @@ To contain the drawer within something other than the viewport, you can render t
                   position='fixed'
                   ref={fixedDrawerRef}
                   isOpen={isFixedOpen}>
-                <ADrawerContent>
-                  <h3 id='left-drawer-title'>
-                    Fixed Drawer
-                  </h3>
-                  <ADivider />
+                <ADrawerHeader divider>
+                  <ADrawerTitle>
+                    <h1>Fixed Drawer</h1>
+                  </ADrawerTitle>
+                </ADrawerHeader>
+                <ADrawerBody />
+                <ADrawerFooter>
                   <AButton onClick={() => setIsFixedOpen(false)}>
                     Close
                   </AButton>
-                </ADrawerContent>
+                </ADrawerFooter>
               </ADrawer>
             </main>
         </div>
@@ -328,37 +361,33 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
             asModal={false}
             isOpen={nonModalOpen}
             slideIn='right'>
-          <MockDrawerContent
-              title='Non-Modal Drawer'
-              content='Focus is not trapped and scrolling is not locked.'
-              onClose={() => setNonModalOpen(false)} />
+          <div style={{
+            display: "flex",
+            flexDirection: "column",
+            height: "100%"
+          }}>
+            <MockDrawerContent
+                title='Non-Modal Drawer'
+                content='Focus is not trapped and scrolling is not locked.'
+                onClose={() => setNonModalOpen(false)} />
+          </div>
         </ADrawer>
       </>
     )
     function MockDrawerContent({ content, onClose, title }) {
       return (
         <>
-          <AListItem twoLine>
-            <AListItemContent>
-              <AListItemTitle><h4><b>{title}</b></h4></AListItemTitle>
-            </AListItemContent>
-            <AListItemAction>
-              <AButton onClick={onClose} tertiaryAlt icon>
-                <AIcon>close</AIcon>
-              </AButton>
-            </AListItemAction>
-          </AListItem>
-          <AListItem twoLine>
-            <AListItemContent style={{paddingTop: '0'}}>
-              {content}
-            </AListItemContent>
-          </AListItem>
-          <div style={{width: '100%', position: 'absolute', bottom: '0', height: '50px'}}>
-            <ADivider style={{margin: 0}} />
-            <AListItem twoLine>
-              <AListItemContent><AButton>Footer Content</AButton></AListItemContent>
-            </AListItem>
-          </div>
+          <ADrawerHeader divider>
+            <ADrawerTitle onCloseButtonClick={onClose}>
+              <h1>{title}</h1>
+            </ADrawerTitle>
+          </ADrawerHeader>
+          <ADrawerBody>{content}</ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={onClose}>
+              Close
+            </AButton>
+          </ADrawerFooter>
         </>
       )
     }
@@ -388,7 +417,7 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
         <ADrawer
             aria-label='Application toolbar.'
             ref={toolbarRef}
-            slimWidth='75px'
+            slimWidth='70px'
             openWidth='250px'
             isOpen={isOpen}
             slim={isSlim}>
@@ -577,7 +606,7 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
 
     return (
       <>
-        <p>Right slide-in</p>
+        <p>Right without slide-in</p>
         <AButton onClick={() => setIsRightOpen(true)} data-test-drawer-trigger-right>Open Right</AButton>
         <ADrawer
             withTransitions={false}
@@ -585,11 +614,18 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
-            closeBtnOnClick={() => setIsRightOpen(false)}
             data-test-drawer-right>
-          <ADrawerContent>
-            <h3 id='right-drawer-title' className="mt-1">Right Drawer </h3> <ADivider /> <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
-          </ADrawerContent>
+          <ADrawerHeader>
+            <ADrawerTitle onCloseButtonClick={() => setIsRightOpen(false)}>
+              <h1 id='left-drawer-title'>No Slide</h1>
+            </ADrawerTitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             This drawer had no animation
+            </ADrawerBody>
+          <ADrawerFooter divider>
+            <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerFooter>
         </ADrawer>
       </>
     )
@@ -604,3 +640,23 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
 ## Accessibility Notes
 
 By default, `ADrawer` renders as a modal. To override this behavior, pass `ADrawer` the `asModal` prop value of `false`. For documentation on modals, reference the [`AModal` documentation](/components/modal).
+
+## Drawer Header Props
+
+<Props of="ADrawerHeader" />
+
+## Drawer Title Props
+
+<Props of="ADrawerTitle" />
+
+## Drawer Subtitle Props
+
+<Props of="ADrawerSubtitle" />
+
+## Drawer Body Props
+
+<Props of="ADrawerBody" />
+
+## Drawer Footer Props
+
+<Props of="ADrawerFooter" />

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -20,6 +20,12 @@ $common-transitions: transform $transition-props, width $transition-props,
   &--modal {
     top: unset;
     left: unset;
+
+    > div {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
   }
 
   &--transitions {

--- a/framework/components/ADrawer/ADrawerBody.js
+++ b/framework/components/ADrawer/ADrawerBody.js
@@ -1,0 +1,37 @@
+import React, {forwardRef} from "react";
+import PropTypes from "prop-types";
+
+import ADrawerContent from "./ADrawerContent";
+import "./ADrawerBody.scss";
+
+/**
+ * The area for the drawer's main content.
+ */
+const ADrawerBody = forwardRef(
+  ({children, className: propsClassName, ...rest}, ref) => {
+    let className = "a-drawer__body";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return (
+      <div ref={ref} className={className} {...rest}>
+        <ADrawerContent>{children}</ADrawerContent>
+      </div>
+    );
+  }
+);
+
+ADrawerBody.propTypes = {
+  /**
+   * String representing class names to be passed to drawer content container.
+   * If rendering the drawer as a modal, it will still be passed to the drawer
+   * panel content element.
+   */
+  className: PropTypes.string
+};
+
+ADrawerBody.displayName = "ADrawerBody";
+
+export default ADrawerBody;

--- a/framework/components/ADrawer/ADrawerBody.js
+++ b/framework/components/ADrawer/ADrawerBody.js
@@ -8,10 +8,7 @@ import "./ADrawerBody.scss";
  * The area for the drawer's main content.
  */
 const ADrawerBody = forwardRef(
-  (
-    {children, className: propsClassName, wrapChildren = true, ...rest},
-    ref
-  ) => {
+  ({children, className: propsClassName, withPadding = true, ...rest}, ref) => {
     let className = "a-drawer__body";
 
     if (propsClassName) {
@@ -20,7 +17,7 @@ const ADrawerBody = forwardRef(
 
     return (
       <div ref={ref} className={className} {...rest}>
-        {wrapChildren ? <ADrawerContent>{children}</ADrawerContent> : children}
+        {withPadding ? <ADrawerContent>{children}</ADrawerContent> : children}
       </div>
     );
   }
@@ -36,7 +33,7 @@ ADrawerBody.propTypes = {
   /**
    * Wrap the component children in an ADrawerContent element
    */
-  wrapChildren: PropTypes.bool
+  withPadding: PropTypes.bool
 };
 
 ADrawerBody.displayName = "ADrawerBody";

--- a/framework/components/ADrawer/ADrawerBody.js
+++ b/framework/components/ADrawer/ADrawerBody.js
@@ -8,7 +8,10 @@ import "./ADrawerBody.scss";
  * The area for the drawer's main content.
  */
 const ADrawerBody = forwardRef(
-  ({children, className: propsClassName, ...rest}, ref) => {
+  (
+    {children, className: propsClassName, wrapChildren = true, ...rest},
+    ref
+  ) => {
     let className = "a-drawer__body";
 
     if (propsClassName) {
@@ -17,7 +20,7 @@ const ADrawerBody = forwardRef(
 
     return (
       <div ref={ref} className={className} {...rest}>
-        <ADrawerContent>{children}</ADrawerContent>
+        {wrapChildren ? <ADrawerContent>{children}</ADrawerContent> : children}
       </div>
     );
   }
@@ -29,7 +32,11 @@ ADrawerBody.propTypes = {
    * If rendering the drawer as a modal, it will still be passed to the drawer
    * panel content element.
    */
-  className: PropTypes.string
+  className: PropTypes.string,
+  /**
+   * Wrap the component children in an ADrawerContent element
+   */
+  wrapChildren: PropTypes.bool
 };
 
 ADrawerBody.displayName = "ADrawerBody";

--- a/framework/components/ADrawer/ADrawerBody.scss
+++ b/framework/components/ADrawer/ADrawerBody.scss
@@ -1,0 +1,4 @@
+.a-drawer__body {
+  flex-grow: 1;
+  overflow-y: auto;
+}

--- a/framework/components/ADrawer/ADrawerFooter.js
+++ b/framework/components/ADrawer/ADrawerFooter.js
@@ -14,7 +14,7 @@ const ADrawerFooter = forwardRef(
       children,
       className: propsClassName,
       variant = "shadow",
-      wrapChildren = true,
+      withPadding = true,
       ...rest
     },
     ref
@@ -39,7 +39,7 @@ const ADrawerFooter = forwardRef(
     return (
       <div {...rest} ref={ref} className={className}>
         {divider}
-        {wrapChildren ? <ADrawerContent>{children}</ADrawerContent> : children}
+        {withPadding ? <ADrawerContent>{children}</ADrawerContent> : children}
       </div>
     );
   }
@@ -59,7 +59,7 @@ ADrawerFooter.propTypes = {
   /**
    * Wrap the component children in an ADrawerContent element
    */
-  wrapChildren: PropTypes.bool
+  withPadding: PropTypes.bool
 };
 
 ADrawerFooter.displayName = "ADrawerFooter";

--- a/framework/components/ADrawer/ADrawerFooter.js
+++ b/framework/components/ADrawer/ADrawerFooter.js
@@ -1,0 +1,47 @@
+import React, {forwardRef} from "react";
+import PropTypes from "prop-types";
+
+import ADivider from "../ADivider/ADivider";
+import ADrawerContent from "./ADrawerContent";
+import "./ADrawerFooter.scss";
+
+/**
+ * The area displayed at the bottom of the drawer.
+ */
+const ADrawerFooter = forwardRef(
+  ({children, className: propsClassName, divider, ...rest}, ref) => {
+    let className = "a-drawer__footer";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    if (divider) {
+      className += ` a-drawer__footer--hasDivider`;
+    }
+
+    return (
+      <div {...rest} ref={ref} className={className}>
+        {divider && <ADivider />}
+        <ADrawerContent>{children}</ADrawerContent>
+      </div>
+    );
+  }
+);
+
+ADrawerFooter.propTypes = {
+  /**
+   * String representing class names to be passed to drawer content container.
+   * If rendering the drawer as a modal, it will still be passed to the drawer
+   * panel content element.
+   */
+  className: PropTypes.string,
+  /**
+   * Replace the default box shadow with an ADivider above the footer
+   */
+  divider: PropTypes.bool
+};
+
+ADrawerFooter.displayName = "ADrawerFooter";
+
+export default ADrawerFooter;

--- a/framework/components/ADrawer/ADrawerFooter.js
+++ b/framework/components/ADrawer/ADrawerFooter.js
@@ -9,21 +9,37 @@ import "./ADrawerFooter.scss";
  * The area displayed at the bottom of the drawer.
  */
 const ADrawerFooter = forwardRef(
-  ({children, className: propsClassName, divider, ...rest}, ref) => {
+  (
+    {
+      children,
+      className: propsClassName,
+      variant = "shadow",
+      wrapChildren = true,
+      ...rest
+    },
+    ref
+  ) => {
     let className = "a-drawer__footer";
+    let divider;
 
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
 
-    if (divider) {
-      className += ` a-drawer__footer--hasDivider`;
+    switch (variant) {
+      case "shadow":
+        break;
+      case "divider":
+        className += ` a-drawer__footer--hasDivider`;
+
+        divider = <ADivider />;
+        break;
     }
 
     return (
       <div {...rest} ref={ref} className={className}>
-        {divider && <ADivider />}
-        <ADrawerContent>{children}</ADrawerContent>
+        {divider}
+        {wrapChildren ? <ADrawerContent>{children}</ADrawerContent> : children}
       </div>
     );
   }
@@ -39,7 +55,11 @@ ADrawerFooter.propTypes = {
   /**
    * Replace the default box shadow with an ADivider above the footer
    */
-  divider: PropTypes.bool
+  variant: PropTypes.oneOf(["shadow", "divider"]),
+  /**
+   * Wrap the component children in an ADrawerContent element
+   */
+  wrapChildren: PropTypes.bool
 };
 
 ADrawerFooter.displayName = "ADrawerFooter";

--- a/framework/components/ADrawer/ADrawerFooter.scss
+++ b/framework/components/ADrawer/ADrawerFooter.scss
@@ -7,6 +7,7 @@
 .a-drawer__footer {
   position: sticky;
   bottom: 0;
+  margin-top: auto;
   box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.12);
   border-top-left-radius: $border-radius--lg;
   border-top-right-radius: $border-radius--lg;

--- a/framework/components/ADrawer/ADrawerFooter.scss
+++ b/framework/components/ADrawer/ADrawerFooter.scss
@@ -1,0 +1,31 @@
+@import "../../styles";
+
+@include theme(a-drawer__footer) using ($theme) {
+  border-color: map-deep-get($theme, "menu", "border-color");
+}
+
+.a-drawer__footer {
+  position: sticky;
+  bottom: 0;
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.12);
+  border-top-left-radius: $border-radius--lg;
+  border-top-right-radius: $border-radius--lg;
+
+  .a-drawer__content {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &-action {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .a-divider {
+    margin: 0;
+  }
+
+  &--hasDivider {
+    box-shadow: none;
+  }
+}

--- a/framework/components/ADrawer/ADrawerHeader.js
+++ b/framework/components/ADrawer/ADrawerHeader.js
@@ -1,0 +1,44 @@
+import React, {forwardRef} from "react";
+import PropTypes from "prop-types";
+
+import ADivider from "../ADivider/ADivider";
+import "./ADrawerHeader.scss";
+
+/**
+ * The area displayed at the top of the drawer.
+ */
+const ADrawerHeader = forwardRef(
+  ({children, className: propsClassName, divider, ...rest}, ref) => {
+    let className = "a-drawer__header";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return (
+      <>
+        <div ref={ref} className={className} {...rest}>
+          {children}
+        </div>
+        {divider && <ADivider />}
+      </>
+    );
+  }
+);
+
+ADrawerHeader.propTypes = {
+  /**
+   * String representing class names to be passed to drawer content container.
+   * If rendering the drawer as a modal, it will still be passed to the drawer
+   * panel content element.
+   */
+  className: PropTypes.string,
+  /**
+   * Adds a divider below the header content
+   */
+  divider: PropTypes.bool
+};
+
+ADrawerHeader.displayName = "ADrawerHeader";
+
+export default ADrawerHeader;

--- a/framework/components/ADrawer/ADrawerHeader.scss
+++ b/framework/components/ADrawer/ADrawerHeader.scss
@@ -1,0 +1,3 @@
+.a-drawer__header {
+  padding: 16px 24px 0 24px;
+}

--- a/framework/components/ADrawer/ADrawerSubtitle.js
+++ b/framework/components/ADrawer/ADrawerSubtitle.js
@@ -1,0 +1,36 @@
+import React, {forwardRef} from "react";
+import PropTypes from "prop-types";
+
+import "./ADrawerSubtitle.scss";
+
+/**
+ * The area displayed at the top of the drawer underneath the title.
+ */
+const ADrawerSubtitle = forwardRef(
+  ({children, className: propsClassName, ...rest}, ref) => {
+    let className = "a-drawer__subtitle";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return (
+      <div className={className} ref={ref} {...rest}>
+        {children}
+      </div>
+    );
+  }
+);
+
+ADrawerSubtitle.propTypes = {
+  /**
+   * String representing class names to be passed to drawer content container.
+   * If rendering the drawer as a modal, it will still be passed to the drawer
+   * panel content element.
+   */
+  className: PropTypes.string
+};
+
+ADrawerSubtitle.displayName = "ADrawerSubtitle";
+
+export default ADrawerSubtitle;

--- a/framework/components/ADrawer/ADrawerSubtitle.scss
+++ b/framework/components/ADrawer/ADrawerSubtitle.scss
@@ -1,0 +1,4 @@
+.a-drawer__subtitle {
+  font-weight: 400;
+  line-height: 20px;
+}

--- a/framework/components/ADrawer/ADrawerTitle.js
+++ b/framework/components/ADrawer/ADrawerTitle.js
@@ -1,0 +1,81 @@
+import React, {forwardRef} from "react";
+import PropTypes from "prop-types";
+
+import AButton from "../AButton/AButton";
+import AIcon from "../AIcon/AIcon";
+import "./ADrawerTitle.scss";
+
+/**
+ * The area displayed at the top of the drawer containing a title and close button.
+ */
+const ADrawerTitle = forwardRef(
+  (
+    {
+      children,
+      className: propsClassName,
+      sticky,
+      onCloseButtonClick,
+      closeTitle,
+      closeBtnProps,
+      ...rest
+    },
+    ref
+  ) => {
+    let className = "a-drawer__title";
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    return (
+      <div className={className} ref={ref} {...rest}>
+        <div className="a-drawer__title-content">{children}</div>
+        <div className="a-drawer__title-close">
+          {onCloseButtonClick && (
+            <AButton
+              icon
+              tertiaryAlt
+              onClick={() => onCloseButtonClick && onCloseButtonClick(false)}
+              {...closeBtnProps}
+            >
+              {closeTitle ? (
+                <div className="pa-2">{closeTitle}</div>
+              ) : (
+                <AIcon>close</AIcon>
+              )}
+            </AButton>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+ADrawerTitle.propTypes = {
+  /**
+   * String representing class names to be passed to drawer content container.
+   * If rendering the drawer as a modal, it will still be passed to the drawer
+   * panel content element.
+   */
+  className: PropTypes.string,
+  /**
+   * Pass onClose handler for Drawer to handle onClose icon and action.
+   * Default: x Icon
+   */
+  closeBtnOnClick: PropTypes.func,
+  /**
+   * Option for close button title instead of default icon
+   */
+  closeTitle: PropTypes.string,
+  /**
+   * Any additional props for close button
+   */
+  closeBtnProps: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.arrayOf(PropTypes.object)
+  ])
+};
+
+ADrawerTitle.displayName = "ADrawerTitle";
+
+export default ADrawerTitle;

--- a/framework/components/ADrawer/ADrawerTitle.scss
+++ b/framework/components/ADrawer/ADrawerTitle.scss
@@ -1,0 +1,9 @@
+.a-drawer__title {
+  display: flex;
+  align-items: center;
+
+  .a-drawer__title-content {
+    flex: 1 1 auto;
+    word-break: break-all;
+  }
+}

--- a/framework/components/ADrawer/index.js
+++ b/framework/components/ADrawer/index.js
@@ -1,4 +1,17 @@
 import ADrawer from "./ADrawer";
+import ADrawerBody from "./ADrawerBody";
 import ADrawerContent from "./ADrawerContent";
+import ADrawerHeader from "./ADrawerHeader";
+import ADrawerFooter from "./ADrawerFooter";
+import ADrawerSubtitle from "./ADrawerSubtitle";
+import ADrawerTitle from "./ADrawerTitle";
 
-export {ADrawer, ADrawerContent};
+export {
+  ADrawer,
+  ADrawerBody,
+  ADrawerContent,
+  ADrawerHeader,
+  ADrawerFooter,
+  ADrawerSubtitle,
+  ADrawerTitle
+};

--- a/framework/index.js
+++ b/framework/index.js
@@ -36,7 +36,15 @@ import {
 } from "./components/ADatePicker";
 import ADialog from "./components/ADialog";
 import ADivider from "./components/ADivider";
-import {ADrawer, ADrawerContent} from "./components/ADrawer";
+import {
+  ADrawer,
+  ADrawerBody,
+  ADrawerContent,
+  ADrawerHeader,
+  ADrawerFooter,
+  ADrawerSubtitle,
+  ADrawerTitle
+} from "./components/ADrawer";
 import AEmptyState from "./components/AEmptyState";
 import AFieldBase from "./components/AFieldBase";
 import {AFooter, AFooterLegal} from "./components/AFooter";
@@ -162,7 +170,12 @@ export {
   ADivider,
   ADotLoader,
   ADrawer,
+  ADrawerBody,
   ADrawerContent,
+  ADrawerHeader,
+  ADrawerFooter,
+  ADrawerSubtitle,
+  ADrawerTitle,
   AEmptyState,
   AFieldBase,
   AFooter,


### PR DESCRIPTION
Resolves #304

Adds composable components for `ADrawer`

- ADrawerHeader
- ADrawerTitle
- ADrawerSubtitle
- ADrawerBody
- ADrawerFooter

Issues resolved:

- auto content scrolling
- title text won't overlap close X button
- footer defaults to box shadow as per design, but has a `divider` option to swap back to the current style

@sabrinamokerji fyi