### PR TITLE
ADataTable arrow up/down keys support

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -70,12 +70,12 @@ Cypress.Commands.add("getByAriaLabel", (label) => {
 });
 
 const keydownUtils = [
-  {keyCode: keyCodes.esc, name: "escapeKeydown"},
-  {keyCode: keyCodes.enter, name: "enterKeydown"},
-  {keyCode: keyCodes.space, name: "spaceKeydown"},
-  {keyCode: keyCodes.down, name: "downArrowKeydown"},
-  {keyCode: keyCodes.up, name: "upArrowKeydown"},
-  {keyCode: keyCodes.tab, name: "tabKeydown"}
+  {key: "Escape", keyCode: keyCodes.esc, name: "escapeKeydown"},
+  {key: "Enter", keyCode: keyCodes.enter, name: "enterKeydown"},
+  {key: " ", keyCode: keyCodes.space, name: "spaceKeydown"},
+  {key: "ArrowDown", keyCode: keyCodes.down, name: "downArrowKeydown"},
+  {key: "ArrowUp", keyCode: keyCodes.up, name: "upArrowKeydown"},
+  {key: "Tab", keyCode: keyCodes.tab, name: "tabKeydown"}
 ];
 
 /**
@@ -85,15 +85,15 @@ const keydownUtils = [
  * @example
  * `cy.trigger("keydown", {keyCode: 13})` can be invoked as `cy.escapeKeydown()`
  */
-keydownUtils.forEach(({keyCode, name}) => {
+keydownUtils.forEach(({key, keyCode, name}) => {
   Cypress.Commands.add(name, {prevSubject: "optional"}, (subject) => {
     if (subject) {
       return cy
         .wrap(subject)
-        .trigger("keydown", {keyCode})
+        .trigger("keydown", {key, keyCode})
         .then(() => subject);
     } else {
-      return cy.get("body").trigger("keydown", {keyCode});
+      return cy.get("body").trigger("keydown", {key, keyCode});
     }
   });
 });

--- a/framework/components/ADataTable/ADataTable.cy.js
+++ b/framework/components/ADataTable/ADataTable.cy.js
@@ -195,5 +195,61 @@ describe("ADataTable", async () => {
         expect(onKeyboardSelectStub.callCount).to.eq(1);
       });
     });
+
+    it("lost focus when clicking outside of the table", () => {
+      const onKeyboardSelectStub = cy.stub();
+
+      cy.mount(
+        <div style={{height: "500px"}}>
+          <ADataTable
+            headers={HEADERS}
+            items={ITEMS}
+            keyboardArrowSupport={{
+              onKeyboardSelect: onKeyboardSelectStub,
+              initiallySelectedRowIndex: 1
+            }}
+          />
+        </div>
+      );
+
+      cy.get("body")
+        .click(0, 499) // 3 rows table + header has 167px height
+        .then(() => {
+          cy.get("table tbody tr").should(
+            "not.have.class",
+            "a-data-table__row--key-selected"
+          );
+          expect(onKeyboardSelectStub.callCount).to.eq(1);
+          expect(onKeyboardSelectStub).to.be.calledWith({
+            index: -1,
+            item: undefined
+          });
+        });
+    });
+
+    it("keeps focus when clicking outside of the table when loosing focus is disabled by disableOnBlurReset param", () => {
+      cy.mount(
+        <div style={{height: "500px"}}>
+          <ADataTable
+            headers={HEADERS}
+            items={ITEMS}
+            keyboardArrowSupport={{
+              onKeyboardSelect: cy.stub(),
+              initiallySelectedRowIndex: 1,
+              disableOnBlurReset: true
+            }}
+          />
+        </div>
+      );
+
+      cy.get("body")
+        .click(0, 499) // 3 rows table + header has 167px height
+        .then(() => {
+          cy.get("table tbody tr").should(
+            "have.class",
+            "a-data-table__row--key-selected"
+          );
+        });
+    });
   });
 });

--- a/framework/components/ADataTable/ADataTable.cy.js
+++ b/framework/components/ADataTable/ADataTable.cy.js
@@ -1,0 +1,199 @@
+import ADataTable from "../ADataTable/ADataTable";
+
+const HEADERS = [
+  {
+    name: "Alpha",
+    key: "a"
+  },
+  {
+    name: "Bravo",
+    key: "b",
+    cell: {
+      component: (item) => {
+        return <input type="text" value={item.b} />;
+      }
+    }
+  }
+];
+
+const ITEMS = [
+  {
+    a: 1428627663,
+    b: "India"
+  },
+  {
+    a: 1425671352,
+    b: "China"
+  },
+  {
+    a: 339996563,
+    b: "United States"
+  }
+];
+
+describe("ADataTable", async () => {
+  describe("keyboardArrowSupport", () => {
+    it("selects first line with arrow down and assign key-selected class to it", () => {
+      const onKeyboardSelectStub = cy.stub();
+
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: onKeyboardSelectStub
+          }}
+        />
+      );
+
+      cy.downArrowKeydown().then(() => {
+        expect(onKeyboardSelectStub.callCount).to.eq(1);
+        expect(onKeyboardSelectStub).to.be.calledWith({
+          index: 0,
+          item: ITEMS[0]
+        });
+        cy.get("table tbody tr:first").should(
+          "have.class",
+          "a-data-table__row--key-selected"
+        );
+      });
+    });
+
+    it("selects last line with arrow up and assign key-selected class to it", () => {
+      const onKeyboardSelectStub = cy.stub();
+
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: onKeyboardSelectStub
+          }}
+        />
+      );
+
+      cy.upArrowKeydown().then(() => {
+        expect(onKeyboardSelectStub.callCount).to.eq(1);
+        expect(onKeyboardSelectStub).to.be.calledWith({
+          index: 2,
+          item: ITEMS[2]
+        });
+        cy.get("table tbody tr:last").should(
+          "have.class",
+          "a-data-table__row--key-selected"
+        );
+      });
+    });
+
+    it("moves to second element after second arrow down click", () => {
+      const onKeyboardSelectStub = cy.stub();
+
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: onKeyboardSelectStub
+          }}
+        />
+      );
+
+      cy.downArrowKeydown().then(() => {
+        expect(onKeyboardSelectStub.callCount).to.eq(1);
+      });
+
+      cy.downArrowKeydown().then(() => {
+        expect(onKeyboardSelectStub.callCount).to.eq(2);
+        expect(onKeyboardSelectStub.getCall(0)).to.be.calledWith({
+          index: 0,
+          item: ITEMS[0]
+        });
+        expect(onKeyboardSelectStub.getCall(1)).to.be.calledWith({
+          index: 1,
+          item: ITEMS[1]
+        });
+        cy.get("table tbody tr:nth-child(2)").should(
+          "have.class",
+          "a-data-table__row--key-selected"
+        );
+      });
+    });
+
+    it("focus fist row after arrow down", () => {
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: cy.stub()
+          }}
+        />
+      );
+
+      cy.downArrowKeydown().then(() => {
+        cy.focused().should("have.attr", "row-index", "0");
+      });
+    });
+
+    it("focus fist row input element after arrow down", () => {
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: cy.stub(),
+            activeRowFocusSelector: "input"
+          }}
+        />
+      );
+
+      cy.downArrowKeydown().then(() => {
+        cy.focused().should("have.value", ITEMS[0].b);
+      });
+    });
+
+    it("selects second row initially after initiallySelectedRowIndex=1", () => {
+      const onKeyboardSelectStub = cy.stub();
+
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: onKeyboardSelectStub,
+            initiallySelectedRowIndex: 1
+          }}
+        />
+      );
+
+      cy.get("table tbody tr:nth-child(2)").should(
+        "have.class",
+        "a-data-table__row--key-selected"
+      );
+      expect(onKeyboardSelectStub.callCount).to.eq(0);
+    });
+
+    it("selects third row after page down and initiallySelectedRowIndex=1", () => {
+      const onKeyboardSelectStub = cy.stub();
+
+      cy.mount(
+        <ADataTable
+          headers={HEADERS}
+          items={ITEMS}
+          keyboardArrowSupport={{
+            onKeyboardSelect: onKeyboardSelectStub,
+            initiallySelectedRowIndex: 1
+          }}
+        />
+      );
+
+      cy.downArrowKeydown().then(() => {
+        cy.get("table tbody tr:last").should(
+          "have.class",
+          "a-data-table__row--key-selected"
+        );
+        expect(onKeyboardSelectStub.callCount).to.eq(1);
+      });
+    });
+  });
+});

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -171,6 +171,31 @@ const ADataTable = forwardRef(
       ]
     );
 
+    const onTableBlur = useCallback(
+      (event) => {
+        if (keyboardArrowSupport?.disableOnBlurReset) return;
+
+        const isEventsInTable = event.currentTarget.contains(
+          event.relatedTarget
+        );
+        if (!isEventsInTable) {
+          setSelectedRowIndex(-1);
+          if (typeof keyboardArrowSupport?.onKeyboardSelect === "function") {
+            keyboardArrowSupport?.onKeyboardSelect(
+              {index: -1, item: undefined},
+              event
+            );
+          }
+        }
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [
+        setSelectedRowIndex,
+        keyboardArrowSupport?.disableOnBlurReset,
+        keyboardArrowSupport?.onKeyboardSelect
+      ]
+    );
+
     useEffect(() => {
       if (keyboardArrowSupport === null || selectedRowIndex === -1) return;
 
@@ -290,7 +315,12 @@ const ADataTable = forwardRef(
           shouldWrap={typeof onScrollToEnd === "function" || maxHeight}
           maxHeight={maxHeight}
         >
-          <ASimpleTable {...rest} ref={combinedTableRef} className={className}>
+          <ASimpleTable
+            {...rest}
+            ref={combinedTableRef}
+            className={className}
+            onBlur={onTableBlur}
+          >
             {headers && (
               <thead>
                 <TableRow
@@ -671,6 +701,11 @@ ADataTable.propTypes = {
      * is focused by default. This option can turn focus off.
      */
     disableRowAutoFocus: PropTypes.bool,
+
+    /**
+     * Disable resetting selection and positon in table when table component looses focus.
+     */
+    disableOnBlurReset: PropTypes.bool,
 
     /**
      * When this selector is provided we try to focus element by `css` selector in active row.

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -250,25 +250,38 @@ const ADataTable = forwardRef(
       [setExpandedRows]
     );
 
-    const sortedItems = useMemo(() => [...items], [items], sort);
-    if (sort) {
-      const sortDir = sort.direction === "desc" ? -1 : 1;
-      const targetHeader = Object.values(headers).find(
-        (x) => x.key === sort.key
-      );
+    const sortedItems = useMemo(() => {
+      if (sort) {
+        const sortDirection = sort.direction === "desc" ? -1 : 1;
+        const sortKey = sort.key;
 
-      let sortFunc = (a, b) => (a === b ? 0 : a < b ? -1 : 1);
-
-      if (targetHeader && typeof targetHeader.sort === "function") {
-        sortFunc = targetHeader.sort;
-      }
-
-      if (!targetHeader || targetHeader.sort !== false) {
-        sortedItems.sort(
-          (a, b) => sortDir * sortFunc(a[sort.key], b[sort.key])
+        const sortingHeader = Object.values(headers).find(
+          (header) => header.key === sortKey
         );
+        let sortFunc = (a, b) => (a === b ? 0 : a < b ? -1 : 1);
+        if (sortingHeader && typeof sortingHeader.sort === "function") {
+          sortFunc = sortingHeader.sort;
+        }
+
+        if (!sortingHeader || sortingHeader.sort !== false) {
+          return items.toSorted(
+            (a, b) => sortDirection * sortFunc(a[sortKey], b[sortKey])
+          );
+        }
       }
-    }
+
+      return [...items];
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+      sort,
+      items,
+      // Optimize headers deps to compare only used properties because "headers" array reference will be probably changed every re-render.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      ...headers.map((header) => header.key),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      ...headers.map((header) => header.sort)
+    ]);
+
     return (
       headers &&
       items && (

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -1,13 +1,26 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useMemo, useRef, useCallback, useState} from "react";
+import React, {
+  forwardRef,
+  useMemo,
+  useRef,
+  useCallback,
+  useState,
+  useEffect
+} from "react";
 
 import {keyCodes} from "../../utils/helpers";
+import {useKeydown} from "../../index";
 
 import AInView from "../AInView";
 import AIcon from "../AIcon";
 import ASimpleTable from "../ASimpleTable";
 import {ASkeleton, ASkeletonText} from "../ASkeleton";
 import "./ADataTable.scss";
+import {useCombinedRefs} from "../../utils/hooks";
+
+const ARROW_UP = "ArrowUp";
+const ARROW_DOWN = "ArrowDown";
+const ARROW_KEYS = [ARROW_UP, ARROW_DOWN];
 
 /**
  * Used inside ADataTable to enable proper styling
@@ -16,7 +29,7 @@ import "./ADataTable.scss";
 const ADataTableWrapper = React.forwardRef(
   ({shouldWrap, maxHeight, style, children, ...rest}, ref) => {
     if (!shouldWrap) {
-      return children;
+      return children; // TODO: ref is lost ?
     }
 
     return (
@@ -50,10 +63,13 @@ const TableHeader = React.forwardRef(({className, ...rest}, ref) => {
 TableHeader.displayName = "TableHeader";
 
 const TableRow = React.forwardRef(
-  ({className: propsClassName, isSelected, ...rest}, ref) => {
+  ({className: propsClassName, isKeySelected, isSelected, ...rest}, ref) => {
     let className = "a-data-table__row";
     if (isSelected) {
       className += " a-data-table__row--selected";
+    }
+    if (isKeySelected) {
+      className += " a-data-table__row--key-selected";
     }
     if (propsClassName) {
       className += ` ${propsClassName}`;
@@ -106,12 +122,107 @@ const ADataTable = forwardRef(
       selectedItems,
       truncateHeaders,
       stickyHeader = false,
+      keyboardArrowSupport = null,
       ...rest
     },
     ref
   ) => {
     const tableWrapperRef = useRef();
+    const simpleTableRef = useRef();
+    const combinedTableRef = useCombinedRefs(simpleTableRef, ref);
     const [expandedRows, setExpandedRows] = useState({});
+    const [selectedRowIndex, setSelectedRowIndex] = useState(-1); // zero based index in items array, -1 for no index
+
+    const handleArrowKeydown = useCallback(
+      (key, event) => {
+        let nextRowIndex;
+
+        if (selectedRowIndex === -1) {
+          // first move
+          if (key === ARROW_UP) nextRowIndex = items.length - 1;
+          else nextRowIndex = 0;
+        } else {
+          // subsequent moves
+          if (key === ARROW_UP) nextRowIndex = selectedRowIndex - 1;
+          else nextRowIndex = selectedRowIndex + 1;
+        }
+
+        if (items[nextRowIndex] === undefined) {
+          // out of items index
+          return;
+        }
+
+        setSelectedRowIndex(nextRowIndex);
+
+        if (typeof keyboardArrowSupport?.onKeyboardSelect === "function") {
+          keyboardArrowSupport?.onKeyboardSelect(
+            {index: nextRowIndex, item: items[nextRowIndex]},
+            event
+          );
+        }
+      },
+      // having keyboardArrowSupport in deps causes unnecessary re-renders
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [
+        items,
+        selectedRowIndex,
+        setSelectedRowIndex,
+        keyboardArrowSupport?.onKeyboardSelect
+      ]
+    );
+
+    useEffect(() => {
+      if (keyboardArrowSupport === null || selectedRowIndex === -1) return;
+
+      const {
+        disableRowAutoFocus,
+        activeRowFocusSelector,
+        overrideFocusOptions = {}
+      } = keyboardArrowSupport;
+
+      if (disableRowAutoFocus) return;
+
+      const row = combinedTableRef.current?.querySelector(
+        `[row-index="${selectedRowIndex}"]`
+      );
+      if (!row) return;
+
+      if (activeRowFocusSelector) {
+        const element = row.querySelector(activeRowFocusSelector);
+        if (element && element.focus) {
+          element.focus(overrideFocusOptions);
+        }
+      } else {
+        row.focus(overrideFocusOptions);
+      }
+      // combinedTableRef should not need to be in deps
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+      keyboardArrowSupport?.disableRowAutoFocus,
+      keyboardArrowSupport?.activeRowFocusSelector,
+      keyboardArrowSupport?.overrideFocusOptions,
+      selectedRowIndex
+    ]);
+
+    useEffect(() => {
+      if (keyboardArrowSupport === null) return;
+
+      const index = keyboardArrowSupport.initiallySelectedRowIndex;
+      if (typeof index === "number" && items[index]) {
+        setSelectedRowIndex(index);
+      } else {
+        setSelectedRowIndex(-1);
+      }
+      // having keyboardArrowSupport in deps causes unnecessary re-renders
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+      keyboardArrowSupport?.initiallySelectedRowIndex,
+      setSelectedRowIndex,
+      items
+    ]);
+
+    useKeydown(ARROW_KEYS, handleArrowKeydown, keyboardArrowSupport !== null);
+
     const ExpandableComponent = useMemo(
       () => expandable?.component,
       [expandable]
@@ -166,7 +277,7 @@ const ADataTable = forwardRef(
           shouldWrap={typeof onScrollToEnd === "function" || maxHeight}
           maxHeight={maxHeight}
         >
-          <ASimpleTable {...rest} ref={ref} className={className}>
+          <ASimpleTable {...rest} ref={combinedTableRef} className={className}>
             {headers && (
               <thead>
                 <TableRow
@@ -292,7 +403,7 @@ const ADataTable = forwardRef(
                         }}
                       >
                         <div className="a-data-table__header__sort-wrap">
-                          {x.align == "end" && sortIcon}
+                          {x.align === "end" && sortIcon}
                           <button
                             {...sortableBtnProps}
                             tabIndex={-1}
@@ -317,7 +428,7 @@ const ADataTable = forwardRef(
               {sortedItems.map((rowItem, i) => {
                 const key = `a-data-table_row_${i}`;
                 const id = `a-data-table_row_${i}`;
-                const isLastRow = i == items.length - 1;
+                const isLastRow = i === items.length - 1;
                 const isInfiniteScrollTarget =
                   isLastRow && typeof onScrollToEnd === "function";
                 const hasExpandedRowContent =
@@ -328,11 +439,15 @@ const ADataTable = forwardRef(
                 const isRowSelected =
                   typeof propsIsRowSelected === "function" &&
                   propsIsRowSelected(rowItem);
+                const isRowKeySelected = selectedRowIndex === i;
                 const rowContent = (
                   <TableRow
                     data-expandable-row={hasExpandedRowContent}
                     isSelected={isRowSelected}
                     key={key}
+                    isKeySelected={isRowKeySelected}
+                    row-index={i}
+                    tabIndex="-1"
                     onClick={(e) =>
                       typeof propsOnRowClick === "function" &&
                       propsOnRowClick(rowItem, e)
@@ -375,6 +490,8 @@ const ADataTable = forwardRef(
 
                       return (
                         <TableCell
+                          tabIndex="-1"
+                          col-index={j}
                           key={`a-data-table_cell_${j}`}
                           className={`text-${y.align || "start"} ${
                             y.cell?.className || ""
@@ -514,7 +631,48 @@ ADataTable.propTypes = {
   /**
    * Enable sticky header
    */
-  stickyHeader: PropTypes.bool
+  stickyHeader: PropTypes.bool,
+
+  /**
+   * Enable and configure support for moving in table using pageup/pagedown keys. `null` (turned off) by default.
+   * `a-data-table__row--key-selected` class is added to currently active row and can be used for styling of key selection.
+   */
+  keyboardArrowSupport: PropTypes.shape({
+    /**
+     * Callback function for key selection. To callback are sent two params
+     * - object {index, item}
+     *    - index - zero based index of currently selected row,
+     *    - item - current data row
+     * - event - triggering event to prevent default, stop propagation etc.
+     */
+    onKeyboardSelect: PropTypes.func,
+
+    /**
+     * Optional way how to select first active row from which we can continue with arrow up/down.
+     * Zero based. It should be within items array range. Set `-1` to unselect.
+     */
+    initiallySelectedRowIndex: PropTypes.number,
+
+    /**
+     * Active row or element in row (specified by `activeRowFocusSelector` param)
+     * is focused by default. This option can turn focus off.
+     */
+    disableRowAutoFocus: PropTypes.bool,
+
+    /**
+     * When this selector is provided we try to focus element by `css` selector in active row.
+     * `disableRowAutoFocus` will turn focus feature off.
+     */
+    activeRowFocusSelector: PropTypes.string,
+
+    /**
+     * When focusing element we can override focus options, e.g. to prevent focus scroll, etc.
+     */
+    overrideFocusOptions: PropTypes.shape({
+      preventScroll: PropTypes.bool,
+      focusVisible: PropTypes.bool
+    })
+  })
 };
 
 ADataTable.displayName = "ADataTable";

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -677,9 +677,75 @@ const headers = [
       className="mx-auto"
     />
   );
-}`
-}
+}`}
+/>
 
+## Keyboard Selection In Table
+
+<Playground
+  code={`() => {
+    const headers = [
+        {
+            name: "Alpha",
+            key: "a",
+        },
+        {
+            name: "Bravo",
+            key: "b",
+            cell: {
+                component: (item) => {
+                    return (<input type="text" value={item.b} />);
+                }
+            }
+        },
+    ];
+    const items = [
+        {
+            a: 1428627663,
+            b: "India"
+        },
+        {
+            a: 1425671352,
+            b: "China"
+        },
+        {
+            a: 339996563,
+            b: "United States"
+        },
+        {
+            a: 277534122,
+            b: "Indonesia"
+        },
+        {
+            a: 240485658,
+            b: "Pakistan"
+        },
+        {
+            a: 223804632,
+            b: "Nigeria"
+        },
+        {
+            a: 216422446,
+            b: "Brazil"
+        }
+    ];
+    return (
+        <ADataTable
+            headers={headers}
+            items={items}
+            className="mx-auto"
+            style={{maxWidth: 500}}
+            keyboardArrowSupport={{
+                onKeyboardSelect: (item, event) => {
+                    console.info(item, event);
+                },
+                activeRowFocusSelector: 'input',
+                initiallySelectedRowIndex: 3
+            }}
+        />
+    );
+}
+`}
 />
 
 ## Data Table Props

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -50,6 +50,10 @@ $hidden-table-col-width: 45px;
         background: map-deep-get($theme, "table", "row-selected") !important;
       }
     }
+
+    &--key-selected {
+      background: map-deep-get($theme, "table", "row-selected");
+    }
   }
 }
 

--- a/framework/hooks/useEscapeKeydown/useEscapeKeydown.js
+++ b/framework/hooks/useEscapeKeydown/useEscapeKeydown.js
@@ -1,32 +1,8 @@
-import {useCallback, useEffect} from "react";
-import {keyCodes} from "../../utils/helpers";
+import {useKeydown} from "../../index";
 
 const useEscapeKeydown = (options) => {
   const {isEnabled, onKeydown} = options;
-
-  const detectEscKeydown = useCallback(
-    (e) => {
-      const key = e.key;
-      const keyCode = e.keyCode;
-      if (key === "Escape" || keyCode === keyCodes.esc) {
-        if (typeof onKeydown === "function") {
-          onKeydown(e);
-        }
-      }
-    },
-    [onKeydown]
-  );
-
-  useEffect(() => {
-    if (!isEnabled) {
-      return;
-    }
-    window.addEventListener("keydown", detectEscKeydown);
-
-    return () => {
-      window.removeEventListener("keydown", detectEscKeydown);
-    };
-  }, [isEnabled, onKeydown, detectEscKeydown]);
+  useKeydown(["Escape"], onKeydown, isEnabled);
 };
 
 export default useEscapeKeydown;

--- a/framework/hooks/useKeydown/useKeydown.cy.js
+++ b/framework/hooks/useKeydown/useKeydown.cy.js
@@ -1,0 +1,34 @@
+import useKeydown from "./useKeydown";
+
+describe("useKeydown()", async () => {
+  it("should detect escape key presses", () => {
+    const mockFn = cy.stub();
+    cy.mount(<KeydownTest onEscapeKeydown={mockFn} />);
+
+    expect(mockFn.callCount).to.eq(0);
+    cy.escapeKeydown().then(() => {
+      expect(mockFn.callCount).to.eq(1);
+    });
+    cy.escapeKeydown().then(() => {
+      expect(mockFn.callCount).to.eq(2);
+    });
+  });
+
+  it("should not detect escape key presses when disabled", () => {
+    const mockFn = cy.stub();
+    cy.mount(<KeydownTest isEnabled={false} onEscapeKeydown={mockFn} />);
+
+    expect(mockFn.callCount).to.eq(0);
+    cy.escapeKeydown().then(() => {
+      expect(mockFn.callCount).to.eq(0);
+    });
+    cy.escapeKeydown().then(() => {
+      expect(mockFn.callCount).to.eq(0);
+    });
+  });
+});
+
+function KeydownTest({isEnabled = true, onEscapeKeydown}) {
+  useKeydown(["Escape"], onEscapeKeydown, isEnabled);
+  return <span>test</span>;
+}

--- a/framework/hooks/useKeydown/useKeydown.js
+++ b/framework/hooks/useKeydown/useKeydown.js
@@ -1,0 +1,24 @@
+import {useEffect} from "react";
+
+const useKeydown = (targetKeys, onKeydown, isEnabled = true) => {
+  useEffect(() => {
+    if (!isEnabled) {
+      return () => {};
+    }
+
+    const handleKeyDown = (event) => {
+      const {key} = event;
+      if (typeof onKeydown === "function" && targetKeys.includes(key)) {
+        onKeydown(key, event);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [targetKeys, onKeydown, isEnabled]);
+};
+
+export default useKeydown;

--- a/framework/hooks/useKeydown/useKeydown.mdx
+++ b/framework/hooks/useKeydown/useKeydown.mdx
@@ -1,0 +1,59 @@
+---
+name: useKeydown
+route: /hooks/use-keydown
+components: useKeydown
+---
+
+# useKeyDown
+
+## Install
+
+Integrate with your build to [auto-import](/#integrating), or add an import in your component:
+
+```
+import { useKeydown } from "@cisco-sbg-ui/magna-react";
+```
+
+## Description
+
+`useKeydown` hook notifies when a user presses the keys specified in the parameter.
+
+### Parameters
+
+A configuration object with the following keys:
+
+- `targetKeys`: An array of key codes that the user would like to respond to. These codes are case-sensitive and must correspond to the values defined by the `KeyboardEvent.key` property. For a list of codes, you can refer to this [page](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values)
+- `onKeydown`: Function to be called when the user presses any key from the `targetKeys` array. `key`(KeyboardEvent.key) and `event` which was triggered ara passed to this callback function.
+- `isEnabled`: If the hook should listen for `keydown` event. "true" by default.
+
+## Usage
+
+<Playground
+  code={`() => {
+    const [collapsed, setCollapsed] = useState(false);
+    useKeydown(["ArrowUp","ArrowDown"], (key) => {
+        switch (key) {
+            case "ArrowUp":
+                setCollapsed(true);
+                break;
+            case "ArrowDown":
+                setCollapsed(false);
+                break;
+        }
+      });
+      return (
+        <AAccordion>
+          <AAccordionPanel
+              collapsed={collapsed}
+              panelKey='demo'>
+            <AAccordionHeader>
+              <AAccordionHeaderTitle>ArrowUp/ArrowDown Keydown Accordion</AAccordionHeaderTitle>
+            </AAccordionHeader>
+            <AAccordionBody>
+              I collapse with an ArrowUp key. Press and expand again with ArrowDown press.
+            </AAccordionBody>
+          </AAccordionPanel>
+        </AAccordion>
+      )
+    }`}
+/>

--- a/framework/index.js
+++ b/framework/index.js
@@ -120,6 +120,7 @@ import {useABreakpoint} from "./components/ABreakpoint";
 import {useAToaster, AToastPlate} from "./components/AToaster";
 import useEscapeKeydown from "./hooks/useEscapeKeydown/useEscapeKeydown";
 import useFocusTrap from "./hooks/useFocusTrap/useFocusTrap";
+import useKeydown from "./hooks/useKeydown/useKeydown";
 import useInView from "./hooks/useInView/useInView";
 import useMediaQuery from "./hooks/useMediaQuery/useMediaQuery";
 import useOutsideClick from "./hooks/useOutsideClick/useOutsideClick";
@@ -242,6 +243,7 @@ export {
   useAToaster,
   useEscapeKeydown,
   useFocusTrap,
+  useKeydown,
   useInView,
   useMediaQuery,
   useOutsideClick,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally
- [x] The component should accept a class name as a prop, if appropriate
- [x] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?**
New feature witch supports: [#1157](https://github.com/advthreat/incident-manager/issues/1157)

**What is the current behavior?** 
There is no such feature.


**What is the new behavior (if this is a feature change)?**
Adds support for moving in ADataTable using arrow up/down keys.

**Does this PR introduce a breaking change?** 
No. It should be backward compatible. Only using new property enables it. 


