### PR TITLE
Fix no label ACheckbox keydown check event handler

### DIFF
--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -169,9 +169,9 @@ const ACheckbox = forwardRef(
     const handleKeyDown = (e) => {
       if (["Enter", "Space"].includes(e.code)) {
         e.preventDefault();
-      }
 
-      onClick && onClick(e);
+        onClick && onClick(e);
+      }
     };
 
     const checkboxContent = (

--- a/framework/components/ACheckbox/ACheckbox.mdx
+++ b/framework/components/ACheckbox/ACheckbox.mdx
@@ -113,9 +113,7 @@ return (
       id="noLabel"
       checked={checked}
       onClick={(e) => {
-        if (e.type === "click") {
-          setChecked(!checked);
-        }
+        setChecked(!checked);
       }}
     />
   </div>


### PR DESCRIPTION
The checked state was not updating correctly when the "space" or "enter" key was pressed while a noLabel checkbox was focused