### PR TITLE
fix: avoid potential cyclic import in Jest

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 
 import {keyCodes} from "../../utils/helpers";
-import {useKeydown} from "../../index";
+import useKeydown from "../../hooks/useKeydown/useKeydown";
 
 import AInView from "../AInView";
 import AIcon from "../AIcon";

--- a/framework/hooks/useEscapeKeydown/useEscapeKeydown.js
+++ b/framework/hooks/useEscapeKeydown/useEscapeKeydown.js
@@ -1,4 +1,4 @@
-import {useKeydown} from "../../index";
+import useKeydown from "../useKeydown/useKeydown";
 
 const useEscapeKeydown = (options) => {
   const {isEnabled, onKeydown} = options;


### PR DESCRIPTION
fix #503

I confirmed locally by copying freshly built `lib` into our project that the test pass then.