### PR TITLE
fix: replace `toSorted` by explicit copy of the array

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -289,7 +289,7 @@ const ADataTable = forwardRef(
         }
 
         if (!sortingHeader || sortingHeader.sort !== false) {
-          return items.toSorted(
+          return [...items].sort(
             (a, b) => sortDirection * sortFunc(a[sortKey], b[sortKey])
           );
         }


### PR DESCRIPTION
fix #505