### PR TITLE
fix: override conflicting theme

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -450,7 +450,7 @@ $btn-transition: color $transition-duration--extra-fast
   .a-icon {
     width: 16px;
     vertical-align: text-bottom;
-    stroke: currentColor;
+    stroke: currentColor !important;
   }
 
   .a-spinner {


### PR DESCRIPTION
**Resolves #516 - Override conflicting color**

This only appears to be an issue once deployed as I could not reproduce on local dev or in magna playground.  This is a quick fix to the stylesheets, but the lengthier fix is combing through `mds-light-theme` and `mds-dark-theme` to update all the colors causing potential conflicts.  Those color definitions are likely outdated by now, but it is still used for theming so it would require time to find and test what the impacts are with either removing unused colors or updating...