### PR TITLE
Rework checkbox to be more magnetic; fix size

### DIFF
--- a/framework/components/AApp/base/color-helpers.scss
+++ b/framework/components/AApp/base/color-helpers.scss
@@ -2,6 +2,10 @@
   background-color: $color_value !important;
 }
 
+@mixin border-color($color_value) {
+  border-color: $color_value !important;
+}
+
 @mixin text-color($color_value) {
   color: $color_value !important;
   fill: $color_value !important;
@@ -24,6 +28,9 @@
         .a-app .#{$color_name}--text {
           @include text-color($color_value);
         }
+        .a-app .#{$color_name}--border-color {
+          @include border-color($color_value);
+        }
       } @else {
         .a-app .#{$color_name}--#{$color_type} {
           @include background-color($color_value);
@@ -36,6 +43,10 @@
 
         .a-app .#{$color_name}--#{$color_type}--text {
           @include text-color($color_value);
+        }
+
+        .a-app .#{$color_name}--#{$color_type}--border-color {
+          @include border-color($color_value);
         }
       }
     }

--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -15,11 +15,8 @@ import "./ACheckbox.scss";
 
 const Icons = {
   checked:
-    "M 2.9999998,0 C 1.3380015,0 0,1.3380016 0,3 v 9 c 0,1.661998 1.3380015,3 2.9999998,3 H 12 c 1.661997,0 3,-1.338002 3,-3 V 3 C 15,1.3380016 13.661997,0 12,0 Z M 10.344726,4.3447266 11.405273,5.4052734 6.3749998,10.435546 3.5947265,7.6552732 4.6552731,6.5947266 6.3749998,8.3144535 Z",
-  unchecked:
-    "M 2.9093777,0 C 1.3101651,0 0,1.3101651 0,2.9093777 v 8.7281333 c 0,1.599213 1.3101651,2.909377 2.9093777,2.909377 h 8.7281333 c 1.599213,0 2.909377,-1.310164 2.909377,-2.909377 V 2.9093777 C 14.546888,1.3101651 13.236724,0 11.637511,0 Z m 0,1.4546888 h 8.7281333 c 0.818477,0 1.454689,0.636211 1.454689,1.4546889 v 8.7281333 c 0,0.818477 -0.636212,1.454689 -1.454689,1.454689 H 2.9093777 c -0.8184779,0 -1.4546889,-0.636212 -1.4546889,-1.454689 V 2.9093777 c 0,-0.8184779 0.636211,-1.4546889 1.4546889,-1.4546889 z",
-  indeterminate:
-    "M 3,0 C 1.3380017,0 0,1.3380017 0,3 v 9 c 0,1.661999 1.3380017,3 3,3 h 9 c 1.661999,0 3,-1.338001 3,-3 V 3 C 15,1.3380017 13.661999,0 12,0 Z m 0.75,6.75 h 7.5 v 1.5 h -7.5 z"
+    "M13.2072 5.20718L6.50008 11.9143L2.79297 8.20718L4.20718 6.79297L6.50008 9.08586L11.793 3.79297L13.2072 5.20718Z",
+  indeterminate: "M13 9H3V7H13V9Z"
 };
 
 let checkboxCounter = 0;
@@ -146,24 +143,32 @@ const ACheckbox = forwardRef(
 
     if (!disabled && !["danger", "warning"].includes(workingValidationState)) {
       if (isStockColor(color)) {
-        boxProps.className += ` ${color}--text`;
+        boxProps.className += ` ${color}--border-color`;
       } else {
         boxProps.style = {
-          fill: color,
-          color
+          borderColor: color
         };
       }
     }
 
-    let currentPath = Icons.unchecked;
-    // TODO: "unchecked" svg is smaller (19.6px) I need to update scale, replace it with svg of same size as "indeterminate" and "checked" (20px)
-    let currentViewBox = "0 0 14.6 14.6";
+    let currentPath;
+    const currentViewBox = "0 0 16 16";
+    let empty = false;
     if (indeterminate) {
       currentPath = Icons.indeterminate;
-      currentViewBox = "0 0 15 15";
     } else if (checked) {
       currentPath = Icons.checked;
-      currentViewBox = "0 0 15 15";
+    } else {
+      empty = true;
+      boxProps.className += " a-empty-box";
+    }
+
+    if (!empty) {
+      if (isStockColor(color)) {
+        boxProps.className += ` ${color}`;
+      } else {
+        boxProps.style = {backgroundColor: color};
+      }
     }
 
     const handleKeyDown = (e) => {
@@ -194,17 +199,21 @@ const ACheckbox = forwardRef(
             el && ((el.indeterminate = indeterminate) || (el.checked = checked))
           }
         />
-        <span {...boxProps}>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox={currentViewBox}>
-            <path d={currentPath} />
-          </svg>
-        </span>
+        {empty ? (
+          <div {...boxProps}></div>
+        ) : (
+          <span {...boxProps}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox={currentViewBox}>
+              <path d={currentPath} />
+            </svg>
+          </span>
+        )}
       </div>
     );
 
     const content =
       withLabel && children ? (
-        <label className="a-checkbox__wrap">
+        <label className={`a-checkbox__wrap a-checkbox--${boxSize}`}>
           {checkboxContent}
           <span
             className={`a-checkbox__label${

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -151,7 +151,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
     position: relative;
     padding: 0;
     align-items: flex-start;
-    align-self: center;
   }
 
   &__input {

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -1,12 +1,13 @@
 @import "../../styles";
 
 $checkbox-box-border-radius: $border-radius--md;
-$checkbox-box-side-length: rem(1);
-$checkbox-box-side-length-magna-medium: $font-size--lg;
-$checkbox-box-side-length-magna-small: rem(1);
-$checkbox-icon-size: $font-size--xs;
-$checkbox-label-font-size: $font-size--sm;
-$checkbox-label-font-size-medium: $font-size--md;
+$checkbox-box-side-length: 20px;
+$checkbox-box-side-length-magna-medium: 20px;
+$checkbox-box-side-length-magna-small: 16px;
+$checkbox-icon-size: 16px;
+$checkbox-icon-size-small: 12px;
+$checkbox-label-font-size: $font-size--md;
+$checkbox-label-font-size-small: $font-size--sm;
 $checkbox-icon-padding-left: $base-padding-xsmall;
 $checkbox-padding: $base-padding-xsmall 0;
 $checkbox-transition: box-shadow $transition-duration--extra-fast
@@ -32,46 +33,54 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       box-shadow: none;
       opacity: 0.6;
     }
-    &:hover {
-      svg {
-        fill: currentColor !important;
-        fill-opacity: 0.7;
-      }
-    }
   }
 
   &--enabled {
     .a-checkbox__box {
-      fill: map-deep-get($theme, "checkbox", "border--enabled");
+      border-color: map-deep-get($theme, "checkbox", "border--enabled");
       color: map-deep-get($theme, "checkbox", "border--checked");
       &:hover {
-        svg {
-          fill: map-deep-get($theme, "checkbox", "border--hover");
-        }
+        border-color: map-deep-get($theme, "checkbox", "border--hover");
       }
     }
   }
 
   &--selected {
     .a-checkbox__box {
-      fill: map-deep-get($theme, "checkbox", "fill-checked");
-      &:hover svg {
-        fill: map-deep-get($theme, "checkbox", "fill-checked--hover");
+      background-color: map-deep-get($theme, "checkbox", "fill-checked");
+      fill: map-deep-get($theme, "checkbox", "fill-enabled");
+
+      &:hover {
+        background-color: map-deep-get(
+          $theme,
+          "checkbox",
+          "fill-checked--hover"
+        );
       }
     }
   }
 
   &--warning {
     .a-checkbox__box {
-      fill: map-deep-get($theme, "control", "warning-color");
-      color: map-deep-get($theme, "control", "warning-color");
+      border-color: map-deep-get($theme, "control", "warning-color");
+    }
+  }
+
+  &--warning.a-checkbox--selected {
+    .a-checkbox__box {
+      background-color: map-deep-get($theme, "control", "warning-color");
     }
   }
 
   &--danger {
     .a-checkbox__box {
-      fill: map-deep-get($theme, "control", "error-color");
-      color: map-deep-get($theme, "control", "error-color");
+      border-color: map-deep-get($theme, "control", "error-color");
+    }
+  }
+
+  &--danger.a-checkbox--selected {
+    .a-checkbox__box {
+      background-color: map-deep-get($theme, "control", "error-color");
     }
   }
 
@@ -79,16 +88,22 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
     .a-checkbox__wrap {
       .a-checkbox {
         &__box {
-          fill: map-deep-get($theme, "checkbox", "border--disabled");
+          border-color: map-deep-get($theme, "checkbox", "border--disabled");
           color: map-deep-get($theme, "checkbox", "border--disabled");
-          background-color: map-deep-get($theme, "checkbox", "fill--disabled");
+          background-color: map-deep-get(
+            $theme,
+            "checkbox",
+            "fill--disabled"
+          ) !important;
           cursor: not-allowed;
-          > svg:hover {
-            fill: map-deep-get($theme, "checkbox", "border--disabled");
-          }
+
+          box-shadow: inset 0 0 0 2px
+            map-deep-get($theme, "checkbox", "border--disabled");
+          border: none;
         }
 
-        &__input:checked {
+        &__input:checked,
+        &__input[aria-checked="mixed"] {
           ~ .a-checkbox {
             &__box {
               svg {
@@ -136,6 +151,7 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
     position: relative;
     padding: 0;
     align-items: flex-start;
+    align-self: center;
   }
 
   &__input {
@@ -154,9 +170,13 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
     border-radius: $checkbox-box-border-radius;
     vertical-align: middle;
     box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     > svg {
-      position: absolute;
+      height: $checkbox-icon-size;
+      width: $checkbox-icon-size;
     }
 
     &:after {
@@ -178,10 +198,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       width: $checkbox-box-side-length-magna-medium;
     }
   }
-  &__box.a-medium-box + .a-checkbox__label {
-    top: unset;
-    font-size: $checkbox-label-font-size-medium;
-  }
 
   &__box.a-small-box {
     height: $checkbox-box-side-length-magna-small;
@@ -191,6 +207,17 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       height: $checkbox-box-side-length-magna-small;
       width: $checkbox-box-side-length-magna-small;
     }
+
+    > svg {
+      height: $checkbox-icon-size-small;
+      width: $checkbox-icon-size-small;
+    }
+  }
+
+  &__box.a-empty-box {
+    border: 2px solid;
+    border-radius: $checkbox-box-border-radius;
+    border-color: red;
   }
 
   &__label {
@@ -226,6 +253,12 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       &:hover:after {
         box-shadow: 0 0 2px 2px transparent;
       }
+    }
+  }
+
+  &--small {
+    .a-checkbox__label {
+      font-size: $checkbox-label-font-size-small;
     }
   }
 }

--- a/framework/styles/theme/default.scss
+++ b/framework/styles/theme/default.scss
@@ -185,7 +185,7 @@ $atomic-default: (
     "fill-enabled": $white,
     "border--enabled": map-get($mds-neutral, "neutral-9"),
     "border--disabled": map-get($mds-neutral, "neutral-5"),
-    "fill--disabled": map-get($mds-neutral, "neutral-2"),
+    "fill--disabled": map-get($mds-neutral, "neutral-3"),
     "label-color--disabled": map-get($mds-neutral, "neutral-6"),
     "icon--disabled": map-get($mds-neutral, "neutral-7"),
     "fill-checked": map-get($mds-light-theme, "status-info"),


### PR DESCRIPTION
Resolves #529

- Magnetized the checkbox svg paths
- Use div+css style for unchekced state
- Standardized viewBox size
- Retained custom colors
- Retained validation states

- Updated disabled checked/intermediate state to match magnetic design
![Screenshot 2023-09-26 at 2 33 08 PM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/06ce0fd5-cad2-4f87-84e5-6e4736b8eb20)
