### PR TITLE
remove color css on checkbox

### DIFF
--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -163,12 +163,16 @@ const ACheckbox = forwardRef(
       boxProps.className += " a-empty-box";
     }
 
-    if (!empty) {
+    if (!empty && color) {
       if (isStockColor(color)) {
         boxProps.className += ` ${color}`;
       } else {
         boxProps.style = {backgroundColor: color};
       }
+    }
+
+    if (color && !disabled) {
+      boxProps.className += ` a-checkbox--hasColor`;
     }
 
     const handleKeyDown = (e) => {

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -38,7 +38,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
   &--enabled {
     .a-checkbox__box {
       border-color: map-deep-get($theme, "checkbox", "border--enabled");
-      color: map-deep-get($theme, "checkbox", "border--checked");
       &:hover {
         border-color: map-deep-get($theme, "checkbox", "border--hover");
       }
@@ -89,7 +88,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       .a-checkbox {
         &__box {
           border-color: map-deep-get($theme, "checkbox", "border--disabled");
-          color: map-deep-get($theme, "checkbox", "border--disabled");
           background-color: map-deep-get(
             $theme,
             "checkbox",
@@ -161,7 +159,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
   }
 
   &__box {
-    color: currentColor;
     position: relative;
     flex: 0 0 auto;
     height: $checkbox-box-side-length;

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -38,7 +38,7 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
   &--enabled {
     .a-checkbox__box {
       border-color: map-deep-get($theme, "checkbox", "border--enabled");
-      color: map-deep-get($theme, "checkbox", "border--checked");
+
       &:hover {
         opacity: 0.7;
         border-color: map-deep-get($theme, "checkbox", "border--hover");
@@ -63,13 +63,23 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
     }
 
     .a-checkbox__box:hover {
-      border-color: map-deep-get($theme, "control", "warning-color");
+      border-color: darken(
+        map-deep-get($theme, "control", "warning-color"),
+        5%
+      );
     }
   }
 
   &--warning.a-checkbox--selected {
     .a-checkbox__box {
       background-color: map-deep-get($theme, "control", "warning-color");
+    }
+
+    .a-checkbox__box:hover {
+      background-color: darken(
+        map-deep-get($theme, "control", "warning-color"),
+        5%
+      );
     }
   }
 
@@ -79,13 +89,20 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
     }
 
     .a-checkbox__box:hover {
-      border-color: map-deep-get($theme, "control", "error-color");
+      border-color: darken(map-deep-get($theme, "control", "error-color"), 5%);
     }
   }
 
   &--danger.a-checkbox--selected {
     .a-checkbox__box {
       background-color: map-deep-get($theme, "control", "error-color");
+    }
+
+    .a-checkbox__box:hover {
+      background-color: darken(
+        map-deep-get($theme, "control", "error-color"),
+        5%
+      );
     }
   }
 
@@ -139,6 +156,16 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
           }
         }
       }
+    }
+  }
+
+  &--hasColor.a-checkbox__box:hover {
+    opacity: 0.7;
+  }
+
+  .a-checkbox--selected {
+    &--hasColor.a-checkbox__box:hover {
+      opacity: 0.7;
     }
   }
 }
@@ -221,7 +248,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
   &__box.a-empty-box {
     border: 2px solid;
     border-radius: $checkbox-box-border-radius;
-    border-color: red;
   }
 
   &__label {

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -40,7 +40,6 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       border-color: map-deep-get($theme, "checkbox", "border--enabled");
 
       &:hover {
-        opacity: 0.7;
         border-color: map-deep-get($theme, "checkbox", "border--hover");
       }
     }
@@ -52,7 +51,11 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       fill: map-deep-get($theme, "checkbox", "fill-enabled");
 
       &:hover {
-        opacity: 0.7;
+        background-color: map-deep-get(
+          $theme,
+          "checkbox",
+          "fill-checked--hover"
+        );
       }
     }
   }

--- a/framework/components/ACheckbox/ACheckbox.scss
+++ b/framework/components/ACheckbox/ACheckbox.scss
@@ -38,7 +38,9 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
   &--enabled {
     .a-checkbox__box {
       border-color: map-deep-get($theme, "checkbox", "border--enabled");
+      color: map-deep-get($theme, "checkbox", "border--checked");
       &:hover {
+        opacity: 0.7;
         border-color: map-deep-get($theme, "checkbox", "border--hover");
       }
     }
@@ -50,17 +52,17 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       fill: map-deep-get($theme, "checkbox", "fill-enabled");
 
       &:hover {
-        background-color: map-deep-get(
-          $theme,
-          "checkbox",
-          "fill-checked--hover"
-        );
+        opacity: 0.7;
       }
     }
   }
 
   &--warning {
     .a-checkbox__box {
+      border-color: map-deep-get($theme, "control", "warning-color");
+    }
+
+    .a-checkbox__box:hover {
       border-color: map-deep-get($theme, "control", "warning-color");
     }
   }
@@ -73,6 +75,10 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
 
   &--danger {
     .a-checkbox__box {
+      border-color: map-deep-get($theme, "control", "error-color");
+    }
+
+    .a-checkbox__box:hover {
       border-color: map-deep-get($theme, "control", "error-color");
     }
   }
@@ -88,6 +94,7 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
       .a-checkbox {
         &__box {
           border-color: map-deep-get($theme, "checkbox", "border--disabled");
+          color: map-deep-get($theme, "checkbox", "border--disabled");
           background-color: map-deep-get(
             $theme,
             "checkbox",
@@ -159,6 +166,7 @@ $checkbox-transition: box-shadow $transition-duration--extra-fast
   }
 
   &__box {
+    color: currentColor;
     position: relative;
     flex: 0 0 auto;
     height: $checkbox-box-side-length;


### PR DESCRIPTION
Conflicts with old styles, and isn't necessary anymore I think

--------

Should darken on hover for default, warning, and danger checkboxes - default darkens on hover for magnetic. Should lighten on custom closers - no magnetic equivalent and this keeps it non breaking