### PR TITLE
Remove first and last of type margin override

### DIFF
--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -6,7 +6,7 @@ $tab-font-size: $font-size--md;
 $tab-bottom-bar-height: -4px;
 $tab-top-bar-height: 4px;
 $tab-padding-bottom: 12px;
-$tab-margin: 0 16px;
+$tab-margin: 0 12px;
 $tab-padding: 4px 0; // doesn't match magnetic (overall height 41px, but magnetic doesn't align to the multiple of 4px pattern here either
 $tab-heading-margin: 0;
 $tab-heading-font-size: $font-size--lg;
@@ -220,14 +220,6 @@ $tab-oversized-margin: 0;
         margin-bottom: 0;
       }
     }
-  }
-
-  &__tab:first-of-type {
-    margin-left: 0;
-  }
-
-  &__tab:last-of-type {
-    margin-right: 0;
   }
 
   .a-tab-group__tab {


### PR DESCRIPTION
Causes issues in tabs that are wrappered, such as ones with `<a>`. 