### PR TITLE
feat: counter multiselect

### DIFF
--- a/framework/components/AMultiSelect/AMultiSelect.cy.js
+++ b/framework/components/AMultiSelect/AMultiSelect.cy.js
@@ -66,17 +66,13 @@ describe("<AMultiSelect />", () => {
 
     cy.focused().click();
 
-    cy.get(".a-list-item")
-      .first()
-      .should("have.class", "a-multiselect__menu-item--selected");
+    cy.get(".a-list-item .a-checkbox__input").first().should("be.checked");
 
     pressUpArrow();
 
     cy.focused().click();
 
-    cy.get(".a-list-item")
-      .last()
-      .should("have.class", "a-multiselect__menu-item--selected");
+    cy.get(".a-list-item .a-checkbox__input").last().should("be.checked");
   });
 
   it("should select items on enter", () => {
@@ -88,21 +84,33 @@ describe("<AMultiSelect />", () => {
 
     cy.focused().type("{enter}");
 
-    cy.get(".a-list-item")
-      .first()
-      .should("have.class", "a-multiselect__menu-item--selected");
+    cy.get(".a-list-item .a-checkbox__input").first().should("be.checked");
 
     pressUpArrow();
 
     cy.focused().type("{enter}");
 
-    cy.get(".a-list-item")
-      .last()
-      .should("have.class", "a-multiselect__menu-item--selected");
+    cy.get(".a-list-item .a-checkbox__input").last().should("be.checked");
+  });
+
+  it("should show items on counter hover", () => {
+    cy.mount(<AMultiSelectTest />);
+
+    openWidget();
+
+    cy.get(".a-multiselect__input").type("fruit");
+
+    pressDownArrow();
+
+    cy.focused().click();
+
+    cy.get(".a-tag").should("have.text", "1").trigger("mouseover");
+
+    cy.get(".a-tooltip").should("be.visible").should("have.text", "Fruit");
   });
 
   it("should show tags", () => {
-    cy.mount(<AMultiSelectTest value={[1, 3]} />);
+    cy.mount(<AMultiSelectTest withTags value={[1, 3]} />);
 
     cy.get(".a-tag")
       .first()
@@ -180,7 +188,7 @@ const items = [
   {id: 6, name: "Fats, Oils, and Sweets"}
 ];
 
-const AMultiSelectTest = ({value: propsValue = []}) => {
+const AMultiSelectTest = ({value: propsValue = [], withTags = false}) => {
   const [value, setValue] = useState(propsValue);
 
   return (
@@ -191,6 +199,7 @@ const AMultiSelectTest = ({value: propsValue = []}) => {
       <AMultiSelect
         data-testid="select-trigger"
         label="Food Group"
+        withTags={withTags}
         items={items}
         itemValue="id"
         itemText="name"

--- a/framework/components/AMultiSelect/AMultiSelect.mdx
+++ b/framework/components/AMultiSelect/AMultiSelect.mdx
@@ -75,6 +75,41 @@ import {AMultiSelect} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
+## With tags
+
+<Playground
+  code={`() => {
+  const items = [
+    "Bread, Cereal, Rice, and Pasta",
+    "Vegetables",
+    "Fruit",
+    "Milk, Yogurt, and Cheese",
+    "Meat, Poultry, Fish",
+    "Fats, Oils, and Sweets"
+  ];
+  const [value, setValue] = useState([]);
+  const [filteredItems, setFilteredItems] = useState(items);
+  return (
+    <div style={{minHeight: 220, minWidth: 250, marginRight: 20}}>
+      <AMultiSelect
+        medium
+        withTags
+        clearable
+        label="Food Group"
+        items={filteredItems}
+        placeholder="Pick a Food Group"
+        onSelected={(item) => {
+          setValue(item);
+        }}
+        value={value}
+      />
+    </div>
+
+);
+}
+`}
+/>
+
 ## MultiSelect Props
 
 The `AMultiSelect` component inherits passed props.

--- a/framework/components/AMultiSelect/AMultiSelect.scss
+++ b/framework/components/AMultiSelect/AMultiSelect.scss
@@ -6,20 +6,6 @@
     box-shadow: map-deep-get($theme, "combobox", "box-shadow");
   }
 
-  &__menu-item-content__check {
-    svg {
-      stroke: map-deep-get($theme, "base", "color--selected");
-    }
-  }
-
-  &__menu-item--selected {
-    background-color: map-deep-get($theme, "menu", "color--selected");
-  }
-
-  &__menu-item:focus {
-    background-color: map-deep-get($theme, "menu", "color--hover") !important;
-  }
-
   &__tags {
     .a-tag {
       .a-button:focus,
@@ -72,23 +58,28 @@
     }
   }
 
+  &__counter {
+    .a-input-base__control {
+      flex-wrap: nowrap !important;
+    }
+  }
+
   &__chevron {
     cursor: pointer;
     align-self: stretch;
   }
 
-  &__menu-item.a-list-item {
-    min-height: 28px;
-    line-height: $line-height--lg;
-    padding: 4px 6px;
-    text-indent: 6px;
-  }
-
-  &.a-input-base--clearable {
-    .a-multiselect__menu-items {
-      right: -50px;
+  &__menu-items {
+    padding: 0;
+    .a-checkbox {
+      width: 100%;
     }
   }
+
+  &__menu-item.a-list-item {
+    padding: 0 10px;
+  }
+
   .a-input-base__control {
     max-height: 100px;
     flex-wrap: wrap;
@@ -118,25 +109,6 @@
 
     .a-input-base__append {
       right: 16px;
-    }
-  }
-
-  &__menu-item-content {
-    display: flex;
-    flex: 1 0 auto;
-
-    &__label {
-      flex: 1 0 auto;
-    }
-
-    &__check {
-      display: flex;
-      align-items: center;
-
-      svg {
-        height: 14px;
-        width: 14px;
-      }
     }
   }
 

--- a/framework/components/AMultiSelect/AMultiSelectCounter.js
+++ b/framework/components/AMultiSelect/AMultiSelectCounter.js
@@ -1,0 +1,39 @@
+import React, {useRef} from "react";
+import {ATooltip} from "../ATooltip";
+import ATag from "../ATag";
+import useToggle from "../../hooks/useToggle/useToggle";
+
+const AMultiSelectCounter = ({items, value}) => {
+  const {isOpen, open, close} = useToggle();
+  const iconRef = useRef(null);
+
+  const itemsMap = new Map(
+    items.map((item) =>
+      typeof item === "string" ? [item, item] : [item.id, item.name]
+    )
+  );
+  const selectedItems = value.map((item) => itemsMap.get(item));
+
+  if (!selectedItems.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <ATag small ref={iconRef} onMouseEnter={open} onMouseLeave={close}>
+        {selectedItems.length}
+      </ATag>
+      <ATooltip
+        anchorRef={iconRef}
+        id="tooltip_usage_2"
+        open={isOpen}
+        placement="top"
+        pointer
+      >
+        {selectedItems.join(", ")}
+      </ATooltip>
+    </>
+  );
+};
+
+export default AMultiSelectCounter;


### PR DESCRIPTION
**Resolves #521 - Create multiselect counter and set as default.**

- Adds a `withTags` prop to multiselect to differentiate tags or counter inputs. 

- Menu list items for multiselects are now checkbox only.  Single select list items remain the same (right aligned checkmark).

**Resources:**
**Magnetic: single and multiselects** - https://magnetic.cisco.com/0a43ab5cd/v/0/p/42131c-select
**Figma** - https://www.figma.com/file/oVZWatImEIbl1c8sjdGxi0/%F0%9F%A7%B2--Magnetic-Design-Library?type=design&node-id=12394-50157&mode=design&t=vRcHv5Zi8JmJw0dV-0