### PR TITLE
Check current ref in resize observer callback

### DIFF
--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -51,6 +51,9 @@ export const useResizeObserver = (containerRef) => {
       return;
     }
     const resizeObserver = new ResizeObserver(() => {
+      if (!containerRef.current) {
+        return;
+      }
       if (containerRef.current?.offsetWidth !== width) {
         setWidth(containerRef.current.offsetWidth);
       }


### PR DESCRIPTION
Resolves #540 

My guess is there's a timing issue with the `.disconnect()` call running after React has already gotten rid of the DOM node that the ref is pointing to.. null checking should avoid the error