### PR TITLE
Default toast placement to upper right

### DIFF
--- a/framework/components/AToast/AToast.js
+++ b/framework/components/AToast/AToast.js
@@ -13,7 +13,7 @@ const AToast = forwardRef(
       dismissable = true,
       level = "info",
       onClose,
-      placement = "bottom-right",
+      placement = "top-right",
       title,
       ...rest
     },
@@ -92,7 +92,7 @@ AToast.propTypes = {
   /**
    * Specifies the placement of the toast.
    */
-  placement: PropTypes.oneOf(["bottom-right", "top"]),
+  placement: PropTypes.oneOf(["bottom-right", "top", "top-right"]),
   /**
    * Sets the title.
    */

--- a/framework/components/AToaster/AToastPlate.js
+++ b/framework/components/AToaster/AToastPlate.js
@@ -11,7 +11,9 @@ const AToastPlate = () => {
   }
 
   const components = toasts
-    .filter(({placement}) => ["bottom-right", "top"].includes(placement))
+    .filter(({placement}) =>
+      ["bottom-right", "top", "top-right"].includes(placement)
+    )
     .reduce(
       (toastsAcc, {placement, component}) => ({
         ...toastsAcc,
@@ -19,7 +21,8 @@ const AToastPlate = () => {
       }),
       {
         "bottom-right": [],
-        top: []
+        top: [],
+        "top-right": []
       }
     );
 
@@ -30,7 +33,8 @@ const AToastPlate = () => {
           !!components.length && (
             <div
               className={`a-toast-plate a-toast-plate--${placement}`}
-              key={index}>
+              key={index}
+            >
               {components}
             </div>
           )

--- a/framework/components/AToaster/AToaster.scss
+++ b/framework/components/AToaster/AToaster.scss
@@ -18,4 +18,9 @@
     left: 50%;
     transform: translateX(-50%);
   }
+
+  &--top-right {
+    top: 80px;
+    right: 24px;
+  }
 }

--- a/framework/components/AToaster/useAToaster.js
+++ b/framework/components/AToaster/useAToaster.js
@@ -84,7 +84,7 @@ const useAToaster = () => {
           ...current,
           {
             id: id,
-            placement: props.placement || "bottom-right",
+            placement: props.placement || "top-right",
             component: (
               <AToasterToast
                 {...props}


### PR DESCRIPTION
Magnetic says toasts should go in the upper right, "24px inset below the header and right edge of the browser window."

Before

![Screenshot 2023-10-04 at 3 31 23 PM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/d782321b-0b51-4568-90d8-6d90b56d8fd3)


After

![Screenshot 2023-10-04 at 3 31 01 PM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/6880e478-2173-45ee-bd53-5d5ba82287ff)

Note that the top offset accounts for the 56px of the XDR header, so it looks a bit off on the magna site