### PR TITLE
fix: scroll state

### DIFF
--- a/framework/components/AMultiSelect/AMultiSelect.js
+++ b/framework/components/AMultiSelect/AMultiSelect.js
@@ -65,6 +65,7 @@ const AMultiSelect = forwardRef(
     const [multiselectId] = useState(multiselectCounter++);
     const [isFocused, setIsFocused] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
+    const [hasScroll, setHasScroll] = useState(false);
     const [filterValue, setFilterValue] = useState("");
     const [error, setError] = useState("");
     const [workingValidationState, setWorkingValidationState] =
@@ -194,17 +195,25 @@ const AMultiSelect = forwardRef(
       };
     }
 
-    if (inputBaseSurfaceRef?.current) {
-      const controlEl = inputBaseSurfaceRef?.current?.querySelector(
-        ".a-input-base__control"
-      );
-
-      if (
-        controlEl.scrollHeight >
-        inputBaseSurfaceRef?.current?.offsetHeight - 4
-      ) {
-        className += " a-multiselect--hasScroll";
+    useEffect(() => {
+      if (withTags) {
+        const tagsEl = inputBaseSurfaceRef?.current?.querySelector(
+          ".a-multiselect__tags"
+        );
+        if (tagsEl) {
+          const inputEl = inputBaseSurfaceRef.current.querySelector(
+            ".a-multiselect__input"
+          );
+          tagsEl.offsetHeight + inputEl.offsetHeight >
+          inputBaseSurfaceRef.current.offsetHeight
+            ? setHasScroll(true)
+            : setHasScroll(false);
+        }
       }
+    }, [onSelected, withTags]);
+
+    if (hasScroll && withTags) {
+      className += " a-multiselect--hasScroll";
     }
 
     const noDataContent = propsNoDataContent ?? (

--- a/framework/components/AMultiSelect/AMultiSelect.scss
+++ b/framework/components/AMultiSelect/AMultiSelect.scss
@@ -27,7 +27,7 @@
     background: transparent;
     box-sizing: border-box;
     color: currentColor;
-    min-height: 24px;
+    min-height: 30px;
     max-width: 100%;
     position: relative;
     padding: 0 8px;
@@ -80,6 +80,14 @@
     padding: 0 10px;
   }
 
+  .a-input-base--small &__input {
+    min-height: 24px;
+  }
+
+  .a-input-base--large &__input {
+    min-height: 36px;
+  }
+
   .a-input-base__control {
     max-height: 100px;
     flex-wrap: wrap;
@@ -104,7 +112,7 @@
 
   &--hasScroll {
     .a-multiselect__tags {
-      padding-right: 36px;
+      padding-right: 42px;
     }
 
     .a-input-base__append {


### PR DESCRIPTION
**Fixes #544 - Clear button overlap** 

**Fixes include:**
- The scroll class was not updating appropriately after onSelect changes.  This was fixed by moving the element checks into a useEffect and tying in the onSelect behavior to react state for real time dimension updates.  

- The elements used to calculate the scroll overflow have been also adjusted for greater accuracy.

- Style updates to large and small input heights

**Demo** 
-Scrollbar appears at the right time
-Very long tags do not overflow clear button

![testCases](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/cf5f3927-c8c1-43c3-b845-705e0081dba5)

