### PR TITLE
feat(ACombobox): allow dropdown menu to be scrollable with "maxHeight" prop

### DIFF
--- a/framework/components/ACombobox/ACombobox.js
+++ b/framework/components/ACombobox/ACombobox.js
@@ -35,6 +35,7 @@ const ACombobox = forwardRef(
       itemValue = "value",
       items = [],
       label,
+      maxHeight,
       noDataContent: propsNoDataContent,
       noDataMessage = "No matches found",
       onChange,
@@ -265,7 +266,12 @@ const ACombobox = forwardRef(
         <input {...inputProps} />
         <AMenu ref={menuRef} {...menuComponentProps}>
           {prependContent}
-          <div className="a-combobox__menu-items__wrapper">
+          <div
+            className={`a-combobox__menu-items__wrapper${
+              maxHeight ? " overflow-y-scroll" : ""
+            }`}
+            style={{maxHeight}}
+          >
             {!items.length && !!noDataContent && (
               <AListItem>{noDataContent}</AListItem>
             )}
@@ -365,6 +371,14 @@ ACombobox.propTypes = {
    * Sets the label content.
    */
   label: PropTypes.node,
+  /**
+   * Sets the max-height of the select dropdown
+   * in the case of many dropdown options needing
+   * overflow styling
+   *
+   * @example maxHeight="300px"
+   */
+  maxHeight: PropTypes.string,
   /**
    * Sets the content for when no matches are available.
    */

--- a/framework/components/ACombobox/ACombobox.mdx
+++ b/framework/components/ACombobox/ACombobox.mdx
@@ -362,7 +362,7 @@ The `ACombobox` component inherits passed props.
             if (!userInput) {
               setFilteredItems(items);
             } else {
-              setFilteredItems(items.filter(item => item === e.target.value));
+              setFilteredItems(items.filter(item => item === userInput));
             }
           }}
           hint={\`Your lucky number: \${JSON.stringify(comboboxValue) || ''}\`}

--- a/framework/components/ACombobox/ACombobox.mdx
+++ b/framework/components/ACombobox/ACombobox.mdx
@@ -337,6 +337,42 @@ The `ACombobox` component inherits passed props.
 `}
 />
 
+## Dropdown Menu Max Height
+
+<Playground
+  code={`() => {
+    const items = useMemo(() => Array.from({length: 100}, (_, i) => (i + 1).toString()), []);
+    const [filteredItems, setFilteredItems] = useState(items);
+    const [comboboxValue, setComboboxValue] = useState();
+    // Add the maxHeight prop in order to prevent options from overflowing
+    return (
+      <div style={{minHeight: 220, minWidth: 250, marginRight: 20}}>
+        <ACombobox
+          placeholder="Find a lucky number"
+          maxHeight="300px"
+          value={comboboxValue}
+          label="Numbers"
+          items={filteredItems}
+          onSelected={item => setComboboxValue(item)}
+          onChange={e => {
+            const userInput = e.target.value;
+
+            setComboboxValue(userInput);
+
+            if (!userInput) {
+              setFilteredItems(items);
+            } else {
+              setFilteredItems(items.filter(item => item === e.target.value));
+            }
+          }}
+          hint={\`Your lucky number: \${JSON.stringify(comboboxValue) || ''}\`}
+        />
+      </div>
+    )
+
+}`}
+/>
+
 ## Accessibility Notes
 
 `ACombobox` inherits the accessibility features of `AMenu`.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally
- [ ] The component should accept a class name as a prop, if appropriate
- [ ] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Introduces equivalent changes from https://github.com/cisco-sbg-ui/atomic-react/pull/1178, but for the `ACombobox` component.


**What is the current behavior?** <!--(You can also link to an open issue here)-->

When `ACombobox` has a large number of items, it spans the entire viewport:

![Screenshot 2023-10-31 at 11 25 56 AM](https://github.com/cisco-sbg-ui/magna-react/assets/94568316/9db2de34-f665-4e4b-9c51-0a4f57391128)



**What is the new behavior (if this is a feature change)?**

Adds a `maxHeight` prop that can be configured to add a scrolling container to the menu items:

![Screenshot 2023-10-31 at 11 26 37 AM](https://github.com/cisco-sbg-ui/magna-react/assets/94568316/faf2e7dd-80cb-4c00-9992-75bede4716e7)



**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
