### PR TITLE
feature: ADataTable takes header properties and pass them to ADataTableHeader ("td") element

### DIFF
--- a/framework/components/ADataTable/ADataTable.cy.js
+++ b/framework/components/ADataTable/ADataTable.cy.js
@@ -32,6 +32,31 @@ const ITEMS = [
 ];
 
 describe("ADataTable", async () => {
+  it("renders data-testid in the table header elements", () => {
+    const headersWithProperties = [
+      {
+        ...HEADERS[0],
+        properties: {
+          "data-testid": "alpha"
+        }
+      },
+      {
+        ...HEADERS[1],
+        properties: {
+          "data-testid": "bravo"
+        }
+      }
+    ];
+    cy.mount(<ADataTable headers={headersWithProperties} items={ITEMS} />);
+
+    cy.get("table thead th:first")
+      .invoke("attr", "data-testid")
+      .should("eq", "alpha");
+    cy.get("table thead th:last")
+      .invoke("attr", "data-testid")
+      .should("eq", "bravo");
+  });
+
   describe("keyboardArrowSupport", () => {
     it("selects first line with arrow down and assign key-selected class to it", () => {
       const onKeyboardSelectStub = cy.stub();

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -17,78 +17,14 @@ import ASimpleTable from "../ASimpleTable";
 import {ASkeleton, ASkeletonText} from "../ASkeleton";
 import "./ADataTable.scss";
 import {useCombinedRefs} from "../../utils/hooks";
+import ADataTableWrapper from "./ADataTableWrapper";
+import ADataTableHeader from "./ADataTableHeader";
+import ADataTableRow from "./ADataTableRow";
+import ADataTableCell from "./ADataTableCell";
 
 const ARROW_UP = "ArrowUp";
 const ARROW_DOWN = "ArrowDown";
 const ARROW_KEYS = [ARROW_UP, ARROW_DOWN];
-
-/**
- * Used inside ADataTable to enable proper styling
- * for infinite scrolling
- */
-const ADataTableWrapper = React.forwardRef(
-  ({shouldWrap, maxHeight, style, children, ...rest}, ref) => {
-    if (!shouldWrap) {
-      return children; // TODO: ref is lost ?
-    }
-
-    return (
-      <div
-        ref={ref}
-        data-testid="table-wrapper"
-        style={{
-          ...style,
-          overflowY: "scroll",
-          maxHeight
-        }}
-        {...rest}
-      >
-        {children}
-      </div>
-    );
-  }
-);
-ADataTableWrapper.displayName = "ADataTableWrapper";
-
-const TableHeader = React.forwardRef(({className, ...rest}, ref) => {
-  return (
-    <th
-      ref={ref}
-      role="columnheader"
-      className={`a-data-table__header${className ? ` ${className}` : ""}`}
-      {...rest}
-    />
-  );
-});
-TableHeader.displayName = "TableHeader";
-
-const TableRow = React.forwardRef(
-  ({className: propsClassName, isKeySelected, isSelected, ...rest}, ref) => {
-    let className = "a-data-table__row";
-    if (isSelected) {
-      className += " a-data-table__row--selected";
-    }
-    if (isKeySelected) {
-      className += " a-data-table__row--key-selected";
-    }
-    if (propsClassName) {
-      className += ` ${propsClassName}`;
-    }
-
-    return <tr ref={ref} role="row" className={className} {...rest} />;
-  }
-);
-TableRow.displayName = "TableRow";
-
-const TableCell = React.forwardRef(({className, ...rest}, ref) => (
-  <td
-    ref={ref}
-    role="cell"
-    className={`a-data-table__cell${className ? ` ${className}` : ""}`}
-    {...rest}
-  />
-));
-TableCell.displayName = "TableCell";
 
 export const getSortIconName = (column, sort) => {
   if (!sort || column.key !== sort.key) {
@@ -127,7 +63,6 @@ const ADataTable = forwardRef(
     },
     ref
   ) => {
-    const tableWrapperRef = useRef();
     const simpleTableRef = useRef();
     const combinedTableRef = useCombinedRefs(simpleTableRef, ref);
     const [expandedRows, setExpandedRows] = useState({});
@@ -311,7 +246,6 @@ const ADataTable = forwardRef(
       headers &&
       items && (
         <ADataTableWrapper
-          ref={tableWrapperRef}
           shouldWrap={typeof onScrollToEnd === "function" || maxHeight}
           maxHeight={maxHeight}
         >
@@ -323,18 +257,18 @@ const ADataTable = forwardRef(
           >
             {headers && (
               <thead>
-                <TableRow
+                <ADataTableRow
                   onClick={(e) =>
                     typeof propsOnRowClick === "function" &&
                     propsOnRowClick(headers, e)
                   }
                 >
                   {ExpandableComponent && (
-                    <TableHeader className="a-data-table__header a-data-table__header--hidden">
+                    <ADataTableHeader className="a-data-table__header a-data-table__header--hidden">
                       <span className="a-data-table__header--hidden__text">
                         Toggle
                       </span>
-                    </TableHeader>
+                    </ADataTableHeader>
                   )}
                   {headers.map((x, i) => {
                     const headerProps = {
@@ -405,14 +339,14 @@ const ADataTable = forwardRef(
 
                     if (!x.sortable) {
                       return (
-                        <TableHeader
+                        <ADataTableHeader
                           {...headerProps}
                           key={`a-data-table_header_${i}`}
                         >
                           <span className="a-data-table__header__label">
                             {x.name}
                           </span>
-                        </TableHeader>
+                        </ADataTableHeader>
                       );
                     }
 
@@ -431,7 +365,7 @@ const ADataTable = forwardRef(
                     );
 
                     return (
-                      <TableHeader
+                      <ADataTableHeader
                         {...headerProps}
                         key={`a-data-table_header_${i}`}
                         tabIndex={0}
@@ -458,13 +392,13 @@ const ADataTable = forwardRef(
                           </button>
                           {x.align !== "end" && sortIcon}
                         </div>
-                      </TableHeader>
+                      </ADataTableHeader>
                     );
                   })}
                   {ExpandableComponent && (
-                    <TableHeader>Additional Details</TableHeader>
+                    <ADataTableHeader>Additional Details</ADataTableHeader>
                   )}
-                </TableRow>
+                </ADataTableRow>
               </thead>
             )}
             <tbody>
@@ -484,7 +418,7 @@ const ADataTable = forwardRef(
                   propsIsRowSelected(rowItem);
                 const isRowKeySelected = selectedRowIndex === i;
                 const rowContent = (
-                  <TableRow
+                  <ADataTableRow
                     data-expandable-row={hasExpandedRowContent}
                     isSelected={isRowSelected}
                     key={key}
@@ -497,7 +431,7 @@ const ADataTable = forwardRef(
                     }
                   >
                     {ExpandableComponent && (
-                      <TableCell>
+                      <ADataTableCell>
                         {hasExpandedRowContent && (
                           <button
                             aria-expanded={expandedRows[id] ? true : false}
@@ -512,7 +446,7 @@ const ADataTable = forwardRef(
                             </AIcon>
                           </button>
                         )}
-                      </TableCell>
+                      </ADataTableCell>
                     )}
                     {headers.map((y, j) => {
                       const {cellLoading} = rowItem;
@@ -532,7 +466,7 @@ const ADataTable = forwardRef(
                       );
 
                       return (
-                        <TableCell
+                        <ADataTableCell
                           tabIndex="-1"
                           col-index={j}
                           key={`a-data-table_cell_${j}`}
@@ -541,20 +475,20 @@ const ADataTable = forwardRef(
                           }`.trim()}
                         >
                           {content}
-                        </TableCell>
+                        </ADataTableCell>
                       );
                     })}
                     {hasExpandedRowContent && (
-                      <TableCell
+                      <ADataTableCell
                         id={id}
                         data-expandable-content
                         hidden={!expandedRows[id]}
                         role="cell"
                       >
                         <ExpandableComponent {...rowItem} />
-                      </TableCell>
+                      </ADataTableCell>
                     )}
-                  </TableRow>
+                  </ADataTableRow>
                 );
                 if (!isInfiniteScrollTarget) {
                   return rowContent;

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -688,10 +688,16 @@ const headers = [
         {
             name: "Alpha",
             key: "a",
+            properties: {
+              "data-testid": "alpha"
+            }
         },
         {
             name: "Bravo",
             key: "b",
+            properties: {
+              "data-testid": "bravo"
+            },
             cell: {
                 component: (item) => {
                     return (<input type="text" defaultValue={item.b} />);

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -694,7 +694,7 @@ const headers = [
             key: "b",
             cell: {
                 component: (item) => {
-                    return (<input type="text" value={item.b} />);
+                    return (<input type="text" defaultValue={item.b} />);
                 }
             }
         },

--- a/framework/components/ADataTable/ADataTableCell.js
+++ b/framework/components/ADataTable/ADataTableCell.js
@@ -8,6 +8,6 @@ const ADataTableCell = ({className, ...rest}) => (
   />
 );
 
-ADataTableCell.displayName = "TableCell";
+ADataTableCell.displayName = "ADataTableCell";
 
 export default ADataTableCell;

--- a/framework/components/ADataTable/ADataTableCell.js
+++ b/framework/components/ADataTable/ADataTableCell.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const ADataTableCell = ({className, ...rest}) => (
+  <td
+    role="cell"
+    className={`a-data-table__cell${className ? ` ${className}` : ""}`}
+    {...rest}
+  />
+);
+
+ADataTableCell.displayName = "TableCell";
+
+export default ADataTableCell;

--- a/framework/components/ADataTable/ADataTableCell.js
+++ b/framework/components/ADataTable/ADataTableCell.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const ADataTableCell = ({className, ...rest}) => (
   <td
@@ -9,5 +10,10 @@ const ADataTableCell = ({className, ...rest}) => (
 );
 
 ADataTableCell.displayName = "ADataTableCell";
+
+ADataTableCell.propTypes = {
+  /**  Additional class names to be applied to the table cell. */
+  className: PropTypes.string
+};
 
 export default ADataTableCell;

--- a/framework/components/ADataTable/ADataTableCellTemplate.js
+++ b/framework/components/ADataTable/ADataTableCellTemplate.js
@@ -1,8 +1,9 @@
 import {ASkeleton, ASkeletonText} from "../ASkeleton";
 import ADataTableCell from "./ADataTableCell";
 import React from "react";
+import PropTypes from "prop-types";
 
-const ADataTableCellTemplate = ({headerItem, rowItem, index}) => {
+const ADataTableCellTemplate = ({rowItem, headerItem, headerIndex}) => {
   const {cellLoading} = rowItem;
 
   const content = cellLoading ? (
@@ -18,7 +19,7 @@ const ADataTableCellTemplate = ({headerItem, rowItem, index}) => {
   return (
     <ADataTableCell
       tabIndex="-1"
-      col-index={index}
+      col-index={headerIndex}
       className={`text-${headerItem.align || "start"} ${
         headerItem.cell?.className || ""
       }`.trim()}
@@ -29,5 +30,39 @@ const ADataTableCellTemplate = ({headerItem, rowItem, index}) => {
 };
 
 ADataTableCellTemplate.displayName = "ADataTableCellTemplate";
+
+ADataTableCellTemplate.propTypes = {
+  /** Specific header item associated with "rowItem" being currently rendered */
+  headerItem: PropTypes.shape({
+    /** The text to be displayed in the header column */
+    name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /** Standard set of HTML TH properties to set on each header element.
+     * Some of these properties can be superseded by computed properties utilized for table functionality. */
+    properties: PropTypes.object,
+    /** The unique identifier to associate a column with subsequent row data */
+    key: PropTypes.string,
+    /** CSS class used to style the header column */
+    className: PropTypes.string,
+    /** The alignment of the header column text content */
+    align: PropTypes.oneOf(["start", "center", "end"]),
+    /** Determines if the column can be sorted by the user */
+    sortable: PropTypes.bool,
+    /** Sorting function for the column data */
+    sort: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+    /** Object that refers to the column's associated data table cells, i.e., <td /> elements */
+    cell: PropTypes.shape({
+      /** Class to be added to each table data element */
+      className: PropTypes.string,
+      /** Custom component to be rendered for each table data item */
+      component: PropTypes.func
+    }).isRequired
+  }),
+
+  /** Row item we are currently rendering */
+  rowItem: PropTypes.object.isRequired,
+
+  /** Header index (zero based)  */
+  headerIndex: PropTypes.number.isRequired
+};
 
 export default ADataTableCellTemplate;

--- a/framework/components/ADataTable/ADataTableCellTemplate.js
+++ b/framework/components/ADataTable/ADataTableCellTemplate.js
@@ -1,0 +1,33 @@
+import {ASkeleton, ASkeletonText} from "../ASkeleton";
+import ADataTableCell from "./ADataTableCell";
+import React from "react";
+
+const ADataTableCellTemplate = ({headerItem, rowItem, index}) => {
+  const {cellLoading} = rowItem;
+
+  const content = cellLoading ? (
+    <ASkeleton hidePanelBackdrop animated style={{padding: 0}}>
+      <ASkeletonText />
+    </ASkeleton>
+  ) : headerItem.cell?.component ? (
+    headerItem.cell.component(rowItem)
+  ) : (
+    rowItem[headerItem.key]
+  );
+
+  return (
+    <ADataTableCell
+      tabIndex="-1"
+      col-index={index}
+      className={`text-${headerItem.align || "start"} ${
+        headerItem.cell?.className || ""
+      }`.trim()}
+    >
+      {content}
+    </ADataTableCell>
+  );
+};
+
+ADataTableCellTemplate.displayName = "ADataTableCellTemplate";
+
+export default ADataTableCellTemplate;

--- a/framework/components/ADataTable/ADataTableHeader.js
+++ b/framework/components/ADataTable/ADataTableHeader.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const ADataTableHeader = ({className, ...rest}) => (
+  <th
+    role="columnheader"
+    className={`a-data-table__header${className ? ` ${className}` : ""}`}
+    {...rest}
+  />
+);
+
+ADataTableHeader.displayName = "TableHeader";
+
+export default ADataTableHeader;

--- a/framework/components/ADataTable/ADataTableHeader.js
+++ b/framework/components/ADataTable/ADataTableHeader.js
@@ -8,6 +8,6 @@ const ADataTableHeader = ({className, ...rest}) => (
   />
 );
 
-ADataTableHeader.displayName = "TableHeader";
+ADataTableHeader.displayName = "ADataTableHeader";
 
 export default ADataTableHeader;

--- a/framework/components/ADataTable/ADataTableHeader.js
+++ b/framework/components/ADataTable/ADataTableHeader.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const ADataTableHeader = ({className, ...rest}) => (
   <th
@@ -9,5 +10,10 @@ const ADataTableHeader = ({className, ...rest}) => (
 );
 
 ADataTableHeader.displayName = "ADataTableHeader";
+
+ADataTableHeader.propTypes = {
+  /**  Additional class names to be applied to the table header. */
+  className: PropTypes.string
+};
 
 export default ADataTableHeader;

--- a/framework/components/ADataTable/ADataTableHeaderTemplate.js
+++ b/framework/components/ADataTable/ADataTableHeaderTemplate.js
@@ -2,6 +2,7 @@ import React from "react";
 import ADataTableHeader from "./ADataTableHeader";
 import AIcon from "../AIcon";
 import {keyCodes} from "../../utils/helpers";
+import PropTypes from "prop-types";
 
 export const getSortIconName = (column, sort) => {
   if (!sort || column.key !== sort.key) {
@@ -20,11 +21,11 @@ export const getSortIconName = (column, sort) => {
 
 const ADataTableHeaderTemplate = ({
   headerItem,
-  index,
   sort,
   onSort,
+  disableSortReset,
   setExpandedRows,
-  disableSortReset
+  ...rest
 }) => {
   const headerProps = {
     className: `a-data-table__header ${
@@ -36,10 +37,10 @@ const ADataTableHeaderTemplate = ({
     scope: "col",
     "aria-label": headerItem.name,
     style: headerItem.style,
-    wrap: headerItem.wrap
+    wrap: headerItem.wrap,
+    ...rest
   };
 
-  const sortableBtnProps = {};
   let onClick;
   if (headerItem.sortable) {
     if (!sort || headerItem.key !== sort.key) {
@@ -89,7 +90,7 @@ const ADataTableHeaderTemplate = ({
 
   if (!headerItem.sortable) {
     return (
-      <ADataTableHeader {...headerProps} key={`a-data-table_header_${index}`}>
+      <ADataTableHeader {...headerProps}>
         <span className="a-data-table__header__label">{headerItem.name}</span>
       </ADataTableHeader>
     );
@@ -123,11 +124,7 @@ const ADataTableHeaderTemplate = ({
     >
       <div className="a-data-table__header__sort-wrap">
         {headerItem.align === "end" && sortIcon}
-        <button
-          {...sortableBtnProps}
-          tabIndex={-1}
-          className="a-data-table__header__sort__button"
-        >
+        <button tabIndex={-1} className="a-data-table__header__sort__button">
           <span className="a-data-table__header__label">{headerItem.name}</span>
         </button>
         {headerItem.align !== "end" && sortIcon}
@@ -137,5 +134,56 @@ const ADataTableHeaderTemplate = ({
 };
 
 ADataTableHeaderTemplate.displayName = "ADataTableHeaderTemplate";
+
+ADataTableHeaderTemplate.propTypes = {
+  /** Particular header item which is currently being rendered */
+  headerItem: PropTypes.shape({
+    /** The text to be displayed in the header column */
+    name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /** Standard set of HTML TH properties to set on each header element.
+     * Some of these properties can be superseded by computed properties utilized for table functionality. */
+    properties: PropTypes.object,
+    /** The unique identifier to associate a column with subsequent row data */
+    key: PropTypes.string,
+    /** CSS class used to style the header column */
+    className: PropTypes.string,
+    /** The alignment of the header column text content */
+    align: PropTypes.oneOf(["start", "center", "end"]),
+    /** Determines if the column can be sorted by the user */
+    sortable: PropTypes.bool,
+    /** Sorting function for the column data */
+    sort: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+    /** Object that refers to the column's associated data table cells, i.e., <td /> elements */
+    cell: PropTypes.shape({
+      /** Class to be added to each table data element */
+      className: PropTypes.string,
+      /** Custom component to be rendered for each table data item */
+      component: PropTypes.func
+    }).isRequired
+  }),
+
+  /**
+   * `sort` configuration
+   */
+  sort: PropTypes.shape({
+    key: PropTypes.string,
+    direction: PropTypes.oneOf(["asc", "desc"])
+  }),
+
+  /**
+   * `sort` click event handler
+   */
+  onSort: PropTypes.func,
+
+  /**
+   * Disables third click of header sort icon to unset sorting.
+   */
+  disableSortReset: PropTypes.bool,
+
+  /**
+   * Expanded row's state setter.
+   */
+  setExpandedRows: PropTypes.func
+};
 
 export default ADataTableHeaderTemplate;

--- a/framework/components/ADataTable/ADataTableHeaderTemplate.js
+++ b/framework/components/ADataTable/ADataTableHeaderTemplate.js
@@ -1,0 +1,141 @@
+import React from "react";
+import ADataTableHeader from "./ADataTableHeader";
+import AIcon from "../AIcon";
+import {keyCodes} from "../../utils/helpers";
+
+export const getSortIconName = (column, sort) => {
+  if (!sort || column.key !== sort.key) {
+    return "sort-empty";
+  }
+
+  switch (sort.direction) {
+    case "asc":
+      return "sort-up";
+    case "desc":
+      return "sort-down";
+    default:
+      return "sort-empty";
+  }
+};
+
+const ADataTableHeaderTemplate = ({
+  headerItem,
+  index,
+  sort,
+  onSort,
+  setExpandedRows,
+  disableSortReset
+}) => {
+  const headerProps = {
+    className: `a-data-table__header ${
+      headerItem.sortable ? "a-data-table__header--sortable" : ""
+    } text-${headerItem.align || "start"} ${headerItem.className || ""}`
+      .replace("  ", " ")
+      .trim(),
+    role: "columnheader",
+    scope: "col",
+    "aria-label": headerItem.name,
+    style: headerItem.style,
+    wrap: headerItem.wrap
+  };
+
+  const sortableBtnProps = {};
+  let onClick;
+  if (headerItem.sortable) {
+    if (!sort || headerItem.key !== sort.key) {
+      headerProps["aria-label"] += ": Not sorted. Activate to sort ascending.";
+      headerProps["aria-sort"] = "none";
+    } else if (sort && sort.direction === "asc") {
+      headerProps["aria-label"] +=
+        ": Sorted ascending. Activate to sort descending.";
+      headerProps["aria-sort"] = "ascending";
+    } else {
+      headerProps["aria-label"] +=
+        ": Sorted descending. Activate to remove sorting.";
+      headerProps["aria-sort"] = "descending";
+    }
+
+    onClick = () => {
+      setExpandedRows({});
+      if (!onSort) {
+        return;
+      }
+
+      if (!disableSortReset) {
+        onSort(
+          sort && sort.key === headerItem.key && sort.direction === "desc"
+            ? null
+            : {
+                key: headerItem.key,
+                direction:
+                  sort &&
+                  headerItem.key === sort.key &&
+                  sort.direction === "asc"
+                    ? "desc"
+                    : "asc"
+              }
+        );
+      } else {
+        onSort({
+          key: headerItem.key,
+          direction:
+            sort && headerItem.key === sort.key && sort.direction === "asc"
+              ? "desc"
+              : "asc"
+        });
+      }
+    };
+  }
+
+  if (!headerItem.sortable) {
+    return (
+      <ADataTableHeader {...headerProps} key={`a-data-table_header_${index}`}>
+        <span className="a-data-table__header__label">{headerItem.name}</span>
+      </ADataTableHeader>
+    );
+  }
+
+  let sortIcon = headerItem.sortable && (
+    <AIcon
+      left={headerItem.align === "end"}
+      right={headerItem.align !== "end"}
+      className={`a-data-table__header__sort ${
+        sort && headerItem.key === sort.key
+          ? "a-data-table__header__sort--active"
+          : ""
+      }`}
+    >
+      {getSortIconName(headerItem, sort)}
+    </AIcon>
+  );
+
+  return (
+    <ADataTableHeader
+      {...headerProps}
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if ([keyCodes.enter, keyCodes.space].includes(e.keyCode)) {
+          e.preventDefault();
+          onClick && onClick(e);
+        }
+      }}
+    >
+      <div className="a-data-table__header__sort-wrap">
+        {headerItem.align === "end" && sortIcon}
+        <button
+          {...sortableBtnProps}
+          tabIndex={-1}
+          className="a-data-table__header__sort__button"
+        >
+          <span className="a-data-table__header__label">{headerItem.name}</span>
+        </button>
+        {headerItem.align !== "end" && sortIcon}
+      </div>
+    </ADataTableHeader>
+  );
+};
+
+ADataTableHeaderTemplate.displayName = "ADataTableHeaderTemplate";
+
+export default ADataTableHeaderTemplate;

--- a/framework/components/ADataTable/ADataTableRow.js
+++ b/framework/components/ADataTable/ADataTableRow.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const ADataTableRow = ({
   className: propsClassName,
@@ -21,5 +22,16 @@ const ADataTableRow = ({
 };
 
 ADataTableRow.displayName = "ADataTableRow";
+
+ADataTableRow.propTypes = {
+  /**  Additional class names to be applied to the table row. */
+  className: PropTypes.string,
+
+  /** Is this row selected */
+  isSelected: PropTypes.bool,
+
+  /** Is this row selected by keyboard navigation */
+  isKeySelected: PropTypes.bool
+};
 
 export default ADataTableRow;

--- a/framework/components/ADataTable/ADataTableRow.js
+++ b/framework/components/ADataTable/ADataTableRow.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+const ADataTableRow = ({
+  className: propsClassName,
+  isKeySelected,
+  isSelected,
+  ...rest
+}) => {
+  let className = "a-data-table__row";
+  if (isSelected) {
+    className += " a-data-table__row--selected";
+  }
+  if (isKeySelected) {
+    className += " a-data-table__row--key-selected";
+  }
+  if (propsClassName) {
+    className += ` ${propsClassName}`;
+  }
+
+  return <tr role="row" className={className} {...rest} />;
+};
+
+ADataTableRow.displayName = "TableRow";
+
+export default ADataTableRow;

--- a/framework/components/ADataTable/ADataTableRow.js
+++ b/framework/components/ADataTable/ADataTableRow.js
@@ -20,6 +20,6 @@ const ADataTableRow = ({
   return <tr role="row" className={className} {...rest} />;
 };
 
-ADataTableRow.displayName = "TableRow";
+ADataTableRow.displayName = "ADataTableRow";
 
 export default ADataTableRow;

--- a/framework/components/ADataTable/ADataTableRowTemplate.js
+++ b/framework/components/ADataTable/ADataTableRowTemplate.js
@@ -4,20 +4,21 @@ import ADataTableCell from "./ADataTableCell";
 import AIcon from "../AIcon";
 import ADataTableCellTemplate from "./ADataTableCellTemplate";
 import AInView from "../AInView";
+import PropTypes from "prop-types";
 
 const ADataTableRowTemplate = ({
   rowItem,
   rowIndex,
-  isLastRow,
   headers,
+  isLastRow,
   onScrollToEnd,
   expandable,
-  expandedRows,
-  toggleRow,
+  toggleExpandedRow,
+  isExpandedRow,
   ExpandableComponent,
-  propsIsRowSelected,
-  selectedRowIndex,
-  propsOnRowClick
+  onRowClick,
+  isSelected,
+  isKeySelected
 }) => {
   const id = `a-data-table_row_${rowIndex}`;
   const isInfiniteScrollTarget =
@@ -27,31 +28,29 @@ const ADataTableRowTemplate = ({
     (typeof expandable.isRowExpandable === "function"
       ? expandable.isRowExpandable(rowItem)
       : true);
-  const isRowSelected =
-    typeof propsIsRowSelected === "function" && propsIsRowSelected(rowItem);
-  const isRowKeySelected = selectedRowIndex === rowIndex;
+
   const rowContent = (
     <ADataTableRow
       data-expandable-row={hasExpandedRowContent}
-      isSelected={isRowSelected}
-      isKeySelected={isRowKeySelected}
+      isSelected={isSelected}
+      isKeySelected={isKeySelected}
       row-index={rowIndex}
       tabIndex="-1"
       onClick={(e) =>
-        typeof propsOnRowClick === "function" && propsOnRowClick(rowItem, e)
+        typeof onRowClick === "function" && onRowClick(rowItem, e)
       }
     >
       {ExpandableComponent && (
         <ADataTableCell>
           {hasExpandedRowContent && (
             <button
-              aria-expanded={!!expandedRows[id]}
+              aria-expanded={isExpandedRow}
               aria-controls={id}
               className="a-data-table__cell__btn--expand"
-              onClick={toggleRow(id)}
+              onClick={() => toggleExpandedRow(`${rowIndex}`)}
             >
               <AIcon size={12}>
-                {expandedRows[id] ? "chevron-down" : "chevron-right"}
+                {isExpandedRow ? "chevron-down" : "chevron-right"}
               </AIcon>
             </button>
           )}
@@ -62,14 +61,14 @@ const ADataTableRowTemplate = ({
           key={`a-data-table_cell_${headerIndex}`}
           rowItem={rowItem}
           headerItem={headerItem}
-          index={headerIndex}
+          headerIndex={headerIndex}
         />
       ))}
       {hasExpandedRowContent && (
         <ADataTableCell
           id={id}
           data-expandable-content
-          hidden={!expandedRows[id]}
+          hidden={!isExpandedRow}
           role="cell"
         >
           <ExpandableComponent {...rowItem} />
@@ -96,5 +95,78 @@ const ADataTableRowTemplate = ({
 };
 
 ADataTableRowTemplate.displayName = "ADataTableRowTemplate";
+
+ADataTableRowTemplate.propTypes = {
+  /** Current row item being rendered */
+  rowItem: PropTypes.object.isRequired,
+
+  /** Zero based index of row item being rendered */
+  rowIndex: PropTypes.object.isRequired,
+
+  /** The table headers containing row renderers */
+  headers: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** The text to be displayed in the header column */
+      name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+      /** Standard set of HTML TH properties to set on each header element.
+       * Some of these properties can be superseded by computed properties utilized for table functionality. */
+      properties: PropTypes.object,
+      /** The unique identifier to associate a column with subsequent row data */
+      key: PropTypes.string,
+      /** CSS class used to style the header column */
+      className: PropTypes.string,
+      /** The alignment of the header column text content */
+      align: PropTypes.oneOf(["start", "center", "end"]),
+      /** Determines if the column can be sorted by the user */
+      sortable: PropTypes.bool,
+      /** Sorting function for the column data */
+      sort: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+      /** Object that refers to the column's associated data table cells, i.e., <td /> elements */
+      cell: PropTypes.shape({
+        /** Class to be added to each table data element */
+        className: PropTypes.string,
+        /** Custom component to be rendered for each table data item */
+        component: PropTypes.func
+      })
+    })
+  ).isRequired,
+
+  /** When we are on the last row true, false otherwise  */
+  isLastRow: PropTypes.bool.isRequired,
+
+  /** Handler called when we scroll to last visible item */
+  onScrollToEnd: PropTypes.func,
+
+  /**
+   * Configuration object for expandable table rows
+   */
+  expandable: PropTypes.shape({
+    /** The component to be rendered on expansion */
+    component: PropTypes.func.isRequired,
+    /**
+     * (optional): A function called when rendering each row to determine
+     * if the row can be expanded an collapsed
+     */
+    isRowExpandable: PropTypes.func
+  }),
+
+  /** Handler called when row is expended/collapsed */
+  toggleExpandedRow: PropTypes.func,
+
+  /** Indicator if row is expanded or collapsed */
+  isExpandedRow: PropTypes.bool,
+
+  /** Resolved expandable component */
+  ExpandableComponent: PropTypes.elementType,
+
+  /** On row click event handler */
+  onRowClick: PropTypes.func,
+
+  /** Is this row selected */
+  isSelected: PropTypes.bool,
+
+  /** Is this row selected by keyboard navigation */
+  isKeySelected: PropTypes.bool
+};
 
 export default ADataTableRowTemplate;

--- a/framework/components/ADataTable/ADataTableRowTemplate.js
+++ b/framework/components/ADataTable/ADataTableRowTemplate.js
@@ -1,0 +1,100 @@
+import React from "react";
+import ADataTableRow from "./ADataTableRow";
+import ADataTableCell from "./ADataTableCell";
+import AIcon from "../AIcon";
+import ADataTableCellTemplate from "./ADataTableCellTemplate";
+import AInView from "../AInView";
+
+const ADataTableRowTemplate = ({
+  rowItem,
+  rowIndex,
+  isLastRow,
+  headers,
+  onScrollToEnd,
+  expandable,
+  expandedRows,
+  toggleRow,
+  ExpandableComponent,
+  propsIsRowSelected,
+  selectedRowIndex,
+  propsOnRowClick
+}) => {
+  const id = `a-data-table_row_${rowIndex}`;
+  const isInfiniteScrollTarget =
+    isLastRow && typeof onScrollToEnd === "function";
+  const hasExpandedRowContent =
+    ExpandableComponent &&
+    (typeof expandable.isRowExpandable === "function"
+      ? expandable.isRowExpandable(rowItem)
+      : true);
+  const isRowSelected =
+    typeof propsIsRowSelected === "function" && propsIsRowSelected(rowItem);
+  const isRowKeySelected = selectedRowIndex === rowIndex;
+  const rowContent = (
+    <ADataTableRow
+      data-expandable-row={hasExpandedRowContent}
+      isSelected={isRowSelected}
+      isKeySelected={isRowKeySelected}
+      row-index={rowIndex}
+      tabIndex="-1"
+      onClick={(e) =>
+        typeof propsOnRowClick === "function" && propsOnRowClick(rowItem, e)
+      }
+    >
+      {ExpandableComponent && (
+        <ADataTableCell>
+          {hasExpandedRowContent && (
+            <button
+              aria-expanded={!!expandedRows[id]}
+              aria-controls={id}
+              className="a-data-table__cell__btn--expand"
+              onClick={toggleRow(id)}
+            >
+              <AIcon size={12}>
+                {expandedRows[id] ? "chevron-down" : "chevron-right"}
+              </AIcon>
+            </button>
+          )}
+        </ADataTableCell>
+      )}
+      {headers.map((headerItem, headerIndex) => (
+        <ADataTableCellTemplate
+          key={`a-data-table_cell_${headerIndex}`}
+          rowItem={rowItem}
+          headerItem={headerItem}
+          index={headerIndex}
+        />
+      ))}
+      {hasExpandedRowContent && (
+        <ADataTableCell
+          id={id}
+          data-expandable-content
+          hidden={!expandedRows[id]}
+          role="cell"
+        >
+          <ExpandableComponent {...rowItem} />
+        </ADataTableCell>
+      )}
+    </ADataTableRow>
+  );
+  if (!isInfiniteScrollTarget) {
+    return rowContent;
+  }
+
+  return (
+    <AInView
+      triggerOnce
+      onChange={({inView, entry}) => {
+        if (inView) {
+          onScrollToEnd(entry);
+        }
+      }}
+    >
+      {rowContent}
+    </AInView>
+  );
+};
+
+ADataTableRowTemplate.displayName = "ADataTableRowTemplate";
+
+export default ADataTableRowTemplate;

--- a/framework/components/ADataTable/ADataTableWrapper.js
+++ b/framework/components/ADataTable/ADataTableWrapper.js
@@ -1,0 +1,32 @@
+/**
+ * Used inside ADataTable to enable proper styling
+ * for infinite scrolling
+ */
+const ADataTableWrapper = ({
+  shouldWrap,
+  maxHeight,
+  style,
+  children,
+  ...rest
+}) => {
+  if (!shouldWrap) {
+    return children;
+  }
+
+  return (
+    <div
+      data-testid="table-wrapper"
+      style={{
+        ...style,
+        overflowY: "scroll",
+        maxHeight
+      }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+ADataTableWrapper.displayName = "ADataTableWrapper";
+
+export default ADataTableWrapper;

--- a/framework/components/ADataTable/ADataTableWrapper.js
+++ b/framework/components/ADataTable/ADataTableWrapper.js
@@ -27,6 +27,7 @@ const ADataTableWrapper = ({
     </div>
   );
 };
+
 ADataTableWrapper.displayName = "ADataTableWrapper";
 
 export default ADataTableWrapper;

--- a/framework/components/ADataTable/useKeyboardNavigation.js
+++ b/framework/components/ADataTable/useKeyboardNavigation.js
@@ -10,20 +10,20 @@ const useKeyboardNavigation = ({
   items,
   getRowByIndex
 }) => {
-  const [selectedRowIndex, setSelectedRowIndex] = useState(-1); // zero based index in items array, -1 for no index
+  const [keySelectedRowIndex, setKeySelectedRowIndex] = useState(-1); // zero based index in items array, -1 for no index
 
   const handleArrowKeydown = useCallback(
     (key, event) => {
       let nextRowIndex;
 
-      if (selectedRowIndex === -1) {
+      if (keySelectedRowIndex === -1) {
         // first move
         if (key === ARROW_UP) nextRowIndex = items.length - 1;
         else nextRowIndex = 0;
       } else {
         // subsequent moves
-        if (key === ARROW_UP) nextRowIndex = selectedRowIndex - 1;
-        else nextRowIndex = selectedRowIndex + 1;
+        if (key === ARROW_UP) nextRowIndex = keySelectedRowIndex - 1;
+        else nextRowIndex = keySelectedRowIndex + 1;
       }
 
       if (items[nextRowIndex] === undefined) {
@@ -31,7 +31,7 @@ const useKeyboardNavigation = ({
         return;
       }
 
-      setSelectedRowIndex(nextRowIndex);
+      setKeySelectedRowIndex(nextRowIndex);
 
       if (typeof keyboardArrowSupport?.onKeyboardSelect === "function") {
         keyboardArrowSupport?.onKeyboardSelect(
@@ -42,7 +42,7 @@ const useKeyboardNavigation = ({
     },
     // having keyboardArrowSupport in deps causes unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [items, selectedRowIndex, keyboardArrowSupport?.onKeyboardSelect]
+    [items, keySelectedRowIndex, keyboardArrowSupport?.onKeyboardSelect]
   );
 
   const onTableBlur = useCallback(
@@ -51,7 +51,7 @@ const useKeyboardNavigation = ({
 
       const isEventsInTable = event.currentTarget.contains(event.relatedTarget);
       if (!isEventsInTable) {
-        setSelectedRowIndex(-1);
+        setKeySelectedRowIndex(-1);
         if (typeof keyboardArrowSupport?.onKeyboardSelect === "function") {
           keyboardArrowSupport?.onKeyboardSelect(
             {index: -1, item: undefined},
@@ -68,7 +68,7 @@ const useKeyboardNavigation = ({
   );
 
   useEffect(() => {
-    if (keyboardArrowSupport === null || selectedRowIndex === -1) return;
+    if (keyboardArrowSupport === null || keySelectedRowIndex === -1) return;
 
     const {
       disableRowAutoFocus,
@@ -78,7 +78,7 @@ const useKeyboardNavigation = ({
 
     if (disableRowAutoFocus) return;
 
-    const row = getRowByIndex && getRowByIndex(selectedRowIndex);
+    const row = getRowByIndex && getRowByIndex(keySelectedRowIndex);
     if (!row) return;
 
     if (activeRowFocusSelector) {
@@ -95,7 +95,7 @@ const useKeyboardNavigation = ({
     keyboardArrowSupport?.disableRowAutoFocus,
     keyboardArrowSupport?.activeRowFocusSelector,
     keyboardArrowSupport?.overrideFocusOptions,
-    selectedRowIndex
+    keySelectedRowIndex
   ]);
 
   useEffect(() => {
@@ -103,9 +103,9 @@ const useKeyboardNavigation = ({
 
     const index = keyboardArrowSupport.initiallySelectedRowIndex;
     if (typeof index === "number" && items[index]) {
-      setSelectedRowIndex(index);
+      setKeySelectedRowIndex(index);
     } else {
-      setSelectedRowIndex(-1);
+      setKeySelectedRowIndex(-1);
     }
     // having keyboardArrowSupport in deps causes unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -114,7 +114,7 @@ const useKeyboardNavigation = ({
   useKeydown(ARROW_KEYS, handleArrowKeydown, keyboardArrowSupport !== null);
 
   return {
-    selectedRowIndex,
+    keySelectedRowIndex,
     onTableBlur
   };
 };

--- a/framework/components/ADataTable/useKeyboardNavigation.js
+++ b/framework/components/ADataTable/useKeyboardNavigation.js
@@ -1,0 +1,122 @@
+import {useCallback, useEffect, useState} from "react";
+import useKeydown from "../../hooks/useKeydown/useKeydown";
+
+const ARROW_UP = "ArrowUp";
+const ARROW_DOWN = "ArrowDown";
+const ARROW_KEYS = [ARROW_UP, ARROW_DOWN];
+
+const useKeyboardNavigation = ({
+  keyboardArrowSupport,
+  items,
+  getRowByIndex
+}) => {
+  const [selectedRowIndex, setSelectedRowIndex] = useState(-1); // zero based index in items array, -1 for no index
+
+  const handleArrowKeydown = useCallback(
+    (key, event) => {
+      let nextRowIndex;
+
+      if (selectedRowIndex === -1) {
+        // first move
+        if (key === ARROW_UP) nextRowIndex = items.length - 1;
+        else nextRowIndex = 0;
+      } else {
+        // subsequent moves
+        if (key === ARROW_UP) nextRowIndex = selectedRowIndex - 1;
+        else nextRowIndex = selectedRowIndex + 1;
+      }
+
+      if (items[nextRowIndex] === undefined) {
+        // out of items index
+        return;
+      }
+
+      setSelectedRowIndex(nextRowIndex);
+
+      if (typeof keyboardArrowSupport?.onKeyboardSelect === "function") {
+        keyboardArrowSupport?.onKeyboardSelect(
+          {index: nextRowIndex, item: items[nextRowIndex]},
+          event
+        );
+      }
+    },
+    // having keyboardArrowSupport in deps causes unnecessary re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items, selectedRowIndex, keyboardArrowSupport?.onKeyboardSelect]
+  );
+
+  const onTableBlur = useCallback(
+    (event) => {
+      if (keyboardArrowSupport?.disableOnBlurReset) return;
+
+      const isEventsInTable = event.currentTarget.contains(event.relatedTarget);
+      if (!isEventsInTable) {
+        setSelectedRowIndex(-1);
+        if (typeof keyboardArrowSupport?.onKeyboardSelect === "function") {
+          keyboardArrowSupport?.onKeyboardSelect(
+            {index: -1, item: undefined},
+            event
+          );
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      keyboardArrowSupport?.disableOnBlurReset,
+      keyboardArrowSupport?.onKeyboardSelect
+    ]
+  );
+
+  useEffect(() => {
+    if (keyboardArrowSupport === null || selectedRowIndex === -1) return;
+
+    const {
+      disableRowAutoFocus,
+      activeRowFocusSelector,
+      overrideFocusOptions = {}
+    } = keyboardArrowSupport;
+
+    if (disableRowAutoFocus) return;
+
+    const row = getRowByIndex && getRowByIndex(selectedRowIndex);
+    if (!row) return;
+
+    if (activeRowFocusSelector) {
+      const element = row.querySelector(activeRowFocusSelector);
+      if (element && element.focus) {
+        element.focus(overrideFocusOptions);
+      }
+    } else {
+      row.focus(overrideFocusOptions);
+    }
+    // combinedTableRef should not need to be in deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    keyboardArrowSupport?.disableRowAutoFocus,
+    keyboardArrowSupport?.activeRowFocusSelector,
+    keyboardArrowSupport?.overrideFocusOptions,
+    selectedRowIndex
+  ]);
+
+  useEffect(() => {
+    if (keyboardArrowSupport === null) return;
+
+    const index = keyboardArrowSupport.initiallySelectedRowIndex;
+    if (typeof index === "number" && items[index]) {
+      setSelectedRowIndex(index);
+    } else {
+      setSelectedRowIndex(-1);
+    }
+    // having keyboardArrowSupport in deps causes unnecessary re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyboardArrowSupport?.initiallySelectedRowIndex, items]);
+
+  useKeydown(ARROW_KEYS, handleArrowKeydown, keyboardArrowSupport !== null);
+
+  return {
+    selectedRowIndex,
+    onTableBlur
+  };
+};
+
+export default useKeyboardNavigation;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally
- [x] The component should accept a class name as a prop, if appropriate
- [x] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?**
- supports: [#2047](https://github.com/advthreat/incident-manager/issues/2047)
- be able to add attributes which will be rendered on header elements
- split very complex ADataTable code to logical components which should help when adding new features

**What is the current behavior?**
- there is no possibility to pass any attribute to ADataTableHeader level.

**What is the new behavior (if this is a feature change)?**
- we can add properties which are used while rendering ADataTableHeader elements.

**Does this PR introduce a breaking change?** 
- no, this feature was created to maintain backward compatibility


