### PR TITLE
feat: divider additions

### DIFF
--- a/framework/components/ADivider/ADivider.js
+++ b/framework/components/ADivider/ADivider.js
@@ -4,11 +4,24 @@ import React, {forwardRef} from "react";
 import "./ADivider.scss";
 
 const ADivider = forwardRef(
-  ({className: propsClassName, light, role = "separator", ...rest}, ref) => {
+  (
+    {
+      className: propsClassName,
+      light = false,
+      strong = false,
+      role = "separator",
+      ...rest
+    },
+    ref
+  ) => {
     let className = "a-divider";
 
     if (light) {
-      className += " a-divider--color-light";
+      className += " a-divider--light";
+    }
+
+    if (strong) {
+      className += " a-divider--strong";
     }
 
     if (propsClassName) {
@@ -25,9 +38,13 @@ ADivider.defaultProps = {
 
 ADivider.propTypes = {
   /**
-   * Toggles the light variant.
+   * Toggles the light variant (1px vs 2px).
    */
   light: PropTypes.bool,
+  /**
+   * Toggles the strong variant.
+   */
+  strong: PropTypes.bool,
   /**
    * Sets the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role.
    */

--- a/framework/components/ADivider/ADivider.mdx
+++ b/framework/components/ADivider/ADivider.mdx
@@ -23,6 +23,8 @@ import {ADivider} from "@cisco-sbg-ui/magna-react";
   {LoremIpsum}
   <ADivider light />
   {LoremIpsum}
+  <ADivider light strong />
+  {LoremIpsum}
 </>
 `}
 />

--- a/framework/components/ADivider/ADivider.scss
+++ b/framework/components/ADivider/ADivider.scss
@@ -3,8 +3,8 @@
 @include theme(a-divider) using ($theme) {
   border-color: map-deep-get($theme, "divider", "color-default");
 
-  &--color-light {
-    border-color: map-deep-get($theme, "divider", "color-light");
+  &--strong {
+    border-color: map-deep-get($theme, "divider", "color-strong");
   }
 }
 
@@ -13,4 +13,8 @@
   border-width: $border-width 0 0 0;
   border-style: solid;
   margin: 20px 0;
+
+  &--light {
+    border-width: 1px 0 0 0;
+  }
 }

--- a/framework/styles/theme/theme-map.scss
+++ b/framework/styles/theme/theme-map.scss
@@ -205,7 +205,7 @@ $themeMap: (
   ),
   "divider": (
     "color-default": $base-border-default,
-    "color-light": $base-border-medium-default
+    "color-strong": $base-border-strong-default
   ),
   "drawer": (
     "bg": $control-bg-weak-default


### PR DESCRIPTION
Closes #586 - Adds options to divider

- No breaking changes to default (2px)
- `Light` variant now refers to height which will be 1px
- Adds option for `strong` variant which is a darker color

![Screenshot 2024-01-05 at 12 29 25 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/67a032e2-83be-4b1b-87ab-dc75e433bcc8)
