### PR TITLE
fix: add identifier

### DIFF
--- a/framework/components/AList/AList.scss
+++ b/framework/components/AList/AList.scss
@@ -42,7 +42,7 @@
   }
 
   a.a-list-item,
-  a:not(.a-tab-group__tab) {
+  &a:not(.a-tab-group__tab) {
     color: map-deep-get($theme, "base", "color") !important;
     font-weight: unset;
   }


### PR DESCRIPTION
Closes #588 - Decouple styling

Seems like this might take care of it.

<img width="436" alt="Screenshot 2024-01-08 at 3 33 04 PM" src="https://github.com/cisco-sbg-ui/magna-react/assets/112431822/c5a261d3-6759-4dd8-95a3-f9ae7eabc568">
<img width="246" alt="Screenshot 2024-01-08 at 3 33 26 PM" src="https://github.com/cisco-sbg-ui/magna-react/assets/112431822/2f4a185d-1f23-40d6-a3c8-28c399240e53">
