### PR TITLE
Add generic prepend and append content to ATextInput

### DIFF
--- a/framework/components/AInputBase/AInputBase.js
+++ b/framework/components/AInputBase/AInputBase.js
@@ -34,12 +34,19 @@ const AInputBase = forwardRef(
     },
     ref
   ) => {
+    const showPrepend =
+        (Array.isArray(prepend) && prepend.length) ||
+        (!Array.isArray(prepend) && prepend),
+      showAppend =
+        (Array.isArray(append) && append.length) ||
+        (!Array.isArray(append) && append);
+
     let className = "a-input-base";
-    if (prepend) {
+    if (showPrepend) {
       className += " a-input-base--prepend";
     }
 
-    if (append) {
+    if (showAppend) {
       className += " a-input-base--append";
     }
 
@@ -89,9 +96,11 @@ const AInputBase = forwardRef(
         validationState={validationState}
       >
         <div ref={surfaceRef} className="a-input-base__surface">
-          {prepend && <div className="a-input-base__prepend">{prepend}</div>}
+          {showPrepend && (
+            <div className="a-input-base__prepend">{prepend}</div>
+          )}
           <div className="a-input-base__control">{children}</div>
-          {(append || clearable) && (
+          {(showAppend || clearable) && (
             <div className="a-input-base__append">
               {clearable && !readOnly && (
                 <AButton

--- a/framework/components/AInputBase/AInputBase.scss
+++ b/framework/components/AInputBase/AInputBase.scss
@@ -142,6 +142,13 @@ $input-transition: border-color $transition-duration--extra-fast
     grid-auto-flow: column;
   }
 
+  &__prepend,
+  &__append {
+    .a-button {
+      height: unset;
+    }
+  }
+
   &--disabled {
     .a-input-base__surface {
       @include disabled;

--- a/framework/components/ATextInput/ATextInput.cy.js
+++ b/framework/components/ATextInput/ATextInput.cy.js
@@ -1,3 +1,4 @@
+import AButton from "../AButton";
 import ATextInput from "./ATextInput";
 
 const commonProps = {
@@ -138,6 +139,41 @@ describe("<ATextInput />", () => {
       cy.get(".a-text-input__input").type("clearable text");
 
       cy.get(".a-input-base__clear").should("not.exist");
+    });
+  });
+
+  describe("when rendered with an append icon", () => {
+    let mockFn;
+    let appendProps;
+
+    beforeEach(() => {
+      mockFn = cy.stub();
+      appendProps = {
+        appendIcon: "star",
+        onClickAppend: mockFn
+      };
+    });
+  });
+
+  describe("when rendered with append content", () => {
+    let mockFn;
+
+    beforeEach(() => {
+      mockFn = cy.stub();
+    });
+
+    it("should handle clicks to the button", () => {
+      cy.mount(
+        <ATextInput
+          {...commonProps}
+          append={<AButton onClick={mockFn}>Show</AButton>}
+        />
+      );
+      cy.get(".a-button")
+        .click()
+        .then(() => {
+          expect(mockFn.callCount).to.eq(1);
+        });
     });
   });
 

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -451,7 +451,8 @@ const {anchorRef, ...infoTooltipProps} = ATooltipPropTypes;
 
 ATextInput.propTypes = {
   /**
-   * Append elements inside the text input
+   * Append elements inside the text input. This allows for custom buttons or other
+   * DOM elements to be used instead of an icon or icon+button.
    */
   append: PropTypes.node,
   /**
@@ -547,7 +548,8 @@ ATextInput.propTypes = {
    */
   placeholder: PropTypes.string,
   /**
-   * Append elements inside the text input
+   * Append elements inside the text input. This allows for custom buttons or other
+   * DOM elements to be used instead of an icon or icon+button.
    */
   prepend: PropTypes.node,
   /**

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -29,6 +29,7 @@ function isNonEmptyString(maybeString) {
 const ATextInput = forwardRef(
   (
     {
+      append: propsAppend,
       appendIcon,
       autoComplete,
       autoFocus,
@@ -52,6 +53,7 @@ const ATextInput = forwardRef(
       onKeyUp,
       onPaste,
       placeholder,
+      prepend: propsPrepend,
       prependIcon,
       readOnly,
       required,
@@ -159,7 +161,8 @@ const ATextInput = forwardRef(
       appendProps.role = "button";
     }
 
-    let appendContent = [];
+    let prependContent = [],
+      appendContent = [];
 
     const isNumberType = type === "number";
 
@@ -276,6 +279,18 @@ const ATextInput = forwardRef(
       appendContent.push(<AIcon {...appendProps}>{appendIcon}</AIcon>);
     }
 
+    if (propsAppend) {
+      appendContent.push(propsAppend);
+    }
+
+    if (propsPrepend) {
+      prependContent.push(propsPrepend);
+    }
+
+    if (prependIcon) {
+      prependContent.push(<AIcon {...prependProps}>{prependIcon}</AIcon>);
+    }
+
     const ruleKeys = rules ? rules.map((r) => r.key).filter((k) => !!k) : [];
 
     const validate = (testValue = nativeInputValue) => {
@@ -366,7 +381,7 @@ const ATextInput = forwardRef(
       disabled,
       focused: isFocused,
       append: appendContent,
-      prepend: prependIcon && <AIcon {...prependProps}>{prependIcon}</AIcon>,
+      prepend: prependContent,
       readOnly,
       validationState: workingValidationState,
       onClear: () => {
@@ -435,6 +450,10 @@ const ATextInput = forwardRef(
 const {anchorRef, ...infoTooltipProps} = ATooltipPropTypes;
 
 ATextInput.propTypes = {
+  /**
+   * Append elements inside the text input
+   */
+  append: PropTypes.node,
   /**
    * Appends an icon inside the text input. The value should be an [icon name](/components/icon).
    */
@@ -527,6 +546,10 @@ ATextInput.propTypes = {
    * The input's `placeholder` attribute.
    */
   placeholder: PropTypes.string,
+  /**
+   * Append elements inside the text input
+   */
+  prepend: PropTypes.node,
   /**
    * Prepends an icon inside the text input. The value should be an [icon name](/components/icon).
    */

--- a/framework/components/ATextInput/ATextInput.mdx
+++ b/framework/components/ATextInput/ATextInput.mdx
@@ -372,6 +372,30 @@ Override internal validation rules by specifying a `key` on the rule. Valid keys
 `}
 />
 
+## Extra Content
+
+<Playground
+  code={`
+  () => {
+  const [isShown, setIsShown] = useState(false);
+  const [value, setValue] = useState("");
+
+return <ATextInput
+label="Password"
+type={!isShown && "password"}
+append={<AButton
+tertiary
+autoComplete="off"
+style={{margin: "0 4px"}}
+onClick={() => {setIsShown(!isShown)}}>
+Show
+
+ </AButton>}
+onChange={(e) => {setValue(e.target.value)}}
+/>}`
+}
+/>
+
 ## Accessibility Notes
 
 The `ATextInput` `click` event handlers for prepended and appended icons are triggered both by the `click` event and by the `keyDown` event for both the `Enter` and `Space` keys.

--- a/framework/components/ATextInput/ATextInput.mdx
+++ b/framework/components/ATextInput/ATextInput.mdx
@@ -374,6 +374,8 @@ Override internal validation rules by specifying a `key` on the rule. Valid keys
 
 ## Extra Content
 
+Use `append` or `prepend` to add custom content, such as a button with text, to the input.
+
 <Playground
   code={`
   () => {

--- a/framework/components/ATextInput/ATextInput.scss
+++ b/framework/components/ATextInput/ATextInput.scss
@@ -74,7 +74,7 @@
     color: currentColor;
     width: 100%;
     position: relative;
-    padding: 0 20px 0 6px;
+    padding: 0 8px;
     border: none;
     appearance: none;
     text-indent: 1px;


### PR DESCRIPTION
Resolves #594 

Also fixes padding issues inside the input (always added `append` to AInputBase, causing scss from ATextInput.scss to have padding 0)