### PR TITLE
fix: allow tooltip trigger on webclamp

### DIFF
--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -38,7 +38,10 @@ const ATriggerTooltip = ({
       return true;
     }
 
-    return element.offsetWidth < element.scrollWidth;
+    return (
+      element.offsetHeight < element.scrollHeight ||
+      element.offsetWidth < element.scrollWidth
+    );
   }, [onlyIfTruncated, anchorRef, childrenRef]);
 
   const {


### PR DESCRIPTION
Resolves #597 - **Allow tooltip trigger on webclamp**

![offsetHeight](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/7e41e591-5c34-4f16-941d-42bd7c433503)
