### PR TITLE
fix: menu overflow

### DIFF
--- a/framework/components/AAccordion/AAccordion.scss
+++ b/framework/components/AAccordion/AAccordion.scss
@@ -170,7 +170,6 @@ $accordion-divider-border-width: thin;
       display: block;
       padding: 0 14px;
       visibility: visible;
-      overflow: hidden;
       opacity: 1;
       @include transition($accordion-transition);
       margin: 0 0 15px 0;


### PR DESCRIPTION
**Resolves #602 - Overflow fix**

![Screenshot 2024-01-30 at 10 28 08 AM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/e4e799f8-5f5a-49c1-83f5-6d47c8923504)

Raj noted they tried to override the overflow, but it impacted the animation.  I compared both with and without and didn't see any differing animation, but its worth more testing.