### PR TITLE
feat: field base can have multiple hints

### DIFF
--- a/framework/components/AAutocomplete/AAutocomplete.js
+++ b/framework/components/AAutocomplete/AAutocomplete.js
@@ -27,6 +27,7 @@ const AAutocomplete = forwardRef(
       clearable,
       disabled,
       hint,
+      hints,
       itemTemplate,
       itemText = "text",
       itemValue = "value",
@@ -138,6 +139,7 @@ const AAutocomplete = forwardRef(
       ),
       error,
       hint,
+      hints,
       label,
       labelFor: `a-autocomplete_${autocompleteId}`,
       onClear: () => {
@@ -297,7 +299,36 @@ AAutocomplete.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/AButtonGroup/AButtonGroup.js
+++ b/framework/components/AButtonGroup/AButtonGroup.js
@@ -14,6 +14,7 @@ const AButtonGroup = forwardRef(
       children,
       className: propsClassName,
       hint,
+      hints,
       label,
       multiple = false,
       onChange,
@@ -126,6 +127,7 @@ const AButtonGroup = forwardRef(
         label={label}
         error={error}
         hint={hint}
+        hints={hints}
         validationState={workingValidationState}
       >
         <div className="a-button-group__wrapper">
@@ -140,7 +142,36 @@ const AButtonGroup = forwardRef(
 
 AButtonGroup.propTypes = {
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/ACombobox/ACombobox.js
+++ b/framework/components/ACombobox/ACombobox.js
@@ -30,6 +30,7 @@ const ACombobox = forwardRef(
       dropdownStyle,
       disabled,
       hint,
+      hints,
       itemTemplate,
       itemText = "text",
       itemValue = "value",
@@ -175,6 +176,7 @@ const ACombobox = forwardRef(
       append: <AIcon {...chevronProps}>chevron-down</AIcon>,
       error,
       hint,
+      hints,
       label,
       labelFor: `a-combobox_${comboboxId}`,
       onClear: () => {
@@ -345,7 +347,36 @@ ACombobox.propTypes = {
    */
   dropdownStyle: PropTypes.object,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/AFieldBase/AFieldBase.cy.js
+++ b/framework/components/AFieldBase/AFieldBase.cy.js
@@ -90,4 +90,115 @@ describe("<AFieldBase />", () => {
       cy.get(".a-menu-base__pointer").should("not.exist");
     });
   });
+
+  describe("when rendered with a hints", () => {
+    it("should render single hint", () => {
+      cy.mount(
+        <AFieldBase
+          {...commonProps}
+          hints={[
+            {
+              content: "Simple hint"
+            }
+          ]}
+        />
+      );
+
+      cy.get(".a-field-base__hint").should("have.length", 1);
+      cy.get(".a-field-base__hint").should("have.text", "Simple hint");
+    });
+
+    it("should render two hints", () => {
+      cy.mount(
+        <AFieldBase
+          {...commonProps}
+          hints={[
+            {
+              content: "Simple hint 1"
+            },
+            {
+              content: "Simple hint 2"
+            }
+          ]}
+        />
+      );
+
+      cy.get(".a-field-base__hint").should("have.length", 2);
+      cy.get(".a-field-base__hint:first").should("have.text", "Simple hint 1");
+      cy.get(".a-field-base__hint:last").should("have.text", "Simple hint 2");
+    });
+
+    it("should render hint with component validation state", () => {
+      cy.mount(
+        <AFieldBase
+          {...commonProps}
+          validationState="danger"
+          hints={[
+            {
+              content: "Simple hint",
+              hintUsesValidationState: true
+            }
+          ]}
+        />
+      );
+
+      cy.get(".a-field-base__hint").should("have.length", 1);
+      cy.get(".a-field-base__hint").should("have.text", "Simple hint");
+      cy.get(".a-alert--state-danger").should("exist");
+    });
+
+    it("should render hint with overridden validation state ", () => {
+      cy.mount(
+        <AFieldBase
+          {...commonProps}
+          validationState="warning"
+          hints={[
+            {
+              content: "Simple hint",
+              validationStateOverride: "danger"
+            }
+          ]}
+        />
+      );
+
+      cy.get(".a-field-base__hint").should("have.length", 1);
+      cy.get(".a-field-base__hint").should("have.text", "Simple hint");
+      cy.get(".a-alert--state-danger").should("exist");
+    });
+
+    it("should render hint when there is no error and we have set hideHintOnError", () => {
+      cy.mount(
+        <AFieldBase
+          {...commonProps}
+          hints={[
+            {
+              content: "Simple hint",
+              hideHintOnError: true
+            }
+          ]}
+        />
+      );
+
+      cy.get(".a-field-base__hint").should("have.length", 1);
+      cy.get(".a-field-base__hint").should("have.text", "Simple hint");
+    });
+
+    it("should not render hint when there is error and we have set hideHintOnError", () => {
+      cy.mount(
+        <AFieldBase
+          {...commonProps}
+          error="ERROR !"
+          hints={[
+            {
+              content: "Simple hint",
+              hideHintOnError: true
+            }
+          ]}
+        />
+      );
+
+      cy.get(".a-field-base__hint").should("have.length", 1);
+      cy.get(".a-field-base__hint").should("have.text", "ERROR !");
+    });
+  });
 });

--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -99,7 +99,7 @@ const AFieldBase = forwardRef(
           </label>
         )}
         {children}
-        {hints &&
+        {Array.isArray(hints) &&
           hints.map((hintObject, index) => {
             // "hints" block should be before "error" hint
             if (hintObject.hideHintOnError && error) return null;

--- a/framework/components/AFieldBase/AFieldBase.js
+++ b/framework/components/AFieldBase/AFieldBase.js
@@ -14,6 +14,7 @@ const AFieldBase = forwardRef(
       className: propsClassName,
       error,
       hint,
+      hints,
       hintUsesValidationState = true,
       label,
       labelHidden = false,
@@ -39,7 +40,8 @@ const AFieldBase = forwardRef(
       className += ` ${propsClassName}`;
     }
 
-    let hintElement;
+    // when removing "hint" property "error" should be preserved.
+    let hintElement = null;
     if (hint && error && !hideHintOnError) {
       hintElement = (
         <>
@@ -97,6 +99,27 @@ const AFieldBase = forwardRef(
           </label>
         )}
         {children}
+        {hints &&
+          hints.map((hintObject, index) => {
+            // "hints" block should be before "error" hint
+            if (hintObject.hideHintOnError && error) return null;
+
+            const objectValidationState = hintObject.validationStateOverride
+              ? hintObject.validationStateOverride
+              : hintObject.hintUsesValidationState
+              ? validationState
+              : "default";
+
+            return (
+              <AHint
+                key={index}
+                className="a-field-base__hint"
+                validationState={objectValidationState}
+              >
+                {hintObject.content}
+              </AHint>
+            );
+          })}
         {hintElement}
       </div>
     );
@@ -107,13 +130,48 @@ const {anchorRef, ...infoTooltipProps} = ATooltipPropTypes;
 
 AFieldBase.propTypes = {
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**
    * Style the hint with the validation state. Default: true.
+   * @deprecated use "hints" property
    */
   hintUsesValidationState: PropTypes.bool,
+  /**
+   * Do not show hint when there are validation errors.
+   * @deprecated use "hints" property
+   */
+  hideHintOnError: PropTypes.bool,
   /**
    * Sets the label content.
    */

--- a/framework/components/AFieldBase/AFieldBase.mdx
+++ b/framework/components/AFieldBase/AFieldBase.mdx
@@ -38,6 +38,31 @@ import {AFieldBase} from "@cisco-sbg-ui/magna-react";
     validationState="danger">
     [Children]
   </AFieldBase>
+
+  <AFieldBase
+    className="mb-3"
+    label="'hints' usage example (with danger validation state)"
+    error="We have an error here !"
+    hints={[
+        {
+            content: "Simple hint, no alert."
+        },
+        {
+            content: "Inferred danger validation.",
+            hintUsesValidationState: true
+        },
+        {
+            content: "Overridden warning validation.",
+            validationStateOverride: "warning"
+        },
+        {
+            content: "THIS HINT SHOULD BE HIDDEN !",
+            hideHintOnError: true
+        }
+    ]}
+    validationState="danger">
+    [Children]
+  </AFieldBase>
 </div>
 `}
 />

--- a/framework/components/AInputBase/AInputBase.js
+++ b/framework/components/AInputBase/AInputBase.js
@@ -17,6 +17,7 @@ const AInputBase = forwardRef(
       disabled,
       focused,
       hint,
+      hints,
       surfaceRef,
       label,
       labelHidden,
@@ -93,6 +94,7 @@ const AInputBase = forwardRef(
         labelHidden={labelHidden}
         onClickLabel={onClickLabel}
         hint={hint}
+        hints={hints}
         validationState={validationState}
       >
         <div ref={surfaceRef} className="a-input-base__surface">
@@ -151,7 +153,36 @@ AInputBase.propTypes = {
    */
   focused: PropTypes.bool,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/AMultiSelect/AMultiSelect.js
+++ b/framework/components/AMultiSelect/AMultiSelect.js
@@ -34,6 +34,7 @@ const AMultiSelect = forwardRef(
       dropdownStyle,
       disabled,
       hint,
+      hints,
       itemTemplate,
       itemText = "text",
       itemValue = "value",
@@ -240,6 +241,7 @@ const AMultiSelect = forwardRef(
       append: <AIcon {...chevronProps}>chevron-down</AIcon>,
       error,
       hint,
+      hints,
       label,
       labelFor: `a-multiselect_${multiselectId}`,
       onClear: () => {
@@ -488,7 +490,36 @@ AMultiSelect.propTypes = {
    */
   dropdownStyle: PropTypes.object,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -27,6 +27,7 @@ const ASelect = forwardRef(
       dropdownStyle,
       disabled,
       hint,
+      hints,
       itemDisabled = "disabled",
       itemSelected = "selected",
       itemTemplate,
@@ -393,6 +394,7 @@ const ASelect = forwardRef(
         validationState={workingValidationState}
         error={error}
         hint={hint}
+        hints={hints}
         required={required}
       >
         <div className="a-select__selection-wrapper">
@@ -520,7 +522,36 @@ ASelect.propTypes = {
    */
   dropdownStyle: PropTypes.object,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/ASlider/ASlider.js
+++ b/framework/components/ASlider/ASlider.js
@@ -33,6 +33,7 @@ const ASlider = forwardRef(
       className: propsClassName,
       disabled,
       hint,
+      hints,
       label,
       min = 0,
       max = 100,
@@ -286,6 +287,7 @@ const ASlider = forwardRef(
         label={label}
         error={error}
         hint={hint}
+        hints={hints}
         validationState={workingValidationState}
       >
         <div className="a-slider__control">
@@ -490,7 +492,36 @@ ASlider.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -37,6 +37,7 @@ const ATextInput = forwardRef(
       clearable,
       disabled,
       hint,
+      hints,
       label,
       labelHidden,
       max,
@@ -382,6 +383,7 @@ const ATextInput = forwardRef(
       clearable: clearable && isNonEmptyString(nativeInputValue),
       error,
       hint,
+      hints,
       label,
       labelHidden,
       required,
@@ -484,7 +486,36 @@ ATextInput.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**

--- a/framework/components/ATextarea/ATextarea.js
+++ b/framework/components/ATextarea/ATextarea.js
@@ -23,6 +23,7 @@ const ATextarea = forwardRef(
       disabled,
       disableGrammarly,
       hint,
+      hints,
       label,
       maxLength,
       onBlur,
@@ -162,6 +163,7 @@ const ATextarea = forwardRef(
       focused: isFocused,
       error,
       hint,
+      hints,
       label,
       labelFor: `a-textarea__field_${textareaId}`,
       disabled,
@@ -238,7 +240,36 @@ ATextarea.propTypes = {
    */
   disableGrammarly: PropTypes.bool,
   /**
+   * Sets hint or multiple hints.
+   */
+  hints: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Hint content.
+       */
+      content: PropTypes.node.isRequired,
+      /**
+       * Style the hint with the component validation state. Default: false.
+       */
+      hintUsesValidationState: PropTypes.bool,
+      /**
+       * Override the validation state of the hint by incorporating the desired state.
+       * The component validation state is disregarded when this property is configured.
+       */
+      validationStateOverride: PropTypes.oneOf([
+        "default",
+        "warning",
+        "danger"
+      ]),
+      /**
+       * Do not show hint when there are validation errors.
+       */
+      hideHintOnError: PropTypes.bool
+    })
+  ),
+  /**
    * Sets the hint content.
+   * @deprecated use "hints" property
    */
   hint: PropTypes.node,
   /**


### PR DESCRIPTION
**Please check if the PR fullfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally
- [x] The component should accept a class name as a prop, if appropriate
- [x] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?** 

UX needs from us to display field hint and optionally display error message - but keeps hint visible (see screenshot). This was not possible to reach with "hint" and "rules" because "rules" needs validation and validation needs user interaction. But we need to control both properties from outside because we are using external validation framework.

I am adding new property "hints" allowing me to put one or more hints to "AFieldBase" and related components.  Every hint can be configurable, we can set alarm level, we can hide it when validation error occur, we can infer component validation status. I kept there original "hint" for backward compatibility and marked it as deprecated. I also marked as deprecated on "AFieldBase" related properties "hintUsesValidationState" and "hideHintOnError".

Supports: https://github.com/advthreat/incident-manager/issues/2228


**What is the current behavior?** 

Current behaviour supports only mix of single hint combined with validation error.


**What is the new behavior (if this is a feature change)?**

This change allows to put more hints to "AFieldBase" and related components.  

**Does this PR introduce a breaking change?**

No, change should be backward compatible.

