### PR TITLE
Fix text color for AButton with href in primary

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -167,7 +167,7 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   &--secondary {
-    color: var(--interact-text-default);
+    color: var(--interact-text-default) !important;
     background-color: var(--interact-bg-weak-default);
     border-color: var(--interact-border-default);
 
@@ -274,6 +274,10 @@ $btn-transition: color $transition-duration--extra-fast
       color: var(--interact-text-weak-disabled);
     }
   }
+}
+
+a.a-button.a-button--primary {
+  color: var(--interact-text-in-default) !important;
 }
 
 a.disabled.a-button,


### PR DESCRIPTION
![Screenshot 2024-02-14 at 1 22 02 PM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/d8a22bf5-ae9b-46f9-8d2a-3305f54d244f)

```
  <AButton  href="https://www.cisco.com">
  Launch Cisco.com
</AButton>
```