### PR TITLE
feature: accordion title has now way to place chevron icon to the left

### DIFF
--- a/framework/components/AAccordion/AAccordion.mdx
+++ b/framework/components/AAccordion/AAccordion.mdx
@@ -233,6 +233,32 @@ All Accordion components (`AAccordion`, `AAccordionPanel`, `AAccordionHeader`, `
 `}
 />
 
+## Icon Placement on the Left Side
+
+<Playground
+  code={`<AAccordion>
+<AAccordionPanel>
+<AAccordionHeader>
+<AAccordionHeaderTitle
+  iconPlacement="left">
+  Accordion Item 1
+</AAccordionHeaderTitle>
+</AAccordionHeader>
+<AAccordionBody>{LoremIpsum}</AAccordionBody>
+</AAccordionPanel>
+<AAccordionPanel collapsed={false}>
+  <AAccordionHeader>
+    <AAccordionHeaderTitle
+      iconPlacement="left">
+      Accordion Item 2
+    </AAccordionHeaderTitle>
+  </AAccordionHeader>
+  <AAccordionBody>{LoremIpsum}</AAccordionBody>
+</AAccordionPanel>
+</AAccordion>
+`}
+/>
+
 ## Accessibility Notes
 
 The `AAccordionPanel` component uses the [aria-expanded](https://www.w3.org/TR/wai-aria/#aria-expanded) attribute to express the collapsed state.

--- a/framework/components/AAccordion/AAccordion.scss
+++ b/framework/components/AAccordion/AAccordion.scss
@@ -11,7 +11,8 @@ $accordion-body-padding: 15px 10px;
 $accordion-border-radius: 6px;
 $accordion-message-font-size: 13px;
 $accordion-toggle-font-size: $font-size--xs;
-$accordion-toggle-margin: 0 8px 0 0;
+$accordion-toggle-right-margin: 0 8px 0 0;
+$accordion-toggle-left-margin: 0 0 0 8px;
 $accordion-transition: visibility 0s ease, max-height $transition-duration ease,
   opacity $transition-duration--fast ease, margin $transition-duration ease;
 $accordion--state-collapsed-transition: visibility $transition-duration ease,
@@ -102,9 +103,20 @@ $accordion-divider-border-width: thin;
     .a-icon {
       height: $accordion-toggle-font-size;
       width: $accordion-toggle-font-size;
-      margin: $accordion-toggle-margin;
       vertical-align: middle;
       fill: var(--interact-icon-weak-default);
+    }
+  }
+
+  &__chevron-right {
+    .a-icon {
+      margin: $accordion-toggle-right-margin;
+    }
+  }
+
+  &__chevron-left {
+    .a-icon {
+      margin: $accordion-toggle-left-margin;
     }
   }
 

--- a/framework/components/AAccordion/AAccordionHeaderTitle.js
+++ b/framework/components/AAccordion/AAccordionHeaderTitle.js
@@ -16,6 +16,7 @@ const AAccordionHeaderTitle = forwardRef(
       className: propsClassName,
       collapseIcon = "caret-up",
       expandIcon = "caret-down",
+      iconPlacement = "right",
       onBlur,
       onClick,
       onFocus,
@@ -62,11 +63,26 @@ const AAccordionHeaderTitle = forwardRef(
       onFocus && onFocus(e);
     };
 
+    const handlerProps = {
+      onBlur: handleBlur,
+      onClick: handleClick,
+      onFocus: handleFocus,
+      onKeyDown: handleKeyDown
+    };
+
     let className = "a-accordion__link",
       chevronClassName = "a-accordion__chevron";
 
     if (propsClassName) {
       className += ` ${propsClassName}`;
+    }
+
+    if (iconPlacement === "left") {
+      chevronClassName += " a-accordion__chevron-left";
+    }
+
+    if (iconPlacement === "right") {
+      chevronClassName += " a-accordion__chevron-right";
     }
 
     const chevronIcon =
@@ -75,36 +91,30 @@ const AAccordionHeaderTitle = forwardRef(
         ? expandIcon
         : collapseIcon;
 
-    const props = {};
-
-    if (hasBody) {
-      props.tabIndex = 0;
-      props.role = "button";
-    }
+    const titleDivProps = {
+      ...(hasBody && {tabIndex: 0}),
+      ...(hasBody && {role: "button"})
+    };
 
     return (
       /* eslint-disable jsx-a11y/no-static-element-interactions */
       <>
+        {chevron && iconPlacement === "left" && (
+          <div {...handlerProps} className={chevronClassName}>
+            <AIcon size={12}>{chevronIcon}</AIcon>
+          </div>
+        )}
         <div
           {...rest}
-          {...props}
-          onBlur={handleBlur}
-          onClick={handleClick}
-          onFocus={handleFocus}
-          onKeyDown={handleKeyDown}
+          {...handlerProps}
+          {...titleDivProps}
           ref={ref}
           className={className}
         >
           {children}
         </div>
-        {chevron && (
-          <div
-            onBlur={handleBlur}
-            onClick={handleClick}
-            onFocus={handleFocus}
-            onKeyDown={handleKeyDown}
-            className={chevronClassName}
-          >
+        {chevron && iconPlacement === "right" && (
+          <div {...handlerProps} className={chevronClassName}>
             <AIcon size={12}>{chevronIcon}</AIcon>
           </div>
         )}
@@ -115,7 +125,10 @@ const AAccordionHeaderTitle = forwardRef(
 );
 
 AAccordionHeaderTitle.defaultProps = {
-  chevron: true
+  chevron: true,
+  collapseIcon: "caret-up",
+  expandIcon: "caret-down",
+  iconPlacement: "right"
 };
 
 AAccordionHeaderTitle.propTypes = {
@@ -130,7 +143,12 @@ AAccordionHeaderTitle.propTypes = {
   /**
    * Sets an alternative expand icon.
    */
-  expandIcon: PropTypes.string
+  expandIcon: PropTypes.string,
+  /**
+   * Decide where the icon will be placed in relation to the title.
+   * Default is "right".
+   */
+  iconPlacement: PropTypes.oneOf(["right", "left"])
 };
 
 AAccordionHeaderTitle.displayName = "AAccordionHeaderTitle";


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally
- [x] The component should accept a class name as a prop, if appropriate
- [x] The component should accept a forward ref, if appropriate


**What kind of change does this PR introduce?** 

Enables to configure placement of `AAccordionHeaderTitle` icon. Now we have way to place it also to the left side.
We verified with UX that they really would like to have it left.

Supports [#1539](https://github.com/advthreat/incident-manager/issues/1539)


**What is the current behavior?**

Currently we are able to place the icon only to the right side.


**Does this PR introduce a breaking change?** 

No this change is backward compatible.


