### PR TITLE
feat: add `APageAlert` component

### DIFF
--- a/framework/components/APageLayout/APageAlert.js
+++ b/framework/components/APageLayout/APageAlert.js
@@ -1,0 +1,24 @@
+import React, {forwardRef} from "react";
+import "./APageAlert.scss";
+import AToast from "../AToast";
+
+const APageAlert = forwardRef(({className: propsClassName, ...rest}, ref) => {
+  let className = "a-page-alert";
+
+  if (propsClassName) {
+    className += ` ${propsClassName}`;
+  }
+
+  return <AToast {...rest} className={className} ref={ref} />;
+});
+
+APageAlert.propTypes = {
+  /**
+   * String representing class names to be passed `AToast` component.
+   */
+  className: PropTypes.string
+};
+
+APageAlert.displayName = "APageAlert";
+
+export default APageAlert;

--- a/framework/components/APageLayout/APageAlert.js
+++ b/framework/components/APageLayout/APageAlert.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, {forwardRef} from "react";
 import "./APageAlert.scss";
 import AToast from "../AToast";

--- a/framework/components/APageLayout/APageAlert.scss
+++ b/framework/components/APageLayout/APageAlert.scss
@@ -1,12 +1,15 @@
 @import "../../styles";
 
 .a-page-alert {
-  min-height: unset; // Reset `a-toast`
-  max-width: unset; // Reset `a-toast`
   margin: map-get($spacers, 2) 0 map-get($spacers, 3) 0;
   line-height: $line-height--md;
 
-  & .a-toast__icon {
-    margin-top: 0; // Reset `a-toast`
+  &.a-toast {
+    min-height: unset; // Reset `a-toast`
+    max-width: unset; // Reset `a-toast`
+
+    & .a-toast__icon {
+      margin-top: 0; // Reset `a-toast`
+    }
   }
 }

--- a/framework/components/APageLayout/APageAlert.scss
+++ b/framework/components/APageLayout/APageAlert.scss
@@ -1,0 +1,12 @@
+@import "../../styles";
+
+.a-page-alert {
+  min-height: unset; // Reset `a-toast`
+  max-width: unset; // Reset `a-toast`
+  margin: map-get($spacers, 2) 0 map-get($spacers, 3) 0;
+  line-height: $line-height--md;
+
+  & .a-toast__icon {
+    margin-top: 0; // Reset `a-toast`
+  }
+}

--- a/framework/components/APageLayout/APageLayout.mdx
+++ b/framework/components/APageLayout/APageLayout.mdx
@@ -12,6 +12,7 @@ Integrate with your build to [auto-import](/#integrating), or add an import in y
 
 ```js
 import {
+  APageAlert,
   APageContainer,
   APageHeader,
   APageTitle,
@@ -97,6 +98,19 @@ return (
       <div style={{fontWeight: 600, paddingRight: "5px"}}>MX450</div>
       <ANetworkValue>e0:cb:bc:a3:03:48</ANetworkValue>
     </APageLabel>
+    <APageAlert level="info" dismissable={false}>
+      <p className="mt-0">
+        In total, completing all 10 subquests for "Recipe for Disaster" awards:
+      </p>
+      <ul>
+        <li>10 Quest points</li>
+        <li>
+          An experience lamp, which grants 20,000 experience to any skill above
+          50 (can be banked for later use)
+        </li>
+        <li>Access to buy Barrows gloves</li>
+      </ul>
+    </APageAlert>
     <ATabGroup scrolling>
       <ATab>One</ATab>
       <ATab>Two</ATab>

--- a/framework/components/APageLayout/index.js
+++ b/framework/components/APageLayout/index.js
@@ -1,3 +1,4 @@
+import APageAlert from "./APageAlert";
 import APageContainer from "./APageContainer";
 import APageHeader from "./APageHeader";
 import APageTitle from "./APageTitle";
@@ -9,6 +10,7 @@ import APageTitleContentRight from "./content/APageTitleContentRight";
 import APageTitleText from "./APageTitleText";
 
 export {
+  APageAlert,
   APageContainer,
   APageHeader,
   APageTitle,

--- a/framework/index.js
+++ b/framework/index.js
@@ -82,6 +82,7 @@ import AMount from "./components/AMount";
 import AMultiSelect from "./components/AMultiSelect";
 import ANetworkValue from "./components/ANetworkValue/ANetworkValue";
 import {
+  APageAlert,
   APageContainer,
   APageHeader,
   APageTitle,
@@ -221,6 +222,7 @@ export {
   AMount,
   AMultiSelect,
   ANetworkValue,
+  APageAlert,
   APageContainer,
   APageHeader,
   APageTitle,


### PR DESCRIPTION
## Context

I was recently given a design to render a page level alert:

<details>
<summary>Screenshot of redacted wireframe</summary>

![Screenshot 2024-02-22 at 4 58 56 PM](https://github.com/cisco-sbg-ui/magna-react/assets/94568316/9eccadc0-8f5e-499f-8873-67a046c2f775)
</details>

I figured instead of doing something locally to the application was requested for, I'd make it part of the "APageLayout" family, especially considering it looks to be part of the [Magnetic "Page title" component specs](https://www.figma.com/file/oVZWatImEIbl1c8sjdGxi0/%F0%9F%A7%B2--Magnetic-Design-Library?type=design&node-id=14757-56953&mode=design&t=kNl71JpX4k6zGpRm-0):

![Screenshot 2024-02-22 at 5 05 38 PM](https://github.com/cisco-sbg-ui/magna-react/assets/94568316/50c2ef81-2920-4fef-b416-f8d9137ce7de)

## This PR

* Adds an `APageAlert` component
  * This component is a wrapper around `AToast` with some style overrides and spacing

## Test Plan

1. Navigate to the [Advanced Usage](https://magna-react-git-feat-a-page-alert.securex-preview.app/components/pagelayout#advanced-usage) Page Layout documentation
2. Verify that you see the page-level alert below the "MX450 e0:cb:bc:a3:03:48" label
3. Modify the props of `APageAlert` in the component to confirm the following look okay:
  3a. Add a `title` string prop to `APageAlert` 
  3b. Add an `onClose` prop an confirm it is called when the close icon is clicked, .e.g., something like `onClose={() => alert("dismissed page alert")}`
  3c. Set the `dismissable ` prop to `false`
  3d. Set the `level` prop to: `"warning"`
  3e. Set the `level` prop to `"danger"`
