### PR TITLE
fix: lower z-index

### DIFF
--- a/framework/components/ATimeline/ATimeline.scss
+++ b/framework/components/ATimeline/ATimeline.scss
@@ -6,14 +6,14 @@ $timeline-item-width: 100%;
 $timeline-icon-border-radius: 50%;
 $timeline-icon-width: 18px;
 $timeline-icon-height: 18px;
-$timeline-icon-z-index: 200;
+$timeline-icon-z-index: 2;
 $timeline-icon-border-width: 2px;
 $timeline-time-width: 125px;
 $timeline-time-min-width: 125px;
 $timeline-time-padding: 0 10px 0 0;
 $timeline-content-margin: 0 0 0 50px;
 $timeline-line-width: 2px;
-$timeline-line-z-index: 100;
+$timeline-line-z-index: 1;
 $timeline-item-transition: $transition-duration--fast;
 $timeline-transition: background-color $timeline-item-transition;
 

--- a/framework/components/ATimeline/ATimeline.scss
+++ b/framework/components/ATimeline/ATimeline.scss
@@ -111,7 +111,7 @@ $timeline-transition: background-color $timeline-item-transition;
     display: block;
     width: $timeline-line-width;
     top: 0;
-    left: 150px;
+    left: 151px;
     bottom: 0;
     z-index: $timeline-line-z-index;
     background-color: var(--control-border-weak-default);


### PR DESCRIPTION
**Fixes #632 - Lower z-index**

I couldn't find a reason why these were set so high to begin with, but was able to lower them without any obvious consequence.  Tested on IM and Shell.

Also added a slight px adjustment to line which was slightly off in other envs:
**Before:**
![Screenshot 2024-02-28 at 11 26 45 AM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/f06281bf-9dc0-4964-be0c-c9186e4ec659)

**After:**
![Screenshot 2024-02-28 at 11 28 13 AM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/36cfa58c-2455-4c70-9a5e-082fd4caa5bf)

