### PR TITLE
fix-627 Add accessibility features to modals and drawers

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -1,4 +1,4 @@
-import React, {forwardRef} from "react";
+import React, {forwardRef, createContext} from "react";
 import PropTypes from "prop-types";
 
 import AModal from "../AModal/AModal";
@@ -7,6 +7,8 @@ import AIcon from "../AIcon/AIcon";
 
 import "./ADrawer.scss";
 import {useDelayUnmount} from "../../utils/hooks";
+
+const DrawerContext = createContext({});
 
 const ADrawer = forwardRef(
   (
@@ -18,6 +20,8 @@ const ADrawer = forwardRef(
       openHeight,
       openWidth,
       isOpen,
+      onClose,
+      closeOnOutsideClick,
       position = "fixed",
       slideIn = "left",
       slim = false,
@@ -121,15 +125,19 @@ const ADrawer = forwardRef(
     }
 
     const drawerPanelComponent = (
-      <DrawerPanelComponent
-        {...rest}
-        ref={shouldRenderModal ? null : ref}
-        className={shouldRenderModal ? "" : className}
-        style={shouldRenderModal ? {} : style}
-      >
-        {closeButton}
-        {shouldRenderChildren && children}
-      </DrawerPanelComponent>
+      <DrawerContext.Provider value={{onClose}}>
+        <DrawerPanelComponent
+          {...rest}
+          ref={shouldRenderModal ? null : ref}
+          className={shouldRenderModal ? "" : className}
+          style={shouldRenderModal ? {height: '100%'} : style}
+        >
+          <div className="a-drawer-content">
+            {closeButton}
+            {shouldRenderChildren && children}
+          </div>
+        </DrawerPanelComponent>
+      </DrawerContext.Provider>
     );
 
     if (!shouldRenderModal) {
@@ -146,6 +154,8 @@ const ADrawer = forwardRef(
         withTransitions={false}
         isOpen={shouldRenderChildren}
         style={style}
+        onClose={onClose}
+        closeOnOutsideClick={closeOnOutsideClick}
       >
         {drawerPanelComponent}
       </AModal>
@@ -172,12 +182,23 @@ ADrawer.propTypes = {
   className: PropTypes.string,
 
   /**
+   * Enables closing the drawer when clicking outside of the drawer content.
+   */
+  closeOnOutsideClick: PropTypes.bool,
+
+  /**
    * Determines if the drawer is opened or closed. For a permanent
    * drawer, pass a constant value of `true`. An example of when this
    * might be useful is for a sidebar that toggles between its slim and
    * full version.
    */
   isOpen: PropTypes.bool,
+
+  /**
+   * Function which closes the Drawer. It is necessary for accessibility concerns, 
+   * specifically to enable exiting the Drawer upon pressing the "Escape" key.
+   */
+  onClose: PropTypes.func,
 
   /**
    * The height of the drawer when it is opened. Most commonly used
@@ -247,3 +268,6 @@ ADrawer.propTypes = {
 ADrawer.displayName = "ADrawer";
 
 export default ADrawer;
+export {
+  DrawerContext
+}

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -31,27 +31,12 @@ The drawer can slide-in from the left, right, or bottom of the page.
   code={`() => {
     const leftDrawerContentRef = useRef();
     const [isLeftOpen, setIsLeftOpen] = useState(false);
-    usePopupQuickExit({
-      popupRef: leftDrawerContentRef,
-      isEnabled: isLeftOpen,
-      onExit: () => setIsLeftOpen(false)
-    });
 
     const rightDrawerContentRef = useRef();
     const [isRightOpen, setIsRightOpen] = useState(false);
-    usePopupQuickExit({
-      popupRef: rightDrawerContentRef,
-      isEnabled: isRightOpen,
-      onExit: () => setIsRightOpen(false)
-    });
 
     const bottomDrawerContentRef = useRef();
     const [isBottomOpen, setIsBottomOpen] = useState(false);
-    usePopupQuickExit({
-      popupRef: bottomDrawerContentRef,
-      isEnabled: isBottomOpen,
-      onExit: () => setIsBottomOpen(false)
-    });
 
     return (
       <>
@@ -62,9 +47,10 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='left'
             ref={leftDrawerContentRef}
             isOpen={isLeftOpen}
+            onClose={() => setIsLeftOpen(false)}
             data-test-drawer-left>
           <ADrawerHeader>
-          <ADrawerTitle onCloseButtonClick={() => setIsLeftOpen(false)}>
+          <ADrawerTitle>
             <h1 id='left-drawer-title'>Left Drawer</h1>
           </ADrawerTitle>
           <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
@@ -84,9 +70,10 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
+            onClose={() => setIsRightOpen(false)}
             data-test-drawer-right>
            <ADrawerHeader>
-          <ADrawerTitle onCloseButtonClick={() => setIsRightOpen(false)}>
+          <ADrawerTitle>
             <h1 id='left-drawer-title'>Right Drawer</h1>
           </ADrawerTitle>
           <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
@@ -106,6 +93,7 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='bottom'
             ref={bottomDrawerContentRef}
             isOpen={isBottomOpen}
+            onClose={() => setIsBottomOpen(false)}
             data-test-drawer-bottom>
           <ADrawerHeader>
           <ADrawerTitle onCloseButtonClick={() => setIsBottomOpen(false)}>
@@ -126,6 +114,42 @@ The drawer can slide-in from the left, right, or bottom of the page.
 }`}
 />
 
+### With closeOnOutsideClick
+
+<Playground
+  code={`() => {
+    const [isLeftOpen, setIsLeftOpen] = useState(false);
+
+    return (
+      <>
+        <p>Left slide-in</p>
+        <AButton onClick={() => setIsLeftOpen(true)} data-test-drawer-trigger-left>Open Left</AButton>
+        <ADrawer
+            aria-labelledby='left-drawer-title'
+            slideIn='left'
+            isOpen={isLeftOpen}
+            onClose={() => setIsLeftOpen(false)}
+            closeOnOutsideClick
+            data-test-drawer-left>
+          <ADrawerHeader>
+          <ADrawerTitle>
+            <h1 id='left-drawer-title'>Left Drawer</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsLeftOpen(false)} data-test-drawer-close-left>Close</AButton>
+          </ADrawerFooter>
+        </ADrawer>
+      </>
+    )
+
+}`}
+/>
+
 ### Custom Width
 
 <Playground
@@ -133,11 +157,6 @@ The drawer can slide-in from the left, right, or bottom of the page.
 
     const rightDrawerContentRef = useRef();
     const [isRightOpen, setIsRightOpen] = useState(false);
-    usePopupQuickExit({
-      popupRef: rightDrawerContentRef,
-      isEnabled: isRightOpen,
-      onExit: () => setIsRightOpen(false)
-    });
 
     return (
       <>
@@ -149,6 +168,7 @@ The drawer can slide-in from the left, right, or bottom of the page.
             slideIn='right'
             ref={rightDrawerContentRef}
             isOpen={isRightOpen}
+            onClose={() => setIsRightOpen(false)}
             data-test-drawer-right>
            <ADrawerHeader>
           <ADrawerTitle onCloseButtonClick={() => setIsRightOpen(false)}>
@@ -285,7 +305,8 @@ To contain the drawer within something other than the viewport, you can render t
                   aria-label='Fixed drawer'
                   position='fixed'
                   ref={fixedDrawerRef}
-                  isOpen={isFixedOpen}>
+                  isOpen={isFixedOpen}
+                  onClose={() => setIsFixedOpen(false)}>
                 <ADrawerHeader divider>
                   <ADrawerTitle>
                     <h1>Fixed Drawer</h1>
@@ -314,13 +335,7 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
 
 <Playground
   code={`() => {
-    const modalContentRef = useRef();
     const [modalOpen, setModalOpen] = useState(false);
-    usePopupQuickExit({
-      popupRef: modalContentRef,
-      isEnabled: modalOpen,
-      onExit: () => setModalOpen(false)
-    });
 
     const nonModalContentRef = useRef();
     const [nonModalOpen, setNonModalOpen] = useState(false);
@@ -340,10 +355,10 @@ Please note that when `ADrawer` is rendered as a modal, focus will be trapped in
         </AButton>
         <ADrawer
             aria-label='Drawer that behaves like a modal.'
-            ref={modalContentRef}
             asModal={true}
             isOpen={modalOpen}
-            slideIn='right'>
+            slideIn='right'
+            onClose={() => setModalOpen(false)}>
             <MockDrawerContent
                 title='Modal Drawer'
                 content='A Drawer that behaves as a modal.'

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -14,15 +14,15 @@ $common-transitions: transform $transition-props, width $transition-props,
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
   background: var(--control-bg-weak-default);
 
+  .a-drawer-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
   &--modal {
     top: unset;
     left: unset;
-
-    > div {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-    }
   }
 
   &--transitions {

--- a/framework/components/ADrawer/ADrawerTitle.js
+++ b/framework/components/ADrawer/ADrawerTitle.js
@@ -1,6 +1,7 @@
-import React, {forwardRef} from "react";
+import React, {forwardRef, useContext} from "react";
 import PropTypes from "prop-types";
 
+import { DrawerContext } from "./ADrawer";
 import AButton from "../AButton/AButton";
 import AIcon from "../AIcon/AIcon";
 import "./ADrawerTitle.scss";
@@ -21,6 +22,7 @@ const ADrawerTitle = forwardRef(
     },
     ref
   ) => {
+    const {onClose} = useContext(DrawerContext);
     let className = "a-drawer__title";
 
     if (propsClassName) {
@@ -31,11 +33,11 @@ const ADrawerTitle = forwardRef(
       <div className={className} ref={ref} {...rest}>
         <div className="a-drawer__title-content">{children}</div>
         <div className="a-drawer__title-close">
-          {onCloseButtonClick && (
+          {(onClose || onCloseButtonClick) && (
             <AButton
               icon
               tertiaryAlt
-              onClick={() => onCloseButtonClick && onCloseButtonClick(false)}
+              onClick={() => (onClose && onClose()) || (onCloseButtonClick && onCloseButtonClick(false))}
               {...closeBtnProps}
             >
               {closeTitle ? (

--- a/framework/components/AModal/AModal.cy.js
+++ b/framework/components/AModal/AModal.cy.js
@@ -57,6 +57,29 @@ function testCoreFunctionality(TestComponent, props = {}) {
     cy.get("[role='dialog']").should("have.focus");
   });
 
+  it("should return focus to element which opened the modal after its closed", () => {
+    cy.mount(<TestComponent {...props} />);
+
+    // Open modal
+    openModal();
+
+    // Close modal
+    cy.getByDataTestId("close-modal-trigger").click();
+    cy.getByDataTestId("modal-trigger").should("have.focus");
+  });
+
+  it("should close the modal on escape key press", () => {
+    cy.mount(<TestComponent {...props} />);
+
+    // Open modal
+    openModal();
+
+    // Escape key press
+    cy.escapeKeydown().then(() => {
+      getModalContent().should("not.exist");
+    });
+  });
+
   it("should trap focus within the modal", () => {
     cy.mount(<TestComponent {...props} />);
 
@@ -112,6 +135,19 @@ function testCoreFunctionality(TestComponent, props = {}) {
     cy.getByDataTestId("modal-trigger").focus();
     cy.getByDataTestId("modal-trigger").click();
     cy.get("textarea").should("have.focus");
+  });
+}
+
+function testOutsideClick(TestComponent, props = {}) {
+  it("should close the modal on outside click when closeOnOutsideClick prop is passed in", () => {
+    cy.mount(<TestComponent {...props} />);
+
+    // Open modal
+    openModal();
+
+    // Click outside modal content
+    cy.get(".a-page-overlay").click(300, 300);
+    getModalContent().should("not.exist");
   });
 }
 
@@ -183,6 +219,10 @@ describe("<AModal />", () => {
 
   testCoreFunctionality(ModalTest);
   testPropagation(WithAccordionTest);
+
+  describe("when rendered with closeOnOutsideClick", () => {
+    testOutsideClick(ModalTest, {closeOnOutsideClick: true});
+  });
 
   describe("when rendered without <APageOverlay />", () => {
     testCoreFunctionality(ModalTest, {withOverlay: false});
@@ -351,6 +391,7 @@ function ModalTest({children, ...modalProps}) {
         data-testid="modal"
         aria-label="modal test"
         isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
         {...modalProps}
       >
         <ContentSetup onCloseBtnClick={() => setIsOpen(false)}>
@@ -381,6 +422,7 @@ function WithAccordionTest({children, ...modalProps}) {
             <AModal
               aria-label="modal-accordion-setup"
               isOpen={isOpen}
+              onClose={() => setIsOpen(false)}
               {...modalProps}
             >
               <ContentSetup onCloseBtnClick={() => setIsOpen(false)}>
@@ -418,6 +460,7 @@ function WithMenuTest(modalProps) {
         data-testid="modal"
         aria-label="modal with menu test"
         isOpen={isModalOpen}
+        onClose={() => setIsOpen(false)}
         {...modalProps}
       >
         <APanel ref={modalContentRef} data-testid="modal-content">
@@ -471,6 +514,7 @@ function WithToastTest(modalProps) {
         data-testid="modal"
         ref={popupRef}
         isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
         {...modalProps}
       >
         <APanel data-testid="modal-content">

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -15,6 +15,7 @@ import {
 
 import "./AModal.scss";
 import {useDelayUnmount} from "../../utils/hooks";
+import usePopupQuickExit from "../../hooks/usePopupQuickExit/usePopupQuickExit";
 
 /**
  * Reasons for not stopping propagation for the following keys:
@@ -39,11 +40,13 @@ const AModal = forwardRef(
       delayUnmount = 200,
       children,
       isOpen: propsIsOpen,
+      onClose,
       small,
       medium,
       large,
       xlarge,
-      onClickOutside,
+      onClickOutside, //***DEPRECATED***
+      closeOnOutsideClick = false,
       withCenteredContent = true,
       withFocusTrap = true,
       autoFocusElementRef,
@@ -59,6 +62,7 @@ const AModal = forwardRef(
     const hasPortalNode = appendTo || appRef.current;
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
+    const childRef = useRef();
 
     const shouldRenderChildren = useDelayUnmount({
       isOpen,
@@ -83,6 +87,12 @@ const AModal = forwardRef(
       autoFocusElementRef: elementRefToAutoFocus
     });
 
+    usePopupQuickExit({
+      popupRef: closeOnOutsideClick && childRef,
+      isEnabled: isOpen,
+      onExit: onClose
+    });
+
     useEffect(() => {
       shouldRenderChildren && withScrollLock
         ? preventBodyScroll()
@@ -92,7 +102,7 @@ const AModal = forwardRef(
         return allowBodyScroll;
       }
     }, [withScrollLock, shouldRenderChildren]);
-
+  
     let visibilityClass = "";
 
     if (!shouldRenderChildren) {
@@ -152,6 +162,12 @@ const AModal = forwardRef(
      *   </AModal>
      * </AButton>
      */
+    const renderChildren = (
+      <span ref={childRef}>
+        {shouldRenderChildren ? children : null}
+      </span>
+    );
+
     if (withOverlay) {
       return ReactDOM.createPortal(
         <APageOverlay
@@ -165,15 +181,6 @@ const AModal = forwardRef(
               propsOnKeyDown(e);
             }
           }}
-          onClick={(e) => {
-            e.stopPropagation();
-            const {target} = e;
-            if (target !== _ref.current) {
-              return;
-            }
-
-            onClickOutside && onClickOutside();
-          }}
         >
           <Component
             role="dialog"
@@ -183,7 +190,7 @@ const AModal = forwardRef(
             className={contentClassName}
             {...rest}
           >
-            {shouldRenderChildren ? children : null}
+            {renderChildren}
           </Component>
         </APageOverlay>,
         appendTo || appRef.current
@@ -215,7 +222,7 @@ const AModal = forwardRef(
         }}
         {...rest}
       >
-        {shouldRenderChildren ? children : null}
+        {renderChildren}
       </Component>,
       appendTo || appRef.current
     );
@@ -263,6 +270,11 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   className: PropTypes.string,
 
   /**
+   * Enables closing the modal when clicking outside of the modal content.
+   */
+  closeOnOutsideClick: PropTypes.bool,
+
+  /**
    * When the modal is rendered `withTransitions`, there is technically a
    * delay from when you set `isOpen` to `false` to when the component
    * actually unmounts from the DOM. This is done to preserve the transition.
@@ -298,8 +310,15 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
 
   /**
    * If not using the `usePopupQuickExit` hook, pass in a function to handle clicking outside of the modal event. `withOverlay` prop must be set to true.
+   * @deprecated use "closeOnOutsideClick" in conjunction with a passed in "onClose" function to close modal
    */
   onClickOutside: PropTypes.func,
+
+  /**
+   * Function which closes the Modal. It is necessary for accessibility concerns, 
+   * specifically to enable exiting the Modal upon pressing the "Escape" key.
+   */
+  onClose: PropTypes.func,
 
   /**
    * Determines if the content rendered underneath the modal should

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -45,7 +45,6 @@ const AModal = forwardRef(
       medium,
       large,
       xlarge,
-      onClickOutside, //***DEPRECATED***
       closeOnOutsideClick = false,
       withCenteredContent = true,
       withFocusTrap = true,
@@ -102,7 +101,7 @@ const AModal = forwardRef(
         return allowBodyScroll;
       }
     }, [withScrollLock, shouldRenderChildren]);
-  
+
     let visibilityClass = "";
 
     if (!shouldRenderChildren) {
@@ -146,6 +145,12 @@ const AModal = forwardRef(
       return null;
     }
 
+    if (rest.onClickOutside) {
+      console.warn(
+        "onClickOutside has been removed. Use onClose and set closeOnOutsideClick to true"
+      );
+    }
+
     /**
      * In the case where `AModal` is rendered inside a clickable element
      * like a button component, we want to prevent clicks and certain
@@ -163,9 +168,7 @@ const AModal = forwardRef(
      * </AButton>
      */
     const renderChildren = (
-      <span ref={childRef}>
-        {shouldRenderChildren ? children : null}
-      </span>
+      <span ref={childRef}>{shouldRenderChildren ? children : null}</span>
     );
 
     if (withOverlay) {
@@ -179,6 +182,13 @@ const AModal = forwardRef(
             const {onKeyDown: propsOnKeyDown} = rest;
             if (typeof propsOnKeyDown === "function") {
               propsOnKeyDown(e);
+            }
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            const {target} = e;
+            if (target !== _ref.current) {
+              return;
             }
           }}
         >
@@ -315,10 +325,10 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   onClickOutside: PropTypes.func,
 
   /**
-   * Function which closes the Modal. It is necessary for accessibility concerns, 
+   * Function which closes the Modal. It is necessary for accessibility concerns,
    * specifically to enable exiting the Modal upon pressing the "Escape" key.
    */
-  onClose: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
 
   /**
    * Determines if the content rendered underneath the modal should

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -17,7 +17,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 ## Usage
 
 <AAlert className="mb-2" level="info" dismissable={false}>
-  Please provide an "onClose" function for accessibility concerns, specifically to enable exiting
+  Provide an "onClose" function for accessibility concerns, specifically to enable exiting
   the modal upon pressing the "Escape" key. 
 </AAlert>
 

--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -16,26 +16,26 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 
 ## Usage
 
+<AAlert className="mb-2" level="info" dismissable={false}>
+  Please provide an "onClose" function for accessibility concerns, specifically to enable exiting
+  the modal upon pressing the "Escape" key. 
+</AAlert>
+
 <Playground
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
-    const ref = useRef();
-    usePopupQuickExit({
-      popupRef: ref,
-      isEnabled: open,
-      onExit: () => setOpen(false)
-    });
     return (
       <div>
         <AButton
-            onClick={() => setOpen(true)}>
-            Open Modal
+        onClick={() => setOpen(true)}>
+          Open Modal
         </AButton>
         <AModal
             aria-labelledby='modal-title'
-            isOpen={open}>
-            <ACardBasic ref={ref} style={{ minWidth: '400px' }} type="dialog">
+            isOpen={open}
+            onClose={() => setOpen(false)}>
+            <ACardBasic style={{ minWidth: '400px' }} type="dialog">
               <ACardHeader>
                 <ACardTitle id='modal-title'>Modal Demo</ACardTitle>
               </ACardHeader>
@@ -60,12 +60,6 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
-    const ref = useRef();
-    usePopupQuickExit({
-      popupRef: ref,
-      isEnabled: open,
-      onExit: () => setOpen(false)
-    });
     return (
       <div>
         <AButton
@@ -75,8 +69,10 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
         <AModal
             aria-labelledby='modal-title'
             withOverlay={false}
-            isOpen={open}>
-            <ACardBasic ref={ref} style={{ minWidth: '400px' }} type="dialog">
+            isOpen={open}
+            onClose={() => setOpen(false)}
+            closeOnOutsideClick>
+            <ACardBasic style={{ minWidth: '400px' }} type="dialog">
               <ACardHeader>
                 <ACardTitle id='modal-title'>Modal Demo</ACardTitle>
               </ACardHeader>
@@ -108,13 +104,7 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
-    const ref = useRef();
     const lastScrollPos = useRef();
-    usePopupQuickExit({
-      popupRef: ref,
-      isEnabled: open,
-      onExit: () => setOpen(false)
-    });
 
     /**
       * The code below has not been verified nor
@@ -162,8 +152,9 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
         <AModal
             aria-labelledby='modal-title'
             withScrollLock={false}
-            isOpen={open}>
-          <ACardBasic ref={ref} style={{ minWidth: '400px' }} type="dialog">
+            isOpen={open}
+            onClose={() => setOpen(false)}>
+          <ACardBasic style={{ minWidth: '400px' }} type="dialog">
             <ACardHeader>
               <ACardTitle id='modal-title'>Modal Demo</ACardTitle>
             </ACardHeader>
@@ -189,12 +180,6 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
-    const ref = useRef();
-    usePopupQuickExit({
-      popupRef: ref,
-      isEnabled: open,
-      onExit: () => setOpen(false)
-    });
     return (
       <div>
         <AButton
@@ -204,8 +189,9 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
         <AModal
             withCenteredContent={false}
             aria-labelledby='modal-title'
-            isOpen={open}>
-            <ACardBasic ref={ref} style={{ minWidth: '400px' }} type="dialog">
+            isOpen={open}
+            onClose={() => setOpen(false)}>
+            <ACardBasic style={{ minWidth: '400px' }} type="dialog">
               <ACardHeader>
                 <ACardTitle id='modal-title'>Modal Demo</ACardTitle>
               </ACardHeader>
@@ -230,12 +216,6 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
-    const ref = useRef();
-    usePopupQuickExit({
-      popupRef: ref,
-      isEnabled: open,
-      onExit: () => setOpen(false)
-    });
     return (
       <div>
         <AButton
@@ -245,8 +225,9 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
         <AModal
             withTransitions={false}
             aria-labelledby='modal-title'
-            isOpen={open}>
-            <ACardBasic ref={ref} style={{ minWidth: '400px' }} type="dialog">
+            isOpen={open}
+            onClose={() => setOpen(false)}>
+            <ACardBasic style={{ minWidth: '400px' }} type="dialog">
               <ACardHeader>
                 <ACardTitle id='modal-title'>Modal Demo</ACardTitle>
               </ACardHeader>
@@ -271,18 +252,14 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
   code={`() => {
   const [open, setOpen] = useState(false);
   const ref = useRef();
-  usePopupQuickExit({
-    popupRef: ref,
-    isEnabled: open,
-    onExit: () => setOpen(false)
-  });
   return (
     <>
       <AButton onClick={() => setOpen(true)}>Start</AButton>
       <AModal
           aria-labelledby='modal-title'
-          isOpen={open}>
-        <ACardBasic ref={ref} style={{width: '700px'}}>
+          isOpen={open}
+          onClose={() => setOpen(false)}>
+        <ACardBasic style={{width: '700px'}}>
           <ACardHeader>
             <ACardTitle id='modal-content'>Embedded Form</ACardTitle>
           </ACardHeader>
@@ -423,12 +400,6 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
   code={`() => {
     const [open, setOpen] = useState(false);
     const [size, setSize] = useState("small");
-    const ref = useRef();
-    usePopupQuickExit({
-      popupRef: ref,
-      isEnabled: open,
-      onExit: () => setOpen(false)
-    });
     return (
       <div>
         <AButton
@@ -450,8 +421,9 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
         <AModal
             aria-labelledby='modal-title'
             isOpen={open}
+            onClose={() => setOpen(false)}
             {...{[size]: true}}>
-            <ACardBasic ref={ref} type="dialog">
+            <ACardBasic type="dialog">
             <ACardHeader>
               <ACardTitle id='modal-title'>Modal Demo</ACardTitle>
             </ACardHeader>
@@ -470,21 +442,12 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
 `}
 />
 
-### With onClickOutside
-
-<AAlert className="mb-2" level="info" dismissable={false}>
-  `withOverlay` must be true for the `onClickOutside` prop to take effect. If
-  you would like to integrate an outside click handler with a non-overlayed
-  `AModal`, consider using the{" "}
-  <a href="/hooks/use-outside-click#description">`useOutsideClick` hook</a>{" "}
-  alongside the `AModal`.
-</AAlert>
+### With closeOnOutsideClick
 
 <Playground
   fullWidthPreview
   code={`() => {
     const [open, setOpen] = useState(false);
-    const [size, setSize] = useState("small");
 
     return (
       <div>
@@ -496,7 +459,8 @@ import {AModal} from "@cisco-sbg-ui/magna-react";
             aria-labelledby='modal-title'
             isOpen={open}
             onClickOutside={() => {setOpen(false)}}
-            {...{[size]: true}}>
+            onClose={() => setOpen(false)}
+            closeOnOutsideClick>
             <ACardBasic type="dialog">
             <ACardHeader>
               <ACardTitle id='modal-title'>Modal Demo</ACardTitle>

--- a/framework/hooks/useOutsideClick/useOutsideClick.js
+++ b/framework/hooks/useOutsideClick/useOutsideClick.js
@@ -9,7 +9,7 @@ const useOutsideClick = (options) => {
       const shouldIgnore =
         ignoreEl && (e.target === ignoreEl || ignoreEl.contains(e.target));
       // Don't register as outside click if the click is coming from within a menu
-      if (!rootRef?.current?.contains(e.target) && !shouldIgnore) {
+      if (rootRef?.current && !rootRef.current?.contains(e.target) && !shouldIgnore) {
         if (typeof onClick === "function") {
           onClick(e);
         }

--- a/framework/hooks/usePopupQuickExit/usePopupQuickExit.js
+++ b/framework/hooks/usePopupQuickExit/usePopupQuickExit.js
@@ -1,5 +1,6 @@
 import useEscapeKeydown from "../useEscapeKeydown/useEscapeKeydown";
 import useOutsideClick from "../useOutsideClick/useOutsideClick";
+import useReturnFocusOnClose from "../useReturnFocusOnClose/useReturnFocusOnClose";
 
 const usePopupQuickExit = (options) => {
   const {popupRef, isEnabled, onExit} = options;
@@ -11,6 +12,9 @@ const usePopupQuickExit = (options) => {
   useEscapeKeydown({
     isEnabled,
     onKeydown: onExit
+  });
+  useReturnFocusOnClose({
+    isOpen: isEnabled
   });
 };
 

--- a/framework/hooks/useReturnFocusOnClose/useReturnFocusOnClose.js
+++ b/framework/hooks/useReturnFocusOnClose/useReturnFocusOnClose.js
@@ -1,0 +1,16 @@
+import {useEffect, useRef} from "react";
+
+// Reapply focus to trigger element once overlay component is closed
+export default function useReturnFocusOnClose({
+  isOpen = false
+}) {
+  const openRef = useRef();
+
+  useEffect(() => {
+    if (isOpen) {
+      openRef.current = document.activeElement;
+    } else if (openRef.current){
+      openRef.current.focus();
+    }
+  }, [isOpen]);
+};


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally
- [ ] The component should accept a class name as a prop, if appropriate
- [ ] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
Closes  #627 

**What is the current behavior?** <!--(You can also link to an open issue here)-->
The current behavior is outlined in the issue here - #627 


**What is the new behavior (if this is a feature change)?**
When closing modals and drawers, the focus should return to whatever element was used to them. Also, they should be able to be closed upon pressing the "Escape" key, provided that an "onClose" function is passed into their props. The usePopupQuickExit hook is utilized to give these components this ability out of the box. 


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->
Although not a breaking change, an onClose function to both Modals and Drawers. 


**Other information**:


