### PR TITLE
remove important from secondary text color

### DIFF
--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -167,7 +167,7 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   &--secondary {
-    color: var(--interact-text-default) !important;
+    color: var(--interact-text-default);
     background-color: var(--interact-bg-weak-default);
     border-color: var(--interact-border-default);
 


### PR DESCRIPTION
Resolves #636 

Seems like this was leftover to account for buttons with anchor tag, but that has been adjusted elsewhere