### PR TITLE
Align placeholder colors

### DIFF
--- a/framework/components/AInlineInputBase/AInlineInputBase.scss
+++ b/framework/components/AInlineInputBase/AInlineInputBase.scss
@@ -15,7 +15,7 @@
   }
 
   &__placeholder {
-    color: var(--base-text-disabled);
+    color: var(--base-text-weak-default);
   }
 
   &__editIcon,

--- a/framework/components/ASelect/ASelect.scss
+++ b/framework/components/ASelect/ASelect.scss
@@ -43,7 +43,7 @@ $select-padding: 6px;
   }
 
   &__placeholder {
-    color: var(--base-text-disabled);
+    color: var(--base-text-weak-default);
   }
 
   &__chevron {

--- a/framework/components/ATextInput/ATextInput.scss
+++ b/framework/components/ATextInput/ATextInput.scss
@@ -81,6 +81,10 @@
 
   .a-text-input {
     &__input {
+      &::placeholder {
+        color: var(--base-text-weak-default);
+      }
+
       &:disabled {
         color: var(--base-text-disabled);
 


### PR DESCRIPTION
Align to `--base-text-weak-default`

Affects `ASelect`, `ATextInput`, and all inputs using `AInputBase`