### PR TITLE
Show tooltip on focusin; close on escape

### DIFF
--- a/framework/components/ATriggerTooltip/ATriggerTooltip.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React, {useCallback, useEffect, useRef} from "react";
 
 import {ATooltip} from "../ATooltip";
+import useEscapeKeydown from "../../hooks/useEscapeKeydown/useEscapeKeydown";
 import useToggle from "../../hooks/useToggle/useToggle";
 import useOutsideClick from "../../hooks/useOutsideClick/useOutsideClick";
 import {handleMultipleRefs} from "../../utils/helpers";
@@ -63,6 +64,8 @@ const ATriggerTooltip = ({
     onClick: close
   });
 
+  useEscapeKeydown({isEnabled: open, onKeydown: close});
+
   useEffect(() => {
     if (!content || disabled) {
       return;
@@ -76,6 +79,8 @@ const ATriggerTooltip = ({
     switch (trigger) {
       case "hover":
         childRefs.forEach((childRef) => {
+          childRef.addEventListener("focusin", open);
+          childRef.addEventListener("focusout", close);
           childRef.addEventListener("mouseenter", open);
           childRef.addEventListener("mouseleave", close);
         });
@@ -92,6 +97,8 @@ const ATriggerTooltip = ({
         if (!childRef) {
           return;
         }
+        childRef.removeEventListener("focusin", open);
+        childRef.removeEventListener("focusout", close);
         childRef.removeEventListener("mouseenter", open);
         childRef.removeEventListener("mouseleave", close);
         childRef.removeEventListener("click", toggle);


### PR DESCRIPTION
Accessibility

> The tooltip should appear on focus or when the element is hovered on, without additional interaction. It should disappear automatically when the focus on the owning element is lost or the mouse is moved outside the owning element and the tooltip. While the tooltip does not receive focus, the Escape should close it if it is open.


Only applies to `ATriggerTooltip`