### PR TITLE
Add a null check for icon name

### DIFF
--- a/framework/components/AIcon/AIcon.js
+++ b/framework/components/AIcon/AIcon.js
@@ -77,6 +77,10 @@ const AIcon = forwardRef(
 
     let magneticIconDef;
 
+    if (!children) {
+      return null;
+    }
+
     if (MagnaIcons[children]) {
       // Check if it's in magna icons
 


### PR DESCRIPTION
If the icon isn't in the magna icons map and it gets to the `kebabify` check, an empty string will crash the component.

Adds a safety check for good measure