### PR TITLE
chore: updating PropTypes to clean up console warning

### DIFF
--- a/framework/components/AEmptyState/AEmptyState.js
+++ b/framework/components/AEmptyState/AEmptyState.js
@@ -102,7 +102,7 @@ AEmptyState.propTypes = {
   /**
    * Message describing the empty state
    */
-  message: PropTypes.string,
+  message: PropTypes.node,
   /**
    * Sets the container size to small.
    */

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -344,9 +344,11 @@ You should provide either an \`aria-label\` or \`aria-labelledby\` prop to \`${c
   /**
    * Specifies what element to autofocus when the modal is opened. By default, when omitted or undefined, the modal root is focused. When null is passed, the modal does not do any autofocus.
    */
-  autoFocusElementRef: PropTypes.oneOf([
-    null,
-    PropTypes.shape({current: PropTypes.any})
+  autoFocusElementRef: PropTypes.oneOfType([
+    PropTypes.oneOf([null]),
+    PropTypes.shape({
+      current: PropTypes.any
+    })
   ]),
 
   /**


### PR DESCRIPTION
related issue https://github.com/advthreat/incident-manager/issues/2432

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [ ] (N/A) The changes are documented in component docs and changelog
- [ ] (N/A) The ESLint plugin has been updated if a new component is added
- [ ] (N/A) Test have been added or modified, if appropriate
- [x] Has been verified locally
- [ ] (N/A) The component should accept a class name as a prop, if appropriate
- [ ] (N/A) The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
updating PropTypes of following components to get rid of warning messages in the console
- `AEmptyState`
- `AModal`

**What is the current behavior?** <!--(You can also link to an open issue here)-->
On the `AModal` component the propType definition of the `autoFocusElementRef` was not correct. It was always complaining when the `autoFocusElementRef` property was set to non nullable value

On the `AEmptyState` the propTape definition is correct (but maybe to strict?). Currently it allows to fill in only string value into the `message` property. In incident manager there are several usages where react element is passed into this property, mainly to split the error message to multiple lines on defined place, for example something like this:
```tsx
<AErrorState
    variant={variant}
    large={!shouldUseMd}
    medium={shouldUseMd}
    label={label}
    message={
  <>
    <span className="d-block">
        {t("incidentDetail.detail.correctUrlLine1")}
    </span>
    <span className="d-block">
        {t("incidentDetail.detail.correctUrlLine2")}
    </span>
  </>
}/>
```

**What is the new behavior (if this is a feature change)?**
`AModal` component accepts `autoFocusElementRef` without warning about incorrect value
`AEmptyState` component allows `message` property to be react element


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->
No



**Other information**:


