### PR TITLE
Switch refs for modal accessibility tracking

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -130,12 +130,10 @@ const ADrawer = forwardRef(
           {...rest}
           ref={shouldRenderModal ? null : ref}
           className={shouldRenderModal ? "" : className}
-          style={shouldRenderModal ? {height: '100%'} : style}
+          style={shouldRenderModal ? {height: "100%"} : style}
         >
-          <div className="a-drawer-content">
-            {closeButton}
-            {shouldRenderChildren && children}
-          </div>
+          {closeButton}
+          {shouldRenderChildren && children}
         </DrawerPanelComponent>
       </DrawerContext.Provider>
     );
@@ -195,7 +193,7 @@ ADrawer.propTypes = {
   isOpen: PropTypes.bool,
 
   /**
-   * Function which closes the Drawer. It is necessary for accessibility concerns, 
+   * Function which closes the Drawer. It is necessary for accessibility concerns,
    * specifically to enable exiting the Drawer upon pressing the "Escape" key.
    */
   onClose: PropTypes.func,
@@ -268,6 +266,4 @@ ADrawer.propTypes = {
 ADrawer.displayName = "ADrawer";
 
 export default ADrawer;
-export {
-  DrawerContext
-}
+export {DrawerContext};

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -14,15 +14,15 @@ $common-transitions: transform $transition-props, width $transition-props,
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.12);
   background: var(--control-bg-weak-default);
 
-  .a-drawer-content {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
-
   &--modal {
     top: unset;
     left: unset;
+
+    > div {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
   }
 
   &--transitions {

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -18,7 +18,7 @@ $common-transitions: transform $transition-props, width $transition-props,
     top: unset;
     left: unset;
 
-    > div {
+    > span > div {
       display: flex;
       flex-direction: column;
       height: 100%;

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -61,6 +61,7 @@ const AModal = forwardRef(
     const hasPortalNode = appendTo || appRef.current;
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
+    const childRef = useRef();
 
     const shouldRenderChildren = useDelayUnmount({
       isOpen,
@@ -86,7 +87,7 @@ const AModal = forwardRef(
     });
 
     usePopupQuickExit({
-      popupRef: closeOnOutsideClick && _ref,
+      popupRef: closeOnOutsideClick && childRef,
       isEnabled: isOpen,
       onExit: onClose
     });
@@ -166,7 +167,9 @@ const AModal = forwardRef(
      *   </AModal>
      * </AButton>
      */
-    const renderChildren = shouldRenderChildren ? children : null;
+    const renderChildren = (
+      <span ref={childRef}>{shouldRenderChildren ? children : null}</span>
+    );
 
     if (withOverlay) {
       return ReactDOM.createPortal(

--- a/framework/components/AModal/AModal.js
+++ b/framework/components/AModal/AModal.js
@@ -61,7 +61,6 @@ const AModal = forwardRef(
     const hasPortalNode = appendTo || appRef.current;
     const isOpen = !!hasPortalNode && propsIsOpen;
     const _ref = useRef();
-    const childRef = useRef();
 
     const shouldRenderChildren = useDelayUnmount({
       isOpen,
@@ -87,7 +86,7 @@ const AModal = forwardRef(
     });
 
     usePopupQuickExit({
-      popupRef: closeOnOutsideClick && childRef,
+      popupRef: closeOnOutsideClick && _ref,
       isEnabled: isOpen,
       onExit: onClose
     });
@@ -167,9 +166,7 @@ const AModal = forwardRef(
      *   </AModal>
      * </AButton>
      */
-    const renderChildren = (
-      <span ref={childRef}>{shouldRenderChildren ? children : null}</span>
-    );
+    const renderChildren = shouldRenderChildren ? children : null;
 
     if (withOverlay) {
       return ReactDOM.createPortal(


### PR DESCRIPTION
Removes new `a-drawer-content` container