### PR TITLE
Remove padding from p tags in AAlert

### DIFF
--- a/framework/components/AAlert/AAlert.scss
+++ b/framework/components/AAlert/AAlert.scss
@@ -129,5 +129,5 @@ $alert-close-icon-size: 10.5px;
 }
 
 .a-app .a-alert p:first-child {
-  margin: 0;
+  margin: 0 0 ($spacing * 0.5) 0;
 }

--- a/framework/components/AAlert/AAlert.scss
+++ b/framework/components/AAlert/AAlert.scss
@@ -68,6 +68,7 @@ $alert-close-icon-size: 10.5px;
     @include flex-fluid;
     @include text-break-word;
   }
+
   &--fit-content-width {
     width: unset;
   }
@@ -125,4 +126,8 @@ $alert-close-icon-size: 10.5px;
       }
     }
   }
+}
+
+.a-app .a-alert p {
+  margin: 0;
 }

--- a/framework/components/AAlert/AAlert.scss
+++ b/framework/components/AAlert/AAlert.scss
@@ -128,6 +128,6 @@ $alert-close-icon-size: 10.5px;
   }
 }
 
-.a-app .a-alert p {
+.a-app .a-alert p:first-child {
   margin: 0;
 }


### PR DESCRIPTION
The markdown pages on the demo site seem to add a `<p>` tag to the AAlert message content when used outside the Playground. This causes the alignment in alerts to be a bit off