### PR TITLE
Fix double focus for checkboxes with no label

### DIFF
--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -232,15 +232,7 @@ const ACheckbox = forwardRef(
           </span>
         </label>
       ) : (
-        <div
-          className="a-checkbox__wrap"
-          onClick={onClick}
-          onKeyDown={handleKeyDown}
-          aria-checked={checked}
-          aria-labelledby={children}
-          role="checkbox"
-          tabIndex={0}
-        >
+        <div className="a-checkbox__wrap" aria-labelledby={children}>
           {checkboxContent}
         </div>
       );

--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -183,6 +183,8 @@ const ACheckbox = forwardRef(
       if (["Enter", "Space"].includes(e.code)) {
         e.preventDefault();
 
+        validate(e.target.checked);
+
         onClick && onClick(e);
       }
     };
@@ -203,6 +205,7 @@ const ACheckbox = forwardRef(
             validate(e.target.checked);
             onClick && onClick(e);
           }}
+          onKeyDown={handleKeyDown}
           ref={(el) =>
             el && ((el.indeterminate = indeterminate) || (el.checked = checked))
           }


### PR DESCRIPTION
When using without a label, the wrapper has a tabIndex for focus, along with the `<input>`. This causes two separate focus states when tabbing through.