### PR TITLE
Support classic themes; setup for future

### DIFF
--- a/docs/Sidebar.js
+++ b/docs/Sidebar.js
@@ -33,13 +33,15 @@ const GitHubIcon = (props) => {
 const Sidebar = ({menus, currentDoc}) => {
   const [items, setItems] = useState([]);
   const currentDocRef = useRef();
-  const {currentTheme} = useATheme();
-  const styleColor = currentTheme === "dusk" ? "white--text" : "black--text";
+  const {currentTheme, isDark} = useATheme();
+  const styleColor = isDark ? "white--text" : "black--text";
   useEffect(() => {
     if (currentDocRef.current) {
       window.scrollTo(0, Math.max(0, currentDocRef.current.offsetTop - 65));
     }
   }, []);
+
+  console.log("isDark", isDark);
 
   useEffect(() => {
     const newItems = [
@@ -116,11 +118,7 @@ const Sidebar = ({menus, currentDoc}) => {
 
   return (
     <div
-      className={`root-sidebar overflow-y-scroll py-3${
-        currentTheme === "dusk"
-          ? " mds-dark-theme--background"
-          : " mds-light-theme--background"
-      }`}
+      className={`root-sidebar overflow-y-scroll py-3`}
       style={{
         position: "fixed",
         height: "100%",
@@ -128,7 +126,7 @@ const Sidebar = ({menus, currentDoc}) => {
       }}
     >
       <div
-        className={`${currentTheme === "dusk" ? "white--text" : "black--text"}`}
+        className={`${isDark ? "white--text" : "black--text"}`}
         style={{display: "flex", padding: "0 15px"}}
       >
         <h1 style={{flex: "1"}}>

--- a/docs/ThemeSwitcher.js
+++ b/docs/ThemeSwitcher.js
@@ -4,18 +4,27 @@ import {
   AButton,
   AButtonGroup,
   ASwitch,
+  AIcon,
+  ATriggerTooltip,
   useATheme,
   useAAutoTheme
 } from "../framework";
 
+const groupStyle = {display: "flex", alignItems: "center"};
+
+const labelStyle = {
+  width: "70px",
+  marginRight: "8px"
+};
+
 const ThemeSwitcher = () => {
   const {currentTheme, setCurrentTheme} = useATheme();
   const autoTheme = useAAutoTheme();
-  const styleColor = currentTheme === "dusk" ? "white--text" : "black--text";
+
   return (
     <div>
-      <div style={{display: "flex"}}>
-        <p style={{marginRight: "15px"}}>Theme:</p>
+      <div style={groupStyle}>
+        <p style={labelStyle}>Theme:</p>
         <AButtonGroup
           selectedValues={[currentTheme]}
           onChange={(value) => {
@@ -25,28 +34,51 @@ const ThemeSwitcher = () => {
             setCurrentTheme(value);
           }}
         >
-          <AButton
-            secondary={currentTheme === "dusk"}
-            data-testid="enable-default-theme"
-            style={{color: `${styleColor}`}}
-            disabled={autoTheme.enabled}
-            value="default"
-          >
+          <AButton secondary data-testid="enable-default-theme" value="default">
             Light
           </AButton>
-          <AButton
-            secondary={currentTheme !== "dusk"}
-            data-testid="enable-dusk-theme"
-            style={{color: `${styleColor}`}}
-            disabled={autoTheme.enabled}
-            value="dusk"
-          >
+          <AButton secondary data-testid="enable-dusk-theme" value="dusk">
             Dusk
           </AButton>
         </AButtonGroup>
       </div>
+      <div style={groupStyle}>
+        <p style={labelStyle}>Classic Theme:</p>
+        <AButtonGroup
+          selectedValues={[currentTheme]}
+          onChange={(value) => {
+            if (autoTheme.enabled) {
+              autoTheme.disable();
+            }
+            console.log("value", value);
+            setCurrentTheme(value);
+          }}
+        >
+          <AButton
+            secondary
+            data-testid="enable-classic-light-theme"
+            value="classic-light"
+          >
+            Light
+          </AButton>
+          <AButton
+            secondary
+            data-testid="enable-classic-dark-theme"
+            value="classic-dark"
+          >
+            Dark
+          </AButton>
+        </AButtonGroup>
+      </div>
       <ASwitch checked={autoTheme.enabled} onClick={autoTheme.toggle}>
-        <span className={styleColor}>Match System Theme</span>
+        <span>
+          Match System Theme{" "}
+          <ATriggerTooltip content="Auto theme uses the 'light' and 'dark' ('default' and 'dusk' in magna-react) themes from MDS">
+            <AIcon style={{width: "14px", verticalAlign: "middle"}}>
+              information
+            </AIcon>
+          </ATriggerTooltip>
+        </span>
       </ASwitch>
     </div>
   );

--- a/framework/components/AApp/base/scrollbar.scss
+++ b/framework/components/AApp/base/scrollbar.scss
@@ -1,7 +1,9 @@
-.theme--default {
+.theme--default,
+.theme--classic-light {
   color-scheme: light;
 }
 
-.theme--dusk {
+.theme--dusk,
+.theme--classic-dark {
   color-scheme: dark;
 }

--- a/framework/components/ATextInput/ATextInput.mdx
+++ b/framework/components/ATextInput/ATextInput.mdx
@@ -27,7 +27,6 @@ import {ATextInput} from "@cisco-sbg-ui/magna-react";
             <ACol>
               <ATextInput
                 small
-                autoFocus={true}
                 clearable
                 label="Location"
                 infoTooltip="Tooltip for Location input"
@@ -54,7 +53,6 @@ import {ATextInput} from "@cisco-sbg-ui/magna-react";
           <ARow>
             <ACol>
               <ATextInput
-                autoFocus={true}
                 clearable
                 label="Medium"
                 placeholder="A medium input"
@@ -66,7 +64,6 @@ import {ATextInput} from "@cisco-sbg-ui/magna-react";
           <ARow>
             <ACol>
               <ATextInput
-                autoFocus={true}
                 clearable
                 label="Large"
                 placeholder="A large input"

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -3,11 +3,8 @@ import React, {forwardRef, useState, useCallback} from "react";
 
 import {useIsomorphicLayoutEffect} from "../../utils/hooks";
 import AThemeContext from "./AThemeContext";
+import {SUPPORTED_THEMES, DEFAULT_THEME, DARK_THEMES} from "./constants";
 import "./ATheme.scss";
-
-const DEFAULT_THEME = "default";
-const DUSK_THEME = "dusk";
-const SUPPORTED_THEMES = [DEFAULT_THEME, DUSK_THEME];
 
 const DEFAULT_INITIAL_THEME = DEFAULT_THEME;
 
@@ -102,8 +99,8 @@ const ATheme = forwardRef(
       }
     }, [currentTheme]);
 
-    const isDark = currentTheme === DUSK_THEME;
-    const isLight = currentTheme !== DUSK_THEME;
+    const isDark = DARK_THEMES.includes(currentTheme);
+    const isLight = !isDark;
 
     const themeContext = {
       persist,
@@ -119,9 +116,10 @@ const ATheme = forwardRef(
 
     let className = "theme--default";
 
-    if (isDark) {
-      className = "theme--dusk";
+    if (isSupportedTheme(currentTheme)) {
+      className = `theme--${currentTheme}`;
     }
+
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }

--- a/framework/components/ATheme/ATheme.scss
+++ b/framework/components/ATheme/ATheme.scss
@@ -7,13 +7,15 @@
   --negative-border-darken: darken(#cc2d37, 5%);
 }
 
-.theme--default {
+.theme--default,
+.theme--classic-light {
   --card-shadow-color: rgba(0, 0, 0, 0.08);
   --text-input-shadow-color: var(--control-border-medium-hover);
   --row-effect-image: none;
 }
 
-.theme--dusk {
+.theme--dusk,
+.theme--classic-dark {
   --card-shadow-color: rgba(0, 0, 0, 0.48);
   --text-input-shadow-color: #5191f080; //TODO waiting for new shadow color/tokens
   --row-effect-image: (

--- a/framework/components/ATheme/constants.js
+++ b/framework/components/ATheme/constants.js
@@ -1,0 +1,14 @@
+export const DEFAULT_THEME = "default";
+export const DUSK_THEME = "dusk";
+export const CLASSIC_LIGHT_THEME = "classic-light";
+export const CLASSIC_DARK_THEME = "classic-dark";
+
+export const SUPPORTED_THEMES = [
+  DEFAULT_THEME,
+  CLASSIC_LIGHT_THEME,
+  DUSK_THEME,
+  CLASSIC_DARK_THEME
+];
+
+export const LIGHT_THEMES = [DEFAULT_THEME, CLASSIC_LIGHT_THEME];
+export const DARK_THEMES = [DUSK_THEME, CLASSIC_DARK_THEME];

--- a/framework/components/ATheme/index.js
+++ b/framework/components/ATheme/index.js
@@ -1,5 +1,25 @@
 import ATheme from "./ATheme";
 import AThemeContext from "./AThemeContext";
 import useATheme from "./useATheme";
+import {
+  DEFAULT_THEME,
+  DUSK_THEME,
+  CLASSIC_LIGHT_THEME,
+  CLASSIC_DARK_THEME,
+  SUPPORTED_THEMES,
+  LIGHT_THEMES,
+  DARK_THEMES
+} from "./constants";
 
-export {ATheme, AThemeContext, useATheme};
+export {
+  ATheme,
+  AThemeContext,
+  useATheme,
+  DEFAULT_THEME,
+  DUSK_THEME,
+  CLASSIC_LIGHT_THEME,
+  CLASSIC_DARK_THEME,
+  SUPPORTED_THEMES,
+  LIGHT_THEMES,
+  DARK_THEMES
+};


### PR DESCRIPTION
Adds support for the magnetic "classic" (classic light and classic dark) themes.

Treats themes as two groups, light themes and dark themes. This should continue to support use of the `AThemeContext`'s props `isLight` and `isDark` as before.

Additionally, the theme constants are now exported for use in other libraries.

Resolves #630

![Screenshot 2024-03-25 at 11 47 03 AM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/96969e61-9518-4e57-a99a-d063dc874141)
