### PR TITLE
feat: col width small option

### DIFF
--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -282,6 +282,7 @@ You can also pass a React element to a header's `name` key in order to handle mo
           {allSelected ? 'Unselect' : 'Select'} all
         </ACheckbox>
       ),
+      colWidthSm: true,
       cell: {
         component: (rowItem) => {
           const rowId = rowItem['firstCol'];
@@ -401,6 +402,7 @@ In this example, the associated more details drawer that is opened is used to de
     {
       name: "Details",
       align: "center",
+      colWidthSm: true,
       cell: {
         component: (item) => (
           <AButton className='ma-0 pa-0' tertiaryAlt icon onClick={() => {
@@ -638,7 +640,8 @@ const headers = [
     {
       name: "Alpha",
       key: "a",
-      align: "end"
+      align: "end",
+      colWidthSm: true,
     },
     {
       name: "Bravo",

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -48,6 +48,17 @@ $hidden-table-col-width: 45px;
         background-color: var(--control-bg-weak-active);
       }
     }
+
+    &.col-width-sm {
+      width: 0 !important; //Required for other envs
+      min-width: 50px !important;
+    }
+    &.col-width-sm:not(:last-of-type) {
+      padding-right: 4px;
+    }
+    &.col-width-sm:not(:first-of-type) {
+      padding-left: 4px;
+    }
   }
 
   &__row {
@@ -61,6 +72,16 @@ $hidden-table-col-width: 45px;
 
     &--key-selected {
       background: var(--control-bg-weak-active);
+    }
+
+    .row-width-sm {
+      min-width: 0 !important;
+    }
+    .row-width-sm:not(:last-of-type) {
+      padding-right: 4px;
+    }
+    .row-width-sm:not(:first-of-type) {
+      padding-left: 4px;
     }
   }
 

--- a/framework/components/ADataTable/ADataTableCellTemplate.js
+++ b/framework/components/ADataTable/ADataTableCellTemplate.js
@@ -22,7 +22,7 @@ const ADataTableCellTemplate = ({rowItem, headerItem, headerIndex}) => {
       col-index={headerIndex}
       className={`text-${headerItem.align || "start"} ${
         headerItem.cell?.className || ""
-      }`.trim()}
+      } ${headerItem.colWidthSm ? "row-width-sm" : ""}`.trim()}
     >
       {content}
     </ADataTableCell>

--- a/framework/components/ADataTable/ADataTableHeader.js
+++ b/framework/components/ADataTable/ADataTableHeader.js
@@ -1,13 +1,23 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const ADataTableHeader = ({className, ...rest}) => (
-  <th
-    role="columnheader"
-    className={`a-data-table__header${className ? ` ${className}` : ""}`}
-    {...rest}
-  />
-);
+const ADataTableHeader = ({className, colWidthSm, ...rest}) => {
+  let propsClassName = className;
+
+  if (colWidthSm) {
+    propsClassName += ` col-width-sm`;
+  }
+
+  return (
+    <th
+      role="columnheader"
+      className={`a-data-table__header${
+        propsClassName ? ` ${propsClassName}` : ""
+      }`}
+      {...rest}
+    />
+  );
+};
 
 ADataTableHeader.displayName = "ADataTableHeader";
 

--- a/framework/components/ADataTable/ADataTableHeaderTemplate.js
+++ b/framework/components/ADataTable/ADataTableHeaderTemplate.js
@@ -38,6 +38,7 @@ const ADataTableHeaderTemplate = ({
     "aria-label": headerItem.name,
     style: headerItem.style,
     wrap: headerItem.wrap,
+    colWidthSm: headerItem.colWidthSm,
     ...rest
   };
 
@@ -159,7 +160,9 @@ ADataTableHeaderTemplate.propTypes = {
       className: PropTypes.string,
       /** Custom component to be rendered for each table data item */
       component: PropTypes.func
-    })
+    }),
+    /** Option to shrink col width */
+    colWidthSm: PropTypes.bool
   }),
 
   /**

--- a/framework/components/ADataTable/ADataTableRowTemplate.js
+++ b/framework/components/ADataTable/ADataTableRowTemplate.js
@@ -135,7 +135,9 @@ ADataTableRowTemplate.propTypes = {
         className: PropTypes.string,
         /** Custom component to be rendered for each table data item */
         component: PropTypes.func
-      })
+      }),
+      /** Option to shrink col width */
+      colWidthSm: PropTypes.bool
     })
   ).isRequired,
 


### PR DESCRIPTION
**Closes #656 - col width small option**

Give option for columns that need smallest width possible. Ideal for icons, small tags, checkboxes etc.

`colWidthSm: true`


