### PR TITLE
Allow css vars as valid color for prop type check

### DIFF
--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -240,7 +240,12 @@ const validColorRegex =
 
 export const isValidColor = (props, propName, componentName) => {
   const color = props?.[propName];
-  if (color && !isStockColor(color) && !validColorRegex.test(color)) {
+  if (
+    color &&
+    !isStockColor(color) &&
+    !validColorRegex.test(color) &&
+    !color.startsWith("var(")
+  ) {
     return new Error(
       "Invalid value (`" +
         JSON.stringify(props[propName]) +


### PR DESCRIPTION
CSS vars can now be used in `ACheckbox` `color` prop, since the CSS "just works". The prop types validation should allow that to go through without warning