### PR TITLE
useDrawerToggle for slide out->in animation

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -109,8 +109,9 @@ const ADrawer = forwardRef(
           {...rest}
           ref={shouldRenderModal ? null : ref}
           className={shouldRenderModal ? "" : className}
-          style={shouldRenderModal ? {height: "100%"} : style}>
-          {shouldRenderChildren && children}
+          style={shouldRenderModal ? {height: "100%"} : style}
+        >
+          {shouldRenderChildren && !isOpen ? prevChildren : children}
         </DrawerPanelComponent>
       </DrawerContext.Provider>
     );
@@ -130,7 +131,8 @@ const ADrawer = forwardRef(
         isOpen={shouldRenderChildren}
         style={style}
         onClose={onClose}
-        closeOnOutsideClick={closeOnOutsideClick}>
+        closeOnOutsideClick={closeOnOutsideClick}
+      >
         {drawerPanelComponent}
       </AModal>
     );

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -6,7 +6,7 @@ import AButton from "../AButton/AButton";
 import AIcon from "../AIcon/AIcon";
 
 import "./ADrawer.scss";
-import {useDelayUnmount} from "../../utils/hooks";
+import {useDelayUnmount, usePrevious} from "../../utils/hooks";
 
 const DrawerContext = createContext({});
 
@@ -45,6 +45,8 @@ const ADrawer = forwardRef(
     const orientation =
       slideIn === "bottom" || slideIn === "top" ? "horizontal" : "vertical";
     let className = `a-drawer a-drawer--${orientation} a-drawer--${position} a-drawer--${slideIn}`;
+
+    const prevChildren = usePrevious(children);
 
     const style = {...propsStyle};
 
@@ -107,8 +109,7 @@ const ADrawer = forwardRef(
           {...rest}
           ref={shouldRenderModal ? null : ref}
           className={shouldRenderModal ? "" : className}
-          style={shouldRenderModal ? {height: "100%"} : style}
-        >
+          style={shouldRenderModal ? {height: "100%"} : style}>
           {shouldRenderChildren && children}
         </DrawerPanelComponent>
       </DrawerContext.Provider>
@@ -129,8 +130,7 @@ const ADrawer = forwardRef(
         isOpen={shouldRenderChildren}
         style={style}
         onClose={onClose}
-        closeOnOutsideClick={closeOnOutsideClick}
-      >
+        closeOnOutsideClick={closeOnOutsideClick}>
         {drawerPanelComponent}
       </AModal>
     );

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -707,6 +707,7 @@ This hook can be used for cases when there isn't a global drawer controller.
               setDrawerContent(null, false);
             }}
             data-test-drawer>
+            <>
           <ADrawerHeader>
             <ADrawerTitle>
               <h1>{content?.title}</h1>
@@ -719,6 +720,7 @@ This hook can be used for cases when there isn't a global drawer controller.
           <ADrawerFooter>
             <AButton onClick={() => setDrawerOpen(false)} data-test-drawer-close>Close</AButton>
           </ADrawerFooter>
+          </>
         </ADrawer>
       </>
     )

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -650,9 +650,9 @@ To contain the drawer within something other than the viewport, you can render t
 
 ### Magnetic Drawer Transition
 
-Magnetic designates that drawers slide out then back in when opening another data object on the same page. Use the `useDrawerToggle` hooks to facilitate the timing of the slide out/in.
+Magnetic designates that drawers slide out then back in when opening another data object on the same page. Use the `useDrawerToggle` hook to facilitate the timing of the slide out/in.
 
-This hook can be used for cases when there isn't a global drawer controller.
+This hook can be used in cases there isn't a global drawer controller.
 
 <Playground
   code={`() => {

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -646,6 +646,93 @@ To contain the drawer within something other than the viewport, you can render t
 }`}
 />
 
+## Slide Out-In
+
+### Magnetic Drawer Transition
+
+Magnetic designates that drawers slide out then back in when opening another data object on the same page. Use the `useDrawerToggle` hooks to facilitate the timing of the slide out/in.
+
+This hook can be used for cases when there isn't a global drawer controller.
+
+<Playground
+  code={`() => {
+    
+    const list = {
+      a: {
+        title: "Content A", 
+        subtitle: "content A subtitle", 
+        body: "Content A body text"
+      }, 
+      b: {
+        title: "Content B", 
+        subtitle: "content B subtitle", 
+        body: "Content B body text"
+      }
+    }
+   
+    const drawerRef = useRef();
+    const {setDrawerOpen, isDrawerOpen} = useDrawerToggle();
+    const [contentId, setContentId] = useState();
+
+    const DrawerContent = ({contentId}) => {
+      const {title, subtitle, body} = list[contentId];
+
+      return (
+        <>
+          <ADrawerHeader>
+            <ADrawerTitle>
+              <h1>{title}</h1>
+            </ADrawerTitle>
+            <ADrawerSubtitle>{subtitle}</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+            {body}
+          </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setDrawerOpen(false)} data-test-drawer-close>Close</AButton>
+          </ADrawerFooter>
+        </>
+      );
+    };
+
+    const setDrawerContent = (newContent, open = true) => {
+      if (newContent === contentId) {
+        return;
+      }
+
+      setContentId(newContent);
+      setDrawerOpen(open);
+    }
+
+    return (
+      <>
+        <AButton onClick={() => {
+            setDrawerContent("a");
+          }}
+          data-test-drawer-trigger-a>Open Content A</AButton><br />
+        <AButton onClick={() => {
+            setDrawerContent("b");
+          }}
+          data-test-drawer-trigger-b>Open Content B</AButton>
+        <ADrawer
+            ref={drawerRef}
+            style={{display: "flex", flexDirection: "column"}}
+            asModal={false}
+            aria-labelledby='drawer-title'
+            slideIn='right'
+            isOpen={isDrawerOpen}
+            onClose={() => {
+              setDrawerContent(null, false);
+            }}
+            data-test-drawer>
+            <DrawerContent contentId={contentId} />
+        </ADrawer>
+      </>
+    )
+
+}`}
+/>
+
 ## Component Props
 
 <Props of="ADrawer" />

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -707,7 +707,6 @@ This hook can be used in cases there isn't a global drawer controller.
               setDrawerContent(null, false);
             }}
             data-test-drawer>
-            <>
           <ADrawerHeader>
             <ADrawerTitle>
               <h1>{content?.title}</h1>
@@ -720,7 +719,6 @@ This hook can be used in cases there isn't a global drawer controller.
           <ADrawerFooter>
             <AButton onClick={() => setDrawerOpen(false)} data-test-drawer-close>Close</AButton>
           </ADrawerFooter>
-          </>
         </ADrawer>
       </>
     )

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -659,41 +659,20 @@ This hook can be used for cases when there isn't a global drawer controller.
     
     const list = {
       a: {
-        title: "Content A", 
-        subtitle: "content A subtitle", 
-        body: "Content A body text"
+        title: "Merlin's Crystal", 
+        subtitle: "Short", 
+        body: "The wizard Merlin has been trapped in a magical crystal by the witch Morgan Le Faye. So far, King Arthur hasn't been able to figure out how to free his mentor from his crystal prison. Can you help?"
       }, 
       b: {
-        title: "Content B", 
-        subtitle: "content B subtitle", 
-        body: "Content B body text"
+        title: "Gertrude's Cat", 
+        subtitle: "Very Short", 
+        body: "Gertrude has lost her cat Fluffs and desperately wants to find her. Can you help bring her home?"
       }
     }
    
     const drawerRef = useRef();
     const {setDrawerOpen, isDrawerOpen} = useDrawerToggle();
     const [contentId, setContentId] = useState();
-
-    const DrawerContent = ({contentId}) => {
-      const {title, subtitle, body} = list[contentId];
-
-      return (
-        <>
-          <ADrawerHeader>
-            <ADrawerTitle>
-              <h1>{title}</h1>
-            </ADrawerTitle>
-            <ADrawerSubtitle>{subtitle}</ADrawerSubtitle>
-          </ADrawerHeader>
-          <ADrawerBody>
-            {body}
-          </ADrawerBody>
-          <ADrawerFooter>
-            <AButton onClick={() => setDrawerOpen(false)} data-test-drawer-close>Close</AButton>
-          </ADrawerFooter>
-        </>
-      );
-    };
 
     const setDrawerContent = (newContent, open = true) => {
       if (newContent === contentId) {
@@ -704,16 +683,19 @@ This hook can be used for cases when there isn't a global drawer controller.
       setDrawerOpen(open);
     }
 
+    const content = list[contentId]
+
     return (
       <>
         <AButton onClick={() => {
             setDrawerContent("a");
           }}
-          data-test-drawer-trigger-a>Open Content A</AButton><br />
+          data-test-drawer-trigger-a>Merlin's Crystal</AButton>
+        <br /><br />
         <AButton onClick={() => {
             setDrawerContent("b");
           }}
-          data-test-drawer-trigger-b>Open Content B</AButton>
+          data-test-drawer-trigger-b>Gertrude's Cat</AButton>
         <ADrawer
             ref={drawerRef}
             style={{display: "flex", flexDirection: "column"}}
@@ -725,7 +707,18 @@ This hook can be used for cases when there isn't a global drawer controller.
               setDrawerContent(null, false);
             }}
             data-test-drawer>
-            <DrawerContent contentId={contentId} />
+          <ADrawerHeader>
+            <ADrawerTitle>
+              <h1>{content?.title}</h1>
+            </ADrawerTitle>
+            <ADrawerSubtitle>{content?.subtitle}</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+            {content?.body}
+          </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setDrawerOpen(false)} data-test-drawer-close>Close</AButton>
+          </ADrawerFooter>
         </ADrawer>
       </>
     )

--- a/framework/components/ADrawer/hooks.js
+++ b/framework/components/ADrawer/hooks.js
@@ -1,0 +1,32 @@
+import {useState} from "react";
+import usePopupQuickExit from "../../hooks/usePopupQuickExit/usePopupQuickExit";
+
+export const useDrawerToggle = (drawerRef, delay = 300) => {
+  const [isDrawerOpen, setIsOpen] = useState(false);
+  let handler;
+
+  usePopupQuickExit({
+    popupRef: drawerRef,
+    isEnabled: isDrawerOpen,
+    onExit: () => setIsOpen(false)
+  });
+
+  const setDrawerOpen = (open) => {
+    handler && clearTimeout(handler);
+
+    if (!open) {
+      setIsOpen(open);
+    } else {
+      setIsOpen(false); // TODO  flushSync here to force the false
+
+      handler = setTimeout(() => {
+        setIsOpen(open);
+      }, delay);
+    }
+    return () => {
+      handler && clearTimeout(handler);
+    };
+  };
+
+  return {setDrawerOpen, isDrawerOpen};
+};

--- a/framework/components/ADrawer/index.js
+++ b/framework/components/ADrawer/index.js
@@ -5,6 +5,7 @@ import ADrawerHeader from "./ADrawerHeader";
 import ADrawerFooter from "./ADrawerFooter";
 import ADrawerSubtitle from "./ADrawerSubtitle";
 import ADrawerTitle from "./ADrawerTitle";
+import {useDrawerToggle} from "./hooks";
 
 export {
   ADrawer,
@@ -13,5 +14,6 @@ export {
   ADrawerHeader,
   ADrawerFooter,
   ADrawerSubtitle,
-  ADrawerTitle
+  ADrawerTitle,
+  useDrawerToggle
 };

--- a/framework/index.js
+++ b/framework/index.js
@@ -42,7 +42,8 @@ import {
   ADrawerHeader,
   ADrawerFooter,
   ADrawerSubtitle,
-  ADrawerTitle
+  ADrawerTitle,
+  useDrawerToggle
 } from "./components/ADrawer";
 import AEmptyState from "./components/AEmptyState";
 import AFieldBase from "./components/AFieldBase";
@@ -268,6 +269,7 @@ export {
   ATriggerTooltip,
   useABreakpoint,
   useADateRange,
+  useDrawerToggle,
   useGetADateRange,
   useAAutoTheme,
   useATheme,

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -73,3 +73,12 @@ export const useResizeObserver = (containerRef) => {
     height
   };
 };
+
+export const usePrevious = (value) => {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+};


### PR DESCRIPTION
Adds a hook for easy Magnetic drawer slide out and back in when changing objects - for single "render" if `ADrawer` where only the content changes on open. 

This will help keep drawer transitions consistent where a global transition context isn't used.