### PR TITLE
Fix docs header height in grid

### DIFF
--- a/pages/[[...route]]/index.scss
+++ b/pages/[[...route]]/index.scss
@@ -23,7 +23,7 @@ body {
 #container {
   display: grid;
   grid-template-columns: 280px auto;
-  grid-template-rows: auto auto;
+  grid-template-rows: 117px auto;
   grid-template-areas:
     "header header"
     "sidebar component";


### PR DESCRIPTION
row height auto doesn't work when deployed...