### PR TITLE
docs: refine success alert criteria rendered for markdown blockquote

### DIFF
--- a/pages/[[...route]]/index.js
+++ b/pages/[[...route]]/index.js
@@ -136,7 +136,7 @@ export default function DocsPage({currentDoc, menus, propsInfo}) {
                             level = "warning";
                           } else if (combined.includes(":danger:")) {
                             level = "danger";
-                          } else if (combined.includes("success")) {
+                          } else if (combined.includes(":success:")) {
                             level = "success";
                           } else {
                             level = "info";


### PR DESCRIPTION
One day, a developer is going to be *really* confused why writing "success" in a blockquote is rendering a success variant `AAlert` component. This will reinforce the pattern of wrapping the desired variants in colons, .e.g., `:success:`