### PR TITLE
Don't require a child in AKeyValue

### DIFF
--- a/framework/components/AKeyValue/AKeyValue.js
+++ b/framework/components/AKeyValue/AKeyValue.js
@@ -44,7 +44,7 @@ AKeyValue.propTypes = {
   /**
    * The `AKeyValue` component requires the data value as the only child element.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Add a help tooltip to the key field
    */


### PR DESCRIPTION
It's valid for the value field to be blank