### PR TITLE
Refactor tab selected tracking; add arrow key accessibility

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -14,6 +14,10 @@ useContainer: true
 - `ALoadNotification` should be replaced with `AEmptyState`
 - `ADialog` should be replaced with `AModal`
 
+### Accessibility Changes
+
+- `ATabGroup` now adheres to ARIA spec in regards to tabs and left/right arrow keys
+
 ### Deprecation Removals
 
 #### AApp

--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -38,26 +38,22 @@ describe("<ATabGroup />", () => {
   // });
 
   it("should navigate with arrow keystroke", () => {
-    cy.mount(<ATabTest width={"15rem"} />);
+    cy.mount(<ATabTest />);
     cy.get(".a-tab-group").focus();
 
-    cy.get(".a-tab-group").type("{rightarrow}");
-    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get(".a-tab-group").type("{leftarrow}");
 
     cy.get(".a-tab-group__tab")
       .first()
       .next()
       .should("have.class", "a-tab-group__tab--focused");
 
-    cy.get(".a-tab-group").type("{leftarrow}");
-    cy.get(".a-tab-group").type("{leftarrow}");
-    cy.get(".a-tab-group").type("{leftarrow}");
-    cy.get(".a-tab-group").type("{esc}"); // close the More menu
-
-    cy.get(".a-tab-group").type("{leftarrow}");
+    cy.get(".a-tab-group").type("{rightarrow}");
 
     cy.get(".a-tab-group__tab")
       .first()
+      .next()
+      .next()
       .next()
       .should("have.class", "a-tab-group__tab--focused");
   });
@@ -107,7 +103,6 @@ describe("<ATabGroup />", () => {
     cy.mount(<ATabTest width={"15rem"} />);
     cy.get(".a-tab-group").focus();
 
-    cy.get(".a-tab-group").type("{rightarrow}");
     cy.get(".a-tab-group").type("{rightarrow}");
     cy.get(".a-tab-group").type("{rightarrow}");
     cy.get(".a-tab-group").type("{rightarrow}");

--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -103,16 +103,13 @@ describe("<ATabGroup />", () => {
     cy.mount(<ATabTest width={"15rem"} />);
     cy.get(".a-tab-group").focus();
 
-    cy.get(".a-tab-group").type("{rightarrow}");
-    cy.get(".a-tab-group").type("{rightarrow}");
-    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get("[data-set=menu]").click();
 
-    cy.get(".a-tab-group__tab--selected").should("exist");
     cy.get(".a-menu").should("exist");
     cy.get(".a-list-item").first().next().type("{enter}");
     cy.get("body").click(0, 0);
-    cy.get(".a-tab-group__tab--selected").should("exist");
-    cy.get(".menu-tab").click();
+    cy.get("[data-set=menu]").click();
+
     cy.get(".a-list-item")
       .get(".a-list-item--selected")
       .should("exist")

--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -59,40 +59,40 @@ describe("<ATabGroup />", () => {
   });
 
   it("should have visible overflow tab", () => {
-    cy.mount(<ATabTest />);
-    cy.get(".menu-tab").should("be.visible");
+    cy.mount(<ATabTest width={"15rem"} />);
+    cy.get(".a-tab-group__menu-tab").should("be.visible");
   });
 
   it("overflow tab should be populated with remaining items", () => {
-    cy.mount(<ATabTest />);
-    cy.get(".menu-tab").click();
-    cy.get(".a-list-item").first().should("be.visible").contains("Six");
+    cy.mount(<ATabTest width={"15rem"} />);
+    cy.get(".a-tab-group__menu-tab").click();
+    cy.get(".a-list-item").last().should("be.visible").contains("Seven");
   });
 
   it("should move more items into overflow menu after resize", () => {
     cy.mount(<ATabTest width={"20rem"} />);
-    cy.get(".menu-tab").click();
+    cy.get(".a-tab-group__menu-tab").click();
     cy.get(".a-list-item").first().should("be.visible").contains("Four");
   });
 
   it("should move even more items into overflow menu after resize", () => {
     cy.mount(<ATabTest width={"15rem"} />);
-    cy.get(".menu-tab").click();
+    cy.get(".a-tab-group__menu-tab").click();
     cy.get(".a-list-item").first().should("be.visible").contains("Three");
   });
 
   it("should remove overflow menu tab if resized", () => {
     cy.mount(<ATabTest width={"100%"} />);
-    cy.get(".menu-tab").should("not.be.visible");
+    cy.get(".a-tab-group__menu-tab").should("not.be.visible");
   });
 
   it("should maintain highlighted state if overflow menu item is selected", () => {
     cy.mount(<ATabTest width={"15rem"} />);
-    cy.get(".menu-tab").click();
+    cy.get(".a-tab-group__menu-tab").click();
     cy.get(".a-list-item")
       .last()
       .click()
-      .get(".menu-tab")
+      .get(".a-tab-group__menu-tab")
       .click()
       .get(".a-menu-base")
       .get(".a-list-item--selected")
@@ -118,7 +118,7 @@ describe("<ATabGroup />", () => {
 
   it("should not render overflow tab if in vertical position", () => {
     cy.mount(<ATabTest width={"15rem"} vertical />);
-    cy.get(".menu-tab").should("not.exist");
+    cy.get(".a-tab-group__menu-tab").should("not.exist");
   });
 });
 

--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -37,6 +37,31 @@ describe("<ATabGroup />", () => {
   //   );
   // });
 
+  it("should navigate with arrow keystroke", () => {
+    cy.mount(<ATabTest width={"15rem"} />);
+    cy.get(".a-tab-group").focus();
+
+    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get(".a-tab-group").type("{rightarrow}");
+
+    cy.get(".a-tab-group__tab")
+      .first()
+      .next()
+      .should("have.class", "a-tab-group__tab--focused");
+
+    cy.get(".a-tab-group").type("{leftarrow}");
+    cy.get(".a-tab-group").type("{leftarrow}");
+    cy.get(".a-tab-group").type("{leftarrow}");
+    cy.get(".a-tab-group").type("{esc}"); // close the More menu
+
+    cy.get(".a-tab-group").type("{leftarrow}");
+
+    cy.get(".a-tab-group__tab")
+      .first()
+      .next()
+      .should("have.class", "a-tab-group__tab--focused");
+  });
+
   it("should have visible overflow tab", () => {
     cy.mount(<ATabTest />);
     cy.get(".menu-tab").should("be.visible");
@@ -78,15 +103,17 @@ describe("<ATabGroup />", () => {
       .contains("Seven");
   });
 
-  it("should maintain highlighted state if overflow menu item is selected by keystroke", () => {
+  it("should maintain highlighted state if overflow menu item is selected by arrow keystroke", () => {
     cy.mount(<ATabTest width={"15rem"} />);
-    cy.get(".a-tab-group__tab")
-      .first()
-      .tab({shift: true})
-      .contains("More")
-      .type("{enter}")
-      .get(".a-tab-group__tab--selected")
-      .should("exist");
+    cy.get(".a-tab-group").focus();
+
+    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get(".a-tab-group").type("{rightarrow}");
+
+    cy.get(".a-tab-group__tab--selected").should("exist");
+    cy.get(".a-menu").should("exist");
     cy.get(".a-list-item").first().next().type("{enter}");
     cy.get("body").click(0, 0);
     cy.get(".a-tab-group__tab--selected").should("exist");

--- a/framework/components/ATabs/ATab.js
+++ b/framework/components/ATabs/ATab.js
@@ -33,10 +33,15 @@ const ATab = forwardRef(
   ) => {
     const tabRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, tabRef);
-    const [tabId, setTabId] = useState(null);
-    const [isSelected, setIsSelected] = useState(null);
-    const {tabChanged, setTabChanged, vertical, secondary} =
+    const tabIdRef = useRef(tabCounter++);
+    //  const [tabId, setTabId] = useState(null);
+    //const [isSelected, setIsSelected] = useState(null);
+    const tabId = tabKey?.toString() || tabIdRef?.current.toString();
+
+    const {selectedTab, setSelectedTab, focusedTab, vertical, secondary} =
       useContext(ATabContext);
+    const isSelected = selectedTab == tabId;
+    const isFocused = focusedTab == tabId;
 
     const menuTab =
       tabRef.current && tabRef.current.classList.contains("menu-tab")
@@ -44,25 +49,10 @@ const ATab = forwardRef(
         : null;
 
     useEffect(() => {
-      if (tabKey) return;
-      if (!tabId) {
-        const index = tabCounter++;
-        setTabId(index);
-        if (selected) {
-          setTabChanged(index);
-        }
+      if (selected) {
+        setSelectedTab(tabId);
       }
-
-      setIsSelected(tabChanged === tabId);
-    }, [setIsSelected, selected, setTabChanged, tabChanged, tabId, tabKey]);
-
-    useEffect(() => {
-      if (tabKey) return;
-      if (!selected && isSelected) {
-        setTabChanged(-1);
-        setIsSelected(false);
-      }
-    }, [selected, tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [selected, setSelectedTab, tabId]);
 
     let className = "a-tab-group__tab";
 
@@ -72,6 +62,10 @@ const ATab = forwardRef(
       if (vertical) {
         className += " a-tab-group__tab--selected--vertical";
       }
+    }
+
+    if (isFocused) {
+      className += " a-tab-group__tab--focused";
     }
 
     if (vertical) {
@@ -86,7 +80,8 @@ const ATab = forwardRef(
       className += ` ${propsClassName}`;
     }
 
-    //If in controlled mode, handle previously selected class.
+    // If in controlled mode, handle previously selected class when interacting
+    // with the overflow menu.
     const handleSiblingSelectedClass = () => {
       const parent = combinedRef.current.parentNode;
       const previousSelectedEl = parent.querySelector("[aria-selected=true]");
@@ -97,35 +92,21 @@ const ATab = forwardRef(
     };
 
     let TagName = "div";
+
     const props = {
       ...rest,
-      "aria-selected": Boolean((tabKey && selected) || isSelected),
+      "data-tabid": tabId,
+      "aria-selected": isSelected,
       ref: combinedRef,
       className,
       onClick: (e) => {
-        !tabKey && setTabChanged(tabId);
+        setSelectedTab(tabId);
         if (menuTab) {
           handleSiblingSelectedClass();
         }
         onClick && onClick(e);
       },
-      onKeyDown: (e) => {
-        if (!href && [keyCodes.enter].includes(e.keyCode)) {
-          e.preventDefault();
-          !tabKey && setTabChanged(tabId);
-          if (menuTab) {
-            handleSiblingSelectedClass();
-          }
-          onClick && onClick(e);
-        } else {
-          onKeyDown && onKeyDown(e);
-        }
-      },
-      onKeyUp: (e) => {
-        onKeyUp && onKeyUp(e);
-      },
-      role: "tab",
-      tabIndex: 0
+      role: "tab"
     };
 
     if (href) {

--- a/framework/components/ATabs/ATab.js
+++ b/framework/components/ATabs/ATab.js
@@ -34,8 +34,6 @@ const ATab = forwardRef(
     const tabRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, tabRef);
     const tabIdRef = useRef(tabCounter++);
-    //  const [tabId, setTabId] = useState(null);
-    //const [isSelected, setIsSelected] = useState(null);
     const tabId = tabKey?.toString() || tabIdRef?.current.toString();
 
     const {selectedTab, setSelectedTab, focusedTab, vertical, secondary} =
@@ -44,7 +42,8 @@ const ATab = forwardRef(
     const isFocused = focusedTab == tabId;
 
     const menuTab =
-      tabRef.current && tabRef.current.classList.contains("menu-tab")
+      tabRef.current &&
+      tabRef.current.classList.contains("a-tab-group__menu-tab")
         ? tabRef.current
         : null;
 
@@ -91,12 +90,13 @@ const ATab = forwardRef(
       }
     };
 
-    let TagName = "div";
+    let TagName = "button";
 
     const props = {
       ...rest,
       "data-tabid": tabId,
       "aria-selected": isSelected,
+      tabIndex: isSelected ? 1 : -1,
       ref: combinedRef,
       className,
       onClick: (e) => {

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -224,8 +224,6 @@ const ATabGroup = forwardRef(
         onKeyDown={(e) => {
           e.stopPropagation();
 
-          console.log(e);
-
           const focusedEl = tabContainerRef.current?.querySelector(
             `[data-tabid='${focusedTab}']`
           );

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -13,13 +13,24 @@ import ATabContext from "./ATabContext";
 import {useCombinedRefs} from "../../utils/hooks";
 import "./ATabs.scss";
 
+const selectedNotMenu = (el) => {
+  return (
+    el?.classList?.contains("a-tab-group__tab--selected") &&
+    el.getAttribute("data-set") !== "menu"
+  );
+};
+
 const getNextFocusId = (direction, containerEl, focusedEl) => {
   let nextId, toFocus;
 
   if (direction == "ArrowLeft") {
     toFocus = focusedEl.previousSibling;
 
-    while (!toFocus || toFocus?.classList.contains("hide")) {
+    while (
+      !toFocus ||
+      toFocus?.classList?.contains("hide") ||
+      selectedNotMenu(toFocus)
+    ) {
       if (!toFocus) {
         toFocus = containerEl.lastChild;
       } else {
@@ -31,7 +42,11 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
   } else if (direction == "ArrowRight") {
     toFocus = focusedEl.nextSibling;
 
-    while (!toFocus || toFocus?.classList?.contains("hide")) {
+    while (
+      !toFocus ||
+      toFocus?.classList?.contains("hide") ||
+      selectedNotMenu(toFocus)
+    ) {
       if (!toFocus) {
         toFocus = containerEl.firstChild;
       } else {

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -77,6 +77,7 @@ const ATabGroup = forwardRef(
     const [menuItems, setMenuItems] = useState([]);
     const tabGroupRef = useRef(null);
     const tabContainerRef = useRef(null);
+    const overflowRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, tabGroupRef);
 
     const setSelectedTab = useCallback(
@@ -93,7 +94,7 @@ const ATabGroup = forwardRef(
       }
 
       //Overflow tab
-      const tab = combinedRef.current.querySelector(".menu-tab");
+      const tab = combinedRef.current.querySelector(".a-tab-group__menu-tab");
 
       if (!tab) {
         return;
@@ -130,7 +131,7 @@ const ATabGroup = forwardRef(
         //If items' total width falls under overall container width, skip
         if (tabWrapper.offsetWidth >= overflowLimit + tabWidth) {
           overflowLimit += tabWidth;
-        } else if (!classList.includes("menu-tab")) {
+        } else if (!classList.includes("a-tab-group__menu-tab")) {
           //If items' total width exceeds overall container width, hide and push to overflow menu
           item.classList.add("hide");
           overflowMenuItems.push(i);
@@ -223,6 +224,8 @@ const ATabGroup = forwardRef(
         onKeyDown={(e) => {
           e.stopPropagation();
 
+          console.log(e);
+
           const focusedEl = tabContainerRef.current?.querySelector(
             `[data-tabid='${focusedTab}']`
           );
@@ -238,7 +241,12 @@ const ATabGroup = forwardRef(
 
             if (elementToFocus.getAttribute("data-set") === "menu") {
               elementToFocus.click();
-            } else if (selectOnArrow && elementToFocus.tagName !== "A") {
+            } else {
+              overflowRef.current?.setMenuOpen(false);
+              combinedRef.current?.focus();
+            }
+
+            if (selectOnArrow && elementToFocus.tagName !== "A") {
               elementToFocus.click();
             }
           } else if (["Enter"].includes(e.key)) {
@@ -251,7 +259,10 @@ const ATabGroup = forwardRef(
             <ATabContext.Provider value={tabContext}>
               {children}
               {!vertical && (
-                <OverflowMenuTab tabGroupRef={combinedRef}>
+                <OverflowMenuTab
+                  tabGroupRef={combinedRef}
+                  passthroughRef={overflowRef}
+                >
                   {renderChildren}
                 </OverflowMenuTab>
               )}

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -13,7 +13,7 @@ import ATabContext from "./ATabContext";
 import {useCombinedRefs} from "../../utils/hooks";
 import "./ATabs.scss";
 
-const selectedNotMenu = (el) => {
+const isTabSelectedAndNotMenuTab = (el) => {
   return (
     el?.classList?.contains("a-tab-group__tab--selected") &&
     el.getAttribute("data-set") !== "menu"
@@ -29,7 +29,7 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
     while (
       !toFocus ||
       toFocus?.classList?.contains("hide") ||
-      selectedNotMenu(toFocus)
+      isTabSelectedAndNotMenuTab(toFocus)
     ) {
       if (!toFocus) {
         toFocus = containerEl.lastChild;
@@ -45,7 +45,7 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
     while (
       !toFocus ||
       toFocus?.classList?.contains("hide") ||
-      selectedNotMenu(toFocus)
+      isTabSelectedAndNotMenuTab(toFocus)
     ) {
       if (!toFocus) {
         toFocus = containerEl.firstChild;

--- a/framework/components/ATabs/ATabs.mdx
+++ b/framework/components/ATabs/ATabs.mdx
@@ -2,7 +2,7 @@
 name: Tabs
 route: /components/tab
 components: ATabGroup, ATab
-title: AAccordion
+title: ATabGroup
 sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framework/components/ATabs
 ---
 
@@ -18,7 +18,8 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
   Note regarding Primary v. Secondary - There is no use case for Primary
   currently so we are setting Secondary to true.
 </AAlert>
-
+<br />
+<br />
 <AAlert dismissable={false}>
   If you need primary immedaitely, set secondary to false and please reach out
   to magna team so we can coordinate with UX on the path forward to implimenting
@@ -117,6 +118,24 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
 `}
 />
 
+#### Select on arrow left/right
+
+In some cases accessibility standards suggest automatically selecting a tab when navigating with the arrow keys
+
+<Playground
+  code={`<ATabGroup selectOnArrow>
+  <ATab selected>One</ATab>
+  <ATab selected>Two</ATab>
+  <ATab selected>Three</ATab>
+  <ATab selected>Four</ATab>
+  <ATab href="https://www.github.com">GitHub</ATab>
+  <ATab href="https://www.cisco.com" target="_blank">
+    Cisco.com
+  </ATab>
+</ATabGroup>
+`}
+/>
+
 #### Links
 
 Tabs will render in the DOM as anchor tags if the `href` property is defined.
@@ -163,4 +182,4 @@ By default, `ATab` components are assigned the [WAI-ARIA](https://www.w3.org/WAI
 
 The `ATab` `click` event handler is triggered both by the `click` event and by the `keyDown` event for the `Enter` key.
 
-Each `ATab` component is tab-focusable with a visual overlay.
+Each `ATab` is focusable using the arrow left/right keys, as per aria guidelines. Tabs that are anchor elements will not be automatically opened even if `selectOnArrow` is set to true.

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -78,7 +78,8 @@ $tab-heading-margin: 0;
 
     &:active,
     &:focus,
-    &:hover {
+    &:hover,
+    &--focused {
       color: var(--base-text-default);
 
       @include tab-bar(

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -79,10 +79,18 @@ $tab-heading-margin: 0;
     &:active,
     &:focus,
     &:hover,
-    &--focused {
+    &--focused:not(.a-tab-group__tab--vertical) {
       color: var(--base-text-default);
 
       @include tab-bar(
+        $tab-bottom-bar-height,
+        var(--brand-accent-border-hover)
+      );
+    }
+
+    &--focused.a-tab-group__tab--vertical {
+      color: var(--base-text-default);
+      @include vertical-tab-bar(
         $tab-bottom-bar-height,
         var(--brand-accent-border-hover)
       );

--- a/framework/components/ATabs/OverflowMenuTab.js
+++ b/framework/components/ATabs/OverflowMenuTab.js
@@ -3,12 +3,14 @@ import ATab from "./ATab";
 import AIcon from "../AIcon";
 import AMenu from "../AMenu";
 
-const OverflowMenuTab = ({tabGroupRef, children}) => {
+const OverflowMenuTab = ({tabGroupRef, passthroughRef, children}) => {
   const menuRef = useRef(null);
   const tabRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuIcon = menuOpen ? "caret-up" : "caret-down";
   const hasSelected = useRef(false);
+
+  passthroughRef.current = {setMenuOpen};
 
   //Force remove tab styles on nested children with links.
   useEffect(() => {
@@ -56,7 +58,7 @@ const OverflowMenuTab = ({tabGroupRef, children}) => {
       <ATab
         ref={tabRef}
         data-set="menu"
-        className={`menu-tab ${!children.length ? "hide" : ""}`}
+        className={`a-tab-group__menu-tab ${!children.length ? "hide" : ""}`}
         selected={menuOpen || hasSelected.current}
         onClick={() => {
           setMenuOpen(!menuOpen);

--- a/framework/components/ATabs/OverflowMenuTab.js
+++ b/framework/components/ATabs/OverflowMenuTab.js
@@ -3,8 +3,9 @@ import ATab from "./ATab";
 import AIcon from "../AIcon";
 import AMenu from "../AMenu";
 
-const OverflowMenuTab = ({children}) => {
+const OverflowMenuTab = ({tabGroupRef, children}) => {
   const menuRef = useRef(null);
+  const tabRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuIcon = menuOpen ? "caret-up" : "caret-down";
   const hasSelected = useRef(false);
@@ -32,7 +33,7 @@ const OverflowMenuTab = ({children}) => {
 
   //If overflow item is selected, let menu know to maintain selected state once closed.
   useEffect(() => {
-    const menuTabEl = menuRef.current;
+    const menuTabEl = tabRef.current;
 
     for (let child of children) {
       const {props} = child;
@@ -53,21 +54,35 @@ const OverflowMenuTab = ({children}) => {
   return (
     <>
       <ATab
-        ref={menuRef}
+        ref={tabRef}
         data-set="menu"
         className={`menu-tab ${!children.length ? "hide" : ""}`}
         selected={menuOpen || hasSelected.current}
-        onClick={() => setMenuOpen(!menuOpen)}
+        onClick={() => {
+          setMenuOpen(!menuOpen);
+
+          if (!menuOpen) {
+            tabGroupRef.current?.blur();
+            menuRef.current?.focus();
+          } else {
+            tabGroupRef.current?.focus();
+          }
+        }}
       >
         More <AIcon>{menuIcon}</AIcon>
       </ATab>
       <AMenu
+        ref={menuRef}
         className="tab-overflow-menu"
-        anchorRef={menuRef}
+        anchorRef={tabRef}
         open={menuOpen}
         closeOnClick
         placement="bottom"
-        onClose={() => setMenuOpen(false)}
+        onClose={() => {
+          setMenuOpen(false);
+
+          tabGroupRef.current?.focus();
+        }}
       >
         {children}
       </AMenu>


### PR DESCRIPTION
Builds off the ideas in https://github.com/cisco-sbg-ui/magna-react/pull/650

The previous implementation lacked a way to track focus and selected state simultaneously. This made it difficult to configure the keyboard arrows to not automatically select a tab (not desired when the panel content may take time to load). Additionally it made it difficult to avoid opening link tabs in the auto-select mode while tracking the other states.

