### PR TITLE
Align AAlert dismiss icon

### DIFF
--- a/framework/components/AAlert/AAlert.scss
+++ b/framework/components/AAlert/AAlert.scss
@@ -43,6 +43,7 @@ $alert-close-icon-size: 10.5px;
     }
 
     &.a-alert__icon--close {
+      align-self: center;
       &:focus {
         box-shadow: var(--shadow-focus) var(--control-border-active);
       }


### PR DESCRIPTION
Figma has the icon aligned vertically centered 

![Screenshot 2024-05-08 at 10 01 39 AM](https://github.com/cisco-sbg-ui/magna-react/assets/23561587/976ffd99-383c-4e88-a7ca-00e0ad9580ce)
