### PR TITLE
Update breakpoints to magnetic spec; move code into hooks

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -19,6 +19,18 @@ useContainer: true
 - `AMenu` now automatically has `useFocusTrap` to support tabbing inside menus after opening
 - `ATabGroup` now adheres to ARIA spec in regards to tabs and left/right arrow keys
 
+### Magnetic Changes
+
+#### Breakpoints
+
+Breakpoints have been updated to match magnetic spec.
+
+- xs: 420
+- sm: 960
+- md: 1280
+- lg: 1680
+- xl: 2080
+
 ### Deprecation Removals
 
 #### AApp

--- a/framework/components/AApp/AApp.mdx
+++ b/framework/components/AApp/AApp.mdx
@@ -511,11 +511,12 @@ For example, `d-flex d-md-block d-print-none`:
 
 Media queries are set for the following breakpoints:
 
-- xs: 479px
-- sm: 767px
-- md: 992px
-- lg: 1200px
-- xl: 1440px
+- xs: 420
+- sm: 960
+- md: 1280
+- lg: 1680
+- xl: 2080
+
 - print (for print styles)
 
 ### Reference

--- a/framework/components/ABreakpoint/ABreakpoint.spec.js
+++ b/framework/components/ABreakpoint/ABreakpoint.spec.js
@@ -1,9 +1,0 @@
-context("ABreakpoint", () => {
-  before(() => {
-    cy.visitInLightTheme("/services/breakpoint");
-  });
-
-  it("works", () => {
-    cy.get("#usage + .playground").contains("Extra Large");
-  });
-});

--- a/framework/components/ABreakpoint/index.js
+++ b/framework/components/ABreakpoint/index.js
@@ -1,3 +1,0 @@
-import useABreakpoint from "./useABreakpoint";
-
-export {useABreakpoint};

--- a/framework/hooks/useABreakpoint/index.js
+++ b/framework/hooks/useABreakpoint/index.js
@@ -1,0 +1,3 @@
+import useABreakpoint, {breakpointThresholds} from "./useABreakpoint";
+
+export {useABreakpoint, breakpointThresholds};

--- a/framework/hooks/useABreakpoint/useABreakpoint.js
+++ b/framework/hooks/useABreakpoint/useABreakpoint.js
@@ -2,6 +2,14 @@ import {useState} from "react";
 
 import {useIsomorphicLayoutEffect} from "../../utils/hooks";
 
+export const breakpointThresholds = {
+  xs: 420,
+  sm: 960,
+  md: 1280,
+  lg: 1680,
+  xl: 2080
+};
+
 const useABreakpoint = () => {
   const [resizeTimeout, setResizeTimeout] = useState(0);
   const [height, setHeight] = useState(0);
@@ -12,14 +20,6 @@ const useABreakpoint = () => {
 
     update();
   }, []);
-
-  const thresholds = {
-    xs: 479,
-    sm: 767,
-    md: 992,
-    lg: 1200,
-    xl: 1440
-  };
 
   const scrollBarWidth = 20;
 
@@ -47,11 +47,12 @@ const useABreakpoint = () => {
     );
   };
 
-  const xs = width < thresholds.xs;
-  const sm = width < thresholds.sm && !xs;
-  const md = width < thresholds.md - scrollBarWidth && !(sm || xs);
-  const lg = width < thresholds.lg - scrollBarWidth && !(md || sm || xs);
-  const xl = width >= thresholds.lg - scrollBarWidth;
+  const xs = width < breakpointThresholds.xs;
+  const sm = width < breakpointThresholds.sm && !xs;
+  const md = width < breakpointThresholds.md - scrollBarWidth && !(sm || xs);
+  const lg =
+    width < breakpointThresholds.lg - scrollBarWidth && !(md || sm || xs);
+  const xl = width >= breakpointThresholds.lg - scrollBarWidth;
   const name = xs ? "xs" : sm ? "sm" : md ? "md" : lg ? "lg" : "xl";
 
   return {

--- a/framework/hooks/useABreakpoint/useABreakpoint.mdx
+++ b/framework/hooks/useABreakpoint/useABreakpoint.mdx
@@ -2,13 +2,27 @@
 name: useABreakPoint
 route: /hooks/use-a-breakpoint
 components: useABreakpoint
-title: useABreakPoint
-sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framework/components/ABreakpoint
+title: useABreakpoint
+sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framework/hooks/useABreakpoint
 ---
 
 ## Usage
 
+### Import
+
 <ComponentImport components="useABreakpoint" />
+
+### Thresholds
+
+Media queries are set for the following breakpoints:
+
+- xs: 420
+- sm: 960
+- md: 1280
+- lg: 1680
+- xl: 2080
+
+These are exported as an object named `breakpointThresholds`
 
 ### Usage
 
@@ -16,7 +30,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
   code={`() => {
   const breakpointHelper = useABreakpoint();
   return (
-    <p>
+    <>
       {breakpointHelper.xs && "Extra Small"}
       {breakpointHelper.sm && "Small"}
       {breakpointHelper.md && "Medium"}
@@ -27,7 +41,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
       <pre><code>
       {JSON.stringify(breakpointHelper, null, 2)}
       </code></pre>
-    </p>
+    </>
   );
 }
 `}

--- a/framework/index.js
+++ b/framework/index.js
@@ -138,8 +138,11 @@ import AToast from "./components/AToast";
 import {ATooltip} from "./components/ATooltip";
 import ATree from "./components/ATree";
 import ATriggerTooltip from "./components/ATriggerTooltip";
-import {useABreakpoint} from "./components/ABreakpoint";
 import {useAToaster, AToastPlate} from "./components/AToaster";
+
+import useABreakpoint, {
+  breakpointThresholds
+} from "./hooks/useABreakpoint/useABreakpoint";
 import useEscapeKeydown from "./hooks/useEscapeKeydown/useEscapeKeydown";
 import useFocusTrap from "./hooks/useFocusTrap/useFocusTrap";
 import useKeydown from "./hooks/useKeydown/useKeydown";
@@ -275,6 +278,7 @@ export {
   ATooltip,
   ATree,
   ATriggerTooltip,
+  breakpointThresholds,
   useABreakpoint,
   useADateRange,
   useDrawerToggle,

--- a/framework/styles/utilities/variables.scss
+++ b/framework/styles/utilities/variables.scss
@@ -94,11 +94,11 @@ $page-width--max: 1440px !default;
 $grid-breakpoints: () !default;
 $grid-breakpoints: map-merge(
   (
-    "xs": 479px,
-    "sm": 767px,
-    "md": 992px,
-    "lg": 1200px,
-    "xl": 1440px
+    "xs": 420px,
+    "sm": 960px,
+    "md": 1280px,
+    "lg": 1680px,
+    "xl": 2080px
   ),
   $grid-breakpoints
 );


### PR DESCRIPTION
Resolves #671 

This updates the breakpoints to magnetic spec, and exports them as an object for use outside of the hook. Docs have been updated as well under `/hooks/use-a-breakpoint`

@sabrinamokerji fyi


This is a breaking change, so will go into magna 2.0