### PR TITLE
fix: spread props in `AActivityTimelineItem` component

### DIFF
--- a/framework/components/AActivityTimeline/AActivityTimelineItem.js
+++ b/framework/components/AActivityTimeline/AActivityTimelineItem.js
@@ -27,6 +27,7 @@ const ICON_STATUS_MAP = {
 const AActivityTimelineItem = forwardRef((props, ref) => {
   const {
     children,
+    className: propsClassName,
     defaultCollapsed,
     isCollapsed: propsIsCollapsed,
     isCollapsible,
@@ -34,7 +35,8 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
     status = "neutral",
     time,
     title,
-    withDivider
+    withDivider,
+    ...rest
   } = props;
 
   const isDividerVisibilityControlled = props.hasOwnProperty("withDivider");
@@ -65,7 +67,13 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
   );
 
   return (
-    <AActivityTimelineListItem icon={statusIcon} status={status} ref={ref}>
+    <AActivityTimelineListItem
+      icon={statusIcon}
+      status={status}
+      ref={ref}
+      className={propsClassName}
+      {...rest}
+    >
       {isCollapsible ? (
         <AActivityTimelineItemHeaderToggleButton
           isCollapsed={isCollapsed}

--- a/framework/components/AActivityTimeline/components/AActivityTimelineListItem.js
+++ b/framework/components/AActivityTimeline/components/AActivityTimelineListItem.js
@@ -3,15 +3,19 @@ import React, {forwardRef} from "react";
 import "../AActivityTimeline.scss";
 
 const AActivityTimelineListItem = forwardRef(
-  ({icon, children, status}, ref) => {
+  ({icon, children, className: propsClassName, status, ...rest}, ref) => {
     let className = "a-activity-timeline__list-item";
 
     if (status === "complete") {
       className += " a-activity-timeline__list-item--complete";
     }
 
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
     return (
-      <li className={className} ref={ref}>
+      <li className={className} ref={ref} {...rest}>
         {icon}
         <div className="flex-grow-1">{children}</div>
       </li>


### PR DESCRIPTION
## Context

Closes #720 

* #720 

## This PR

* Spreads props coming into the "AActivityTimelineItem" component from a developer
  * I also explicitly added the `className` as its own prop to make it more clear to a reader of the component that it does take `className` as a prop (so that they don't have to make an assumption that it would be passed down via spread instead)

## Test Plan

1. Copy the following code snippet:

    ```jsx
    <AActivityTimeline>
      <AActivityTimelineItem
        data-testid="TimelineItem"
        time="2022-02-12 21:11:10 UTC"
        title="Account Created"
      />
    </AActivityTimeline>
    ```
2. [Go to the `AActivityTimeline` documentation page for the preview branch](https://magna-react.vercel.app/components/activity-timeline)
3. Paste the code you copied from step 1 into any playground editor
4. Inspect the browser for the playground editor's rendered content
5. **Verify that the `data-testid` attribute is present on the `.a-activity-timeline__list-item` element in the DOM**