### PR TITLE
Revert "fix: accordian transition"

### DIFF
--- a/framework/components/AAccordion/AAccordion.scss
+++ b/framework/components/AAccordion/AAccordion.scss
@@ -46,6 +46,11 @@ $accordion-divider-border-width: thin;
       var(--control-border-default);
   }
   */
+    &--state-collapsed {
+      .a-accordion__body {
+        display: none;
+      }
+    }
 
     &--is-focused .a-accordion__header {
       border: $border-width solid;
@@ -154,7 +159,7 @@ $accordion-divider-border-width: thin;
 .a-app--animated .a-accordion {
   .a-accordion__card {
     .a-accordion__body {
-      overflow: hidden;
+      display: block;
       padding: 0 14px;
       visibility: visible;
       opacity: 1;


### PR DESCRIPTION
This reverts commit d50888d24320ded92e2fc772930b61450e11d1ed

https://github.com/cisco-sbg-ui/magna-react/commit/d50888d24320ded92e2fc772930b61450e11d1ed

`overflow: hidden` seems to break ASelect menu when inside of an accordion

Reverting for now