### PR TITLE
feat(AActivityTimeline): allow timeline item connector visibility to be controlled with prop

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -111,3 +111,12 @@ Cypress.Commands.add("hoverATooltip", (withClick = false) => {
 Cypress.Commands.add("clickATooltip", (withClick = false) => {
   return cy.getByAriaLabel("information icon").trigger("click");
 });
+
+Cypress.Commands.add("getPseudoElementStyle", ($el, pseudoElement, style) => {
+  // https://stackoverflow.com/a/75887385
+  const subject = $el[0];
+  const window = subject.ownerDocument.defaultView;
+  const pseudoElementStyles = window.getComputedStyle(subject, pseudoElement);
+
+  return pseudoElementStyles.getPropertyValue(style);
+});

--- a/framework/components/AActivityTimeline/AActivityTimeline.cy.js
+++ b/framework/components/AActivityTimeline/AActivityTimeline.cy.js
@@ -19,13 +19,13 @@ describe("<AActivityTimeline />", () => {
       if (index < $list.length - 1) {
         expect(borderValue).contains(DEFAULT_BORDER_STYLE);
       } else {
-        // The very last item should not have a left border
+        // The very last item should not have a timeline item connector
         expect(borderValue).contains("0");
       }
     });
   });
 
-  it("should render a left border if there is only one timeline item", () => {
+  it("should render a timeline item connector if there is only one timeline item", () => {
     cy.mount(<UncontrolledTimelineTest itemCount={1} />);
 
     cy.get(".a-activity-timeline__list-item").then(($el) => {
@@ -38,7 +38,7 @@ describe("<AActivityTimeline />", () => {
     });
   });
 
-  it("should always render a left border if the prop for it is passed", () => {
+  it("should always render a timeline item connector if the prop for it is passed", () => {
     cy.mount(
       <UncontrolledTimelineTest>
         <AActivityTimelineItem time="Mock time" title="Mock title" />
@@ -46,7 +46,7 @@ describe("<AActivityTimeline />", () => {
         <AActivityTimelineItem
           time="Mock time"
           title="Mock title"
-          withConnector={true} // If not passed, the left border would be hidden by default since this is the last item
+          withConnector={true} // If not passed, the timeline item connector would be hidden by default since this is the last item
         />
       </UncontrolledTimelineTest>
     );
@@ -62,7 +62,7 @@ describe("<AActivityTimeline />", () => {
     });
   });
 
-  it("should render a blue left border if the item is complete", () => {
+  it("should render a blue timeline item connector if the item is complete", () => {
     cy.mount(
       <UncontrolledTimelineTest>
         <AActivityTimelineItem

--- a/framework/components/AActivityTimeline/AActivityTimeline.cy.js
+++ b/framework/components/AActivityTimeline/AActivityTimeline.cy.js
@@ -38,6 +38,30 @@ describe("<AActivityTimeline />", () => {
     });
   });
 
+  it("should always render a left border if the prop for it is passed", () => {
+    cy.mount(
+      <UncontrolledTimelineTest>
+        <AActivityTimelineItem time="Mock time" title="Mock title" />
+        <AActivityTimelineItem time="Mock time" title="Mock title" />
+        <AActivityTimelineItem
+          time="Mock time"
+          title="Mock title"
+          withConnector={true} // If not passed, the left border would be hidden by default since this is the last item
+        />
+      </UncontrolledTimelineTest>
+    );
+
+    // Every timeline item, including the last one, should have the connector
+    cy.get(".a-activity-timeline__list-item").then(($el) => {
+      // https://stackoverflow.com/a/75887385
+      const subject = $el[0];
+      const window = subject.ownerDocument.defaultView;
+      const before = window.getComputedStyle(subject, ":before");
+      const borderValue = before.getPropertyValue("border-left");
+      expect(borderValue).contains(DEFAULT_BORDER_STYLE);
+    });
+  });
+
   it("should render a blue left border if the item is complete", () => {
     cy.mount(
       <UncontrolledTimelineTest>

--- a/framework/components/AActivityTimeline/AActivityTimeline.cy.js
+++ b/framework/components/AActivityTimeline/AActivityTimeline.cy.js
@@ -10,32 +10,24 @@ describe("<AActivityTimeline />", () => {
     cy.mount(<UncontrolledTimelineTest itemCount={5} />);
 
     cy.get(".a-activity-timeline__list-item").each(($el, index, $list) => {
-      // https://stackoverflow.com/a/75887385
-      const subject = $el[0];
-      const window = subject.ownerDocument.defaultView;
-      const before = window.getComputedStyle(subject, ":before");
-      const borderValue = before.getPropertyValue("border-left");
-
-      if (index < $list.length - 1) {
-        expect(borderValue).contains(DEFAULT_BORDER_STYLE);
-      } else {
-        // The very last item should not have a timeline item connector
-        expect(borderValue).contains("0");
-      }
+      cy.getPseudoElementStyle($el, ":before", "border-left").then(
+        (borderStyle) => {
+          expect(borderStyle).contains(
+            index < $list.length - 1 ? DEFAULT_BORDER_STYLE : "0"
+          );
+        }
+      );
     });
   });
 
   it("should render a timeline item connector if there is only one timeline item", () => {
     cy.mount(<UncontrolledTimelineTest itemCount={1} />);
 
-    cy.get(".a-activity-timeline__list-item").then(($el) => {
-      // https://stackoverflow.com/a/75887385
-      const subject = $el[0];
-      const window = subject.ownerDocument.defaultView;
-      const before = window.getComputedStyle(subject, ":before");
-      const borderValue = before.getPropertyValue("border-left");
-      expect(borderValue).contains(DEFAULT_BORDER_STYLE);
-    });
+    cy.get(".a-activity-timeline__list-item")
+      .then(($el) => cy.getPseudoElementStyle($el, ":before", "border-left"))
+      .then((borderStyle) => {
+        expect(borderStyle).contains(DEFAULT_BORDER_STYLE);
+      });
   });
 
   it("should always render a timeline item connector if the prop for it is passed", () => {
@@ -51,14 +43,12 @@ describe("<AActivityTimeline />", () => {
       </UncontrolledTimelineTest>
     );
 
-    // Every timeline item, including the last one, should have the connector
-    cy.get(".a-activity-timeline__list-item").then(($el) => {
-      // https://stackoverflow.com/a/75887385
-      const subject = $el[0];
-      const window = subject.ownerDocument.defaultView;
-      const before = window.getComputedStyle(subject, ":before");
-      const borderValue = before.getPropertyValue("border-left");
-      expect(borderValue).contains(DEFAULT_BORDER_STYLE);
+    cy.get(".a-activity-timeline__list-item").each(($el, index, $list) => {
+      cy.getPseudoElementStyle($el, ":before", "border-left").then(
+        (borderStyle) => {
+          expect(borderStyle).contains(DEFAULT_BORDER_STYLE);
+        }
+      );
     });
   });
 
@@ -73,14 +63,11 @@ describe("<AActivityTimeline />", () => {
       </UncontrolledTimelineTest>
     );
 
-    cy.get(".a-activity-timeline__list-item").then(($el) => {
-      // https://stackoverflow.com/a/75887385
-      const subject = $el[0];
-      const window = subject.ownerDocument.defaultView;
-      const before = window.getComputedStyle(subject, ":before");
-      const borderValue = before.getPropertyValue("border-left");
-      expect(borderValue).contains(COMPLETE_STATUS_BORDER_STYLE);
-    });
+    cy.get(".a-activity-timeline__list-item")
+      .then(($el) => cy.getPseudoElementStyle($el, ":before", "border-left"))
+      .then((borderStyle) => {
+        expect(borderStyle).contains(COMPLETE_STATUS_BORDER_STYLE);
+      });
   });
 
   it("should render the neutral icon if the variant cannot be resolved", () => {

--- a/framework/components/AActivityTimeline/AActivityTimeline.mdx
+++ b/framework/components/AActivityTimeline/AActivityTimeline.mdx
@@ -34,6 +34,45 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
 `}
 />
 
+#### Paginated List (`withConnector` prop)
+
+When rendering a timeline from a paginated source of data, the last item in the _visible_ slice of data may not actually be the very last item in the entirety of the list. As such, the connector on the last timeline item in the slice should still exist to indicate to the user that the timeline is ongoing. In such situations, you can explicitly pass the `withConnector` prop to control its presence.
+
+<Playground
+  code={`() => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [resultsPerPage, setResultsPerPage] = useState(3);
+  const paginatedData = [...new Array(resultsPerPage).keys()].map((index) => {
+    const countingNumber = index + 1;
+    return (currentPage - 1) * resultsPerPage + countingNumber;
+  });
+  const TOTAL_ITEMS = 30;
+  return (
+    <>
+      <AActivityTimeline isPaginated>
+        {paginatedData.map((num) => (
+          <AActivityTimelineItem
+            key={num}
+            title={\`Item #\${num}\`}
+            time={\`\${num} days ago\`}
+            withConnector={num < TOTAL_ITEMS}
+          />
+        ))}
+      </AActivityTimeline>
+      <APagination
+        className="mt-4"
+        onPageChange={(value) => setCurrentPage(value)}
+        onResultsPerPageChange={(value) => setResultsPerPage(value)}
+        page={currentPage}
+        resultsPerPage={resultsPerPage}
+        total={TOTAL_ITEMS}
+      />
+    </>
+  );
+};
+`}
+/>
+
 #### Statuses
 
 <Playground

--- a/framework/components/AActivityTimeline/AActivityTimeline.scss
+++ b/framework/components/AActivityTimeline/AActivityTimeline.scss
@@ -17,9 +17,11 @@
     }
 
     // The last list item should not have a vertical bar
-    // unless it is the only item in the list
-    &:not(:last-child)::before,
-    &:only-child::before {
+    // unless it is the only item in the list or its being
+    // explicitly styled that way
+    &--connected::before,
+    &:not(&--disconnected):not(:last-child)::before,
+    &:not(&--disconnected):only-child::before {
       content: "";
       position: absolute;
       left: 12px;
@@ -28,11 +30,9 @@
       border-left: 2px solid var(--base-border-default);
     }
 
-    &--complete {
-      &:not(:last-child)::before,
-      &:only-child::before {
-        border-left-color: var(--interact-border-default);
-      }
+    &--complete:not(&--disconnected):not(:last-child)::before,
+    &--complete:not(&--disconnected):only-child::before {
+      border-left-color: var(--interact-border-default);
     }
 
     &__header {

--- a/framework/components/AActivityTimeline/AActivityTimelineItem.js
+++ b/framework/components/AActivityTimeline/AActivityTimelineItem.js
@@ -35,6 +35,7 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
     status = "neutral",
     time,
     title,
+    withConnector,
     withDivider,
     ...rest
   } = props;
@@ -70,6 +71,7 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
     <AActivityTimelineListItem
       icon={statusIcon}
       status={status}
+      withConnector={withConnector}
       ref={ref}
       className={propsClassName}
       {...rest}
@@ -166,6 +168,21 @@ AActivityTimelineItem.propTypes = {
    * title text. Can be a string or any other valid React Element.
    */
   time: PropTypes.elementType,
+
+  /**
+   * Determines if the item should have the vertical connector underneath the
+   * timeline item bullet circle.
+   *
+   * If not explicitly passed, then every item gets a connector except for the
+   * very last one in the list.
+   *
+   * Passing this prop can be useful if you're rendering a paginated list of data
+   * and the last item in the user's current view of the list may not actually be
+   * the very last item in the list (since it is paginated). In such cases, you
+   * would want to show the connector to indicate that the timeline is still ongoing.
+   * For this, you can explicitly pass `withConnector={true}` to guarantee it appears.
+   */
+  withConnector: PropTypes.bool,
 
   /**
    * Determines if the item should have a divider at the bottom.

--- a/framework/components/AActivityTimeline/components/AActivityTimelineListItem.js
+++ b/framework/components/AActivityTimeline/components/AActivityTimelineListItem.js
@@ -3,11 +3,22 @@ import React, {forwardRef} from "react";
 import "../AActivityTimeline.scss";
 
 const AActivityTimelineListItem = forwardRef(
-  ({icon, children, className: propsClassName, status, ...rest}, ref) => {
+  (
+    {icon, children, className: propsClassName, status, withConnector, ...rest},
+    ref
+  ) => {
     let className = "a-activity-timeline__list-item";
 
     if (status === "complete") {
       className += " a-activity-timeline__list-item--complete";
+    }
+
+    // Explicit check for `true` and `false` since an `undefined` value
+    // (i.e. a missing prop) means we should resort to default behavior
+    if (withConnector === true) {
+      className += " a-activity-timeline__list-item--connected";
+    } else if (withConnector === false) {
+      className += " a-activity-timeline__list-item--disconnected";
     }
 
     if (propsClassName) {


### PR DESCRIPTION
## Context

When timeline items are rendered from a paginated source of data, it is possible (and likely) that the very last item in the user's current view is *not* the very last item in the source of data. In such cases, the vertical "connector" rendered underneath the timeline *should* be rendered. However, given the current implementation, the connector would be hidden since it is the last list item in the DOM.

This PR solves this issue by allowing a developer to pass a `withConnector` prop to control the connector's visibility.

(Please see [preview branch "Paginated List" example](https://magna-react-git-feat-timeline-item-connector-prop.securex-preview.app/components/activity-timeline) for more context)

## This PR

* Adds a `withConnector` prop to the `AActivityTimelineItem` component
* Adds documentation for paginated lists of data with the timeline item
* Adds and refines tests

## Test Plan

1. Navigate to the [`AActivityTimeline` documentation page for the preview branch](https://magna-react-git-feat-timeline-item-connector-prop.securex-preview.app/components/activity-timeline)
2. In the very first example, pass the `withConnector` prop to the very last item that is rendered in the timeline
3. **Verify that the timeline item connector renders**
