### PR TITLE
Dropdown/#721

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useContext, useState} from "react";
+import React, {forwardRef, useContext} from "react";
 
 import AButtonGroupContext from "../AButtonGroup/AButtonGroupContext";
 import ASpinner from "../ASpinner";
@@ -126,7 +126,7 @@ const AButton = forwardRef(
       <TagName {...props}>
         {loading && <ASpinner size="small" />}
         {children}
-        {dropdown && <AIcon className="ml-3">{dropdownIcon}</AIcon>}
+        {dropdown && <AIcon className="ml-1">{dropdownIcon}</AIcon>}
       </TagName>
     );
   }

--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -1,8 +1,9 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useContext} from "react";
+import React, {forwardRef, useContext, useState} from "react";
 
 import AButtonGroupContext from "../AButtonGroup/AButtonGroupContext";
 import ASpinner from "../ASpinner";
+import AIcon from "../AIcon";
 
 import "./AButton.scss";
 
@@ -28,6 +29,8 @@ const AButton = forwardRef(
       value,
       loading = false,
       noPadding = false,
+      open = false,
+      dropdown = false,
       ...rest
     },
     ref
@@ -117,10 +120,13 @@ const AButton = forwardRef(
       props.value = value;
     }
 
+    const dropdownIcon = open ? "caret-up" : "caret-down";
+
     return (
       <TagName {...props}>
         {loading && <ASpinner size="small" />}
         {children}
+        {dropdown && <AIcon className="ml-3">{dropdownIcon}</AIcon>}
       </TagName>
     );
   }
@@ -163,6 +169,14 @@ AButton.propTypes = {
    * Toggles the `tertiaryAlt` style variant.
    */
   tertiaryAlt: PropTypes.bool,
+  /**
+   * Applies dropdown icon style
+   */
+  dropdown: PropTypes.bool,
+  /**
+   * Required with dropdown prop to toggle dropdown icon
+   */
+  open: PropTypes.bool,
   /**
    * The button type.
    */

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -211,6 +211,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
 
 Use with `AMenu`'s prop `open` to toggle the dropdown icon.
 See `AMenu` for more details on usage.
+Component `ADropdown` is also available for more standard use cases.
 
 <Playground
   code={`<>

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -207,6 +207,21 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
 `}
 />
 
+#### Dropdown Button Styles
+
+Use with AMenu's prop `open` to toggle the dropdown icon.
+See `AMenu` for more details on menu usage.
+
+<Playground
+  code={`<>
+    <AButton dropdown className="mr-1">Dropdown</AButton>
+    <AButton secondary dropdown className="mr-1">Dropdown</AButton>
+    <AButton tertiary dropdown className="mr-1">Dropdown</AButton>
+    <AButton tertiary noPadding dropdown className="mr-1">Dropdown</AButton>
+    <AButton tertiaryAlt dropdown className="mr-1">Dropdown</AButton>
+</>`}
+/>
+
 #### Link Buttons
 
 If the `href` property is used, the component will render as an HTML anchor.

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -209,8 +209,8 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
 
 #### Dropdown Button Styles
 
-Use with AMenu's prop `open` to toggle the dropdown icon.
-See `AMenu` for more details on menu usage.
+Use with `AMenu`'s prop `open` to toggle the dropdown icon.
+See `AMenu` for more details on usage.
 
 <Playground
   code={`<>

--- a/framework/components/ADropdown/ADropdown.cy.js
+++ b/framework/components/ADropdown/ADropdown.cy.js
@@ -1,0 +1,33 @@
+import ADropdown from "./ADropdown";
+import AIcon from "../AIcon";
+
+describe("<Dropdown/>", () => {
+  it("should render", () => {
+    cy.mount(<ADropdown title="dropdown" />);
+  });
+
+  it("should have title icon", () => {
+    cy.mount(<ADropdown title={<AIcon>users</AIcon>} />);
+    cy.get(".a-button .a-icon--users").should("be.visible");
+  });
+
+  it("should change variant", () => {
+    cy.mount(<ADropdown secondary title="dropdown" />);
+    cy.get(".a-button--secondary").should("exist");
+  });
+
+  it("should show loading icon", () => {
+    cy.mount(<ADropdown secondary title="dropdown" loading />);
+    cy.get(".a-button .a-spinner").should("be.visible");
+  });
+
+  it("should expand on click", () => {
+    cy.mount(
+      <ADropdown secondary title="dropdown">
+        <p>test</p>
+      </ADropdown>
+    );
+    cy.get(".a-button").click();
+    cy.get(".a-menu").should("exist");
+  });
+});

--- a/framework/components/ADropdown/ADropdown.js
+++ b/framework/components/ADropdown/ADropdown.js
@@ -1,0 +1,123 @@
+import PropTypes from "prop-types";
+import React, {forwardRef, useRef, useState} from "react";
+import AButton from "../AButton";
+import AMenu from "../AMenu";
+
+const ADropdown = forwardRef(
+  (
+    {
+      className: propsClassName,
+      primary,
+      secondary,
+      tertiary,
+      tertiaryAlt,
+      disabled,
+      destructive,
+      noPadding,
+      loading,
+      title,
+      small,
+      position,
+      children,
+      ...rest
+    },
+    ref
+  ) => {
+    const buttonRef = useRef(null);
+    const [open, setOpen] = useState(false);
+
+    if (propsClassName) {
+      className += ` ${propsClassName}`;
+    }
+
+    const dropdownVariantProps = {
+      primary,
+      secondary,
+      tertiary,
+      tertiaryAlt,
+      destructive,
+      disabled,
+      noPadding,
+      loading,
+      small
+    };
+
+    return (
+      <div {...rest} ref={ref} className={propsClassName}>
+        <AButton
+          ref={buttonRef}
+          dropdown
+          open={open}
+          onClick={() => setOpen(!open)}
+          aria-haspopup="true"
+          {...dropdownVariantProps}
+        >
+          {title}
+        </AButton>
+        <AMenu
+          anchorRef={buttonRef}
+          open={open}
+          placement={position}
+          onClose={() => setOpen(false)}
+        >
+          {children}
+        </AMenu>
+      </div>
+    );
+  }
+);
+
+ADropdown.propTypes = {
+  /**
+   * Toggles the `disabled` state.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Signifies an icon-only button.
+   */
+  icon: PropTypes.bool,
+  /**
+   * Toggles the `primary` style variant. If no style variant is chosen, `primary` is applied.
+   */
+  primary: PropTypes.bool,
+  /**
+   * Toggles the `secondary` style variant.
+   */
+  secondary: PropTypes.bool,
+  /**
+   * Toggles the `tertiary` style variant.
+   */
+  tertiary: PropTypes.bool,
+  /**
+   * Toggles the `tertiaryAlt` style variant.
+   */
+  tertiaryAlt: PropTypes.bool,
+  /**
+   * Destructive - button for destructive action, should be used with confirm dialog/modal when clicked
+   */
+  destructive: PropTypes.bool,
+  /**
+   * Apply Magnetic small size styles vs only re-skin styles, defaults to false
+   */
+  small: PropTypes.bool,
+  /**
+   * Apply Magnetic medium size styles vs only re-skin styles, defaults to false
+   */
+  medium: PropTypes.bool,
+  /**
+   * Automatically add a loading spinner to the button
+   */
+  loading: PropTypes.bool,
+  /**
+   * Removes padding on any button, defaults to false
+   */
+  noPadding: PropTypes.bool,
+  /**
+   * Title of dropdown can be string or react element
+   */
+  title: PropTypes.node
+};
+
+ADropdown.displayName = "ADropdown";
+
+export default ADropdown;

--- a/framework/components/ADropdown/ADropdown.mdx
+++ b/framework/components/ADropdown/ADropdown.mdx
@@ -1,0 +1,381 @@
+---
+name: Dropdown
+route: /components/dropdown
+components: ADropdown
+title: ADropdown
+sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framework/components/ADropdown
+---
+
+## Usage
+
+### Import
+
+<ComponentImport components="ADropdown" />
+
+### Usage
+
+<Playground
+  code={`<>
+  <div className="d-flex gap-3 flex-wrap mb-3">
+    <ADropdown title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown secondary title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+          <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown tertiary title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+          <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown tertiary noPadding title="Dropdown inline">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+         </AListItem>
+         <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem
+           onClick={() => alert("should not fire")}
+           className="pl-3 py-1"
+           disabled>
+           Disabled Item
+         </AListItem>
+         <AListItemDivider className="mb-0 mt-3" />
+         <AListItem twoLine>
+           <AListItemContent className="pb-0">
+             <a onClick={() => alert("alert3")}>Connect</a>
+           </AListItemContent>
+         </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown tertiaryAlt title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown disabled title="Dropdown disabled">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown destructive secondary title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+         </AListItem>
+         <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem
+           onClick={() => alert("should not fire")}
+           className="pl-3 py-1"
+           disabled>
+           Disabled Item
+         </AListItem>
+         <AListItemDivider className="mb-0 mt-3" />
+         <AListItem twoLine>
+           <AListItemContent className="pb-0">
+             <a onClick={() => alert("alert3")}>Connect</a>
+           </AListItemContent>
+         </AListItem>
+      </>
+    </ADropdown>
+  </div>
+  <div className="d-flex gap-3 flex-wrap">
+     <ADropdown small title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown small secondary title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+          <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown small tertiary title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+          <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown small tertiary noPadding title="Dropdown inline">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+         </AListItem>
+         <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem
+           onClick={() => alert("should not fire")}
+           className="pl-3 py-1"
+           disabled>
+           Disabled Item
+         </AListItem>
+         <AListItemDivider className="mb-0 mt-3" />
+         <AListItem twoLine>
+           <AListItemContent className="pb-0">
+             <a onClick={() => alert("alert3")}>Connect</a>
+           </AListItemContent>
+         </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown small tertiaryAlt title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown small disabled title="Dropdown disabled">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+        </AListItem>
+        <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+          Example
+        </AListItem>
+        <AListItem
+          onClick={() => alert("should not fire")}
+          className="pl-3 py-1"
+          disabled>
+          Disabled Item
+        </AListItem>
+        <AListItemDivider className="mb-0 mt-3" />
+        <AListItem twoLine>
+          <AListItemContent className="pb-0">
+            <a onClick={() => alert("alert3")}>Connect</a>
+          </AListItemContent>
+        </AListItem>
+      </>
+    </ADropdown>
+    <ADropdown small destructive secondary title="Dropdown">
+      <>
+        <AListItem twoLine className="px-3 h3 my-0 pb-1">
+           <AListItemTitle>Bottom</AListItemTitle>
+         </AListItem>
+         <AListItem onClick={() => alert("alert1")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem onClick={() => alert("alert2")} className="pl-3 py-1">
+           Example
+         </AListItem>
+         <AListItem
+           onClick={() => alert("should not fire")}
+           className="pl-3 py-1"
+           disabled>
+           Disabled Item
+         </AListItem>
+         <AListItemDivider className="mb-0 mt-3" />
+         <AListItem twoLine>
+           <AListItemContent className="pb-0">
+             <a onClick={() => alert("alert3")}>Connect</a>
+           </AListItemContent>
+         </AListItem>
+      </>
+    </ADropdown>
+  </div>
+</>
+`}
+/>
+
+## Component Props
+
+The `ADropdown` component inherits passed props.
+
+<Props of="ADropdown" />

--- a/framework/components/ADropdown/ADropdown.mdx
+++ b/framework/components/ADropdown/ADropdown.mdx
@@ -12,7 +12,13 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
 
 <ComponentImport components="ADropdown" />
 
+<AAlert dismissable={false}>
+  It is necessary for `ADropdown` to be a descendant of `AApp` for mounting.
+</AAlert>
+
 ### Usage
+
+For more advanced use cases of dropdown see `AMenu` and `AButton`
 
 <Playground
   code={`<>

--- a/framework/components/ADropdown/index.js
+++ b/framework/components/ADropdown/index.js
@@ -1,0 +1,1 @@
+export {default} from "./ADropdown";

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -51,6 +51,9 @@ return (
   <div>
     <AButton
       ref={button1Ref}
+      dropdown
+      open={open1}
+      secondary
       onClick={() => setOpen1(!open1)}
       aria-haspopup="true">
       Pivot Menu
@@ -101,7 +104,6 @@ return (
     open={open1}
     placement="bottom"
     onClose={() => setOpen1(false)}
-    pointer
     className="py-3">
     <AListItem twoLine className="px-3 h3 my-0 pb-1">
       <AListItemTitle>Bottom</AListItemTitle>

--- a/framework/components/AMenu/AMenu.mdx
+++ b/framework/components/AMenu/AMenu.mdx
@@ -18,7 +18,11 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
   It is necessary for `AMenu` to be a descendant of `AApp` for mounting.
 </AAlert>
 
+<br />
+
 #### Usage
+
+`ADropdown` is available for standard use cases. For more advanced use cases see `AMenu` and `AButton`
 
 <Playground
   fullWidthPreview

--- a/framework/index.js
+++ b/framework/index.js
@@ -17,6 +17,7 @@ import ABadge from "./components/ABadge";
 import ABreadcrumb from "./components/ABreadcrumb";
 import AButton from "./components/AButton";
 import AButtonGroup from "./components/AButtonGroup";
+import ADropdown from "./components/ADropdown";
 import {
   ACardContainer,
   ACardBasic,
@@ -195,6 +196,7 @@ export {
   ADrawerFooter,
   ADrawerSubtitle,
   ADrawerTitle,
+  ADropdown,
   AEmptyState,
   AFieldBase,
   AFooter,

--- a/framework/styles/utilities/mixins.scss
+++ b/framework/styles/utilities/mixins.scss
@@ -122,11 +122,12 @@
   height: 34px;
   padding: 8px 12px;
 
+  svg.a-icon {
+    width: 16px;
+  }
+
   &.a-button--icon {
     padding: 8.25px;
-    svg.a-icon {
-      width: 16px;
-    }
   }
 
   &.a-button--inline-btn {
@@ -140,11 +141,11 @@
   padding: 4px 8px;
   font-size: $font-size--sm;
 
+  svg.a-icon {
+    width: 14px;
+  }
   &.a-button--icon {
     padding: 8.25px;
-    svg.a-icon {
-      width: 14px;
-    }
   }
   &.a-button--inline-btn {
     height: 18px;


### PR DESCRIPTION
**Closes #721 - Add dropdown options**

## ADropdown
Adds a new component`ADropdown` which is a built in extension of both of the `AButton` and `AMenu` options below.

![Screenshot 2024-05-21 at 2 52 32 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/e92bd802-30ca-4aea-8e63-e74221e727a7)

## AButton and AMenu  
#### (for quick refactoring of current implementations, or for more customized approaches)
One of the benefits of `AMenu` is that it can be used in conjunction with any element that requires a dropdown option.  The examples for the "trigger" component we have in `AMenu` documentation all happen to use `AButton`, but it is also used for other cases such as [ADateRangePicker](https://magna-react.vercel.app/components/date-picker?page=usage)

Since the `Dropdown` functionality is already handled in `AMenu`, one addition that seemed useful was adding in the caret toggle so devs don't have to write repetitive icon logic and styles anytime they want to add the dropdown icon to a button.

Props added to `AButton` are booleans: 
`dropdown` and `open`

![Screenshot 2024-05-20 at 5 04 06 PM](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/b09f5bdc-f088-471c-95ab-d4bd57bd5a10)


 In `AMenu`, I added a the `dropdown` prop and most frequently used style to `AButton` as the first example since it will likely be sought out the most.  

![dropdown](https://github.com/cisco-sbg-ui/magna-react/assets/112431822/97820588-e991-4be5-b039-c02fc65149c4)
