### PR TITLE
proxy click router component as tab; don't style links at a global level for tabs

### DIFF
--- a/framework/components/AApp/base/links.scss
+++ b/framework/components/AApp/base/links.scss
@@ -1,4 +1,4 @@
-.a-app a:not(.a-button):not(.a-tree__content) {
+.a-app a:not(.a-button):not(.a-tree__content):not(.a-tab-group__tab) {
   color: var(--interact-text-default);
 
   cursor: pointer;

--- a/framework/components/ATabs/ATab.js
+++ b/framework/components/ATabs/ATab.js
@@ -8,7 +8,6 @@ import React, {
 } from "react";
 
 import ATabContext from "./ATabContext";
-import {keyCodes} from "../../utils/helpers";
 import {useCombinedRefs} from "../../utils/hooks";
 import "./ATabs.scss";
 

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -115,7 +115,7 @@ const ATabGroup = forwardRef(
         parseInt(tabStyle.marginLeft) + parseInt(tabStyle.marginRight);
 
       //Calculate width of overflow tab which serves as our minimum width.
-      let overflowLimit = overflowTab.offsetWidth + tabMargin + 5; //Increase by 5 as a width buffer on tabs with smaller words
+      let overflowLimit = overflowTab.offsetWidth + tabMargin + 12; //Increase by 5 as a width buffer on tabs with smaller words
 
       Array.from(contentWrapper.childNodes).forEach((item, i) => {
         if (!item || !item.classList) {
@@ -151,13 +151,13 @@ const ATabGroup = forwardRef(
     }, [handleOverflow, selectedTab]);
 
     useEffect(() => {
-      if (!tabContainerRef.current) {
+      if (!combinedRef.current) {
         return;
       }
 
-      const target = tabContainerRef.current.parentNode;
+      const target = combinedRef.current;
       const resizeObserver = new ResizeObserver(
-        debounce(() => {
+        debounce((foo) => {
           if (tabContainerRef.current) {
             handleOverflow();
           }
@@ -171,7 +171,7 @@ const ATabGroup = forwardRef(
           resizeObserver.unobserve(target);
         }
       };
-    }, [tabContainerRef, handleOverflow]);
+    }, [combinedRef, tabContainerRef, handleOverflow]);
 
     let className = "a-tab-group";
     let tabContentClassName = "a-tab-group__tab-content";

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -79,6 +79,7 @@ const ATabGroup = forwardRef(
     const tabContainerRef = useRef(null);
     const overflowRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, tabGroupRef);
+    const menuItemRefs = useRef([]);
 
     const setSelectedTab = useCallback(
       (tabId) => {
@@ -207,9 +208,26 @@ const ATabGroup = forwardRef(
         const routerLink = child.props.tab?.route;
 
         if (routerLink) {
+          const clone = React.cloneElement(child, {
+            ...child.props,
+            ref: (ref) => (childrenRef.current[i] = ref)
+          });
+
+          const onKeyDown = (e) => {
+            if (e.key !== "Enter") {
+              return;
+            }
+
+            menuItemRefs.current[i]?.children[0]?.click();
+          };
+
           return (
-            <AListItem component="div" {...rest}>
-              {child}
+            <AListItem
+              ref={(ref) => (menuItemRefs.current[i] = ref)}
+              onKeyDown={onKeyDown}
+              {...rest}
+            >
+              {clone}
             </AListItem>
           );
         }

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -157,7 +157,7 @@ const ATabGroup = forwardRef(
 
       const target = combinedRef.current;
       const resizeObserver = new ResizeObserver(
-        debounce((foo) => {
+        debounce(() => {
           if (tabContainerRef.current) {
             handleOverflow();
           }

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -28,7 +28,7 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
 
     while (
       !toFocus ||
-      toFocus?.classList?.contains("hide") ||
+      toFocus?.classList?.contains("a-tab-group__tab--hide") ||
       isTabSelectedAndNotMenuTab(toFocus)
     ) {
       if (!toFocus) {
@@ -44,7 +44,7 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
 
     while (
       !toFocus ||
-      toFocus?.classList?.contains("hide") ||
+      toFocus?.classList?.contains("a-tab-group__tab--hide") ||
       isTabSelectedAndNotMenuTab(toFocus)
     ) {
       if (!toFocus) {
@@ -126,7 +126,7 @@ const ATabGroup = forwardRef(
           return;
         }
         //Show all elements initially while we calculate size
-        item.classList.remove("hide");
+        item.classList.remove("a-tab-group__tab--hide");
         //Tab item's width
         const tabWidth = item.offsetWidth + tabMargin;
         //If items' total width falls under overall container width, skip
@@ -134,16 +134,16 @@ const ATabGroup = forwardRef(
           overflowLimit += tabWidth;
         } else if (!classList.includes("a-tab-group__menu-tab")) {
           //If items' total width exceeds overall container width, hide and push to overflow menu
-          item.classList.add("hide");
+          item.classList.add("a-tab-group__tab--hide");
           overflowMenuItems.push(i);
         }
       });
 
       //Handles overflow tab's visibility
       if (!overflowMenuItems.length) {
-        tab.classList.add("hide");
+        tab.classList.add("a-tab-group__tab--hide");
       } else if (overflowMenuItems.length) {
-        tab.classList.remove("hide");
+        tab.classList.remove("a-tab-group__tab--hide");
       }
 
       setMenuItems(overflowMenuItems);
@@ -208,11 +208,6 @@ const ATabGroup = forwardRef(
         const routerLink = child.props.tab?.route;
 
         if (routerLink) {
-          const clone = React.cloneElement(child, {
-            ...child.props,
-            ref: (ref) => (childrenRef.current[i] = ref)
-          });
-
           const onKeyDown = (e) => {
             if (e.key !== "Enter") {
               return;
@@ -227,7 +222,7 @@ const ATabGroup = forwardRef(
               onKeyDown={onKeyDown}
               {...rest}
             >
-              {clone}
+              {child}
             </AListItem>
           );
         }

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -161,7 +161,7 @@ const ATabGroup = forwardRef(
           if (tabContainerRef.current) {
             handleOverflow();
           }
-        })
+        }, 10)
       );
 
       resizeObserver.observe(target);

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 
 import {debounce} from "../../utils/helpers";
+import {useCombinedRefs} from "../../utils/hooks";
 import OverflowMenuTab from "./OverflowMenuTab";
 import AListItem from "../AList/AListItem";
 import ATabContext from "./ATabContext";

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -78,7 +78,7 @@ const ATabGroup = forwardRef(
     const tabGroupRef = useRef(null);
     const tabContainerRef = useRef(null);
     const overflowRef = useRef(null);
-    const overflowMenuRef = useRef(); //useCombinedRefs(ref, tabGroupRef);
+    const combinedRef = useCombinedRefs(ref, tabGroupRef);
     const menuItemRefs = useRef([]);
 
     const setSelectedTab = useCallback(
@@ -90,12 +90,12 @@ const ATabGroup = forwardRef(
     );
 
     const handleOverflow = useCallback(() => {
-      if (!overflowMenuRef.current || vertical) {
+      if (!combinedRef.current || vertical) {
         return;
       }
 
       //Overflow tab
-      const overflowTab = overflowMenuRef.current.querySelector(
+      const overflowTab = combinedRef.current.querySelector(
         ".a-tab-group__menu-tab"
       );
 
@@ -104,7 +104,7 @@ const ATabGroup = forwardRef(
       }
 
       const overflowMenuItems = [];
-      const tabWrapper = overflowMenuRef.current;
+      const tabWrapper = combinedRef.current;
 
       const contentWrapper = tabContainerRef.current;
 
@@ -143,7 +143,7 @@ const ATabGroup = forwardRef(
       }
 
       setMenuItems(overflowMenuItems);
-    }, [overflowMenuRef, vertical]);
+    }, [combinedRef, vertical]);
 
     useEffect(() => {
       handleOverflow();
@@ -234,7 +234,7 @@ const ATabGroup = forwardRef(
       <div
         {...rest}
         role="tablist"
-        ref={overflowMenuRef}
+        ref={combinedRef}
         className={className}
         tabIndex={0}
         onClick={() => {}}
@@ -258,7 +258,7 @@ const ATabGroup = forwardRef(
               elementToFocus.click();
             } else {
               overflowRef.current?.setMenuOpen(false);
-              overflowMenuRef.current?.focus();
+              combinedRef.current?.focus();
             }
 
             if (selectOnArrow && elementToFocus.tagName !== "A") {
@@ -275,7 +275,7 @@ const ATabGroup = forwardRef(
               {children}
               {!vertical && (
                 <OverflowMenuTab
-                  tabGroupRef={overflowMenuRef}
+                  tabGroupRef={combinedRef}
                   passthroughRef={overflowRef}
                 >
                   {renderChildren}

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -34,6 +34,10 @@ $tab-heading-margin: 0;
     display: flex;
   }
 
+  &__tab-content {
+    overflow: hidden;
+  }
+
   &__tab-content--vertical {
     display: flex;
     flex-direction: column;
@@ -225,6 +229,14 @@ $tab-heading-margin: 0;
     a {
       width: 100%;
       color: var(--base-text-default) !important;
+    }
+  }
+
+  .a-tab-group__menu-overflow-item {
+    padding: 0 !important;
+    > a,
+    div {
+      padding: 8px 10px;
     }
   }
 }

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -63,7 +63,7 @@ $tab-heading-margin: 0;
       margin: 0 4px 2px 4px;
     }
 
-    &.hide {
+    &--hide {
       display: none !important;
     }
     svg {

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -224,6 +224,7 @@ $tab-heading-margin: 0;
     }
     a {
       width: 100%;
+      color: var(--base-text-default) !important;
     }
   }
 }

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -36,6 +36,7 @@ $tab-heading-margin: 0;
 
   &__tab-content {
     overflow: hidden;
+    white-space: nowrap;
   }
 
   &__tab-content--vertical {

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -389,3 +389,13 @@ export const handleBoldText = (value, item) => {
 
   return boldText;
 };
+
+export const debounce = (func, timeout = 100) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
+};


### PR DESCRIPTION
When the ATab is a router element, the onClick functionality isn't actually what controls the route change - so proxy click the item in the more menu to run the router's logic.


Color causes issues with tabs that set an `<a>` element as the component for a tab