### PR TITLE
Bump node actions in ci

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -16,8 +16,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Configure NPM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Configure NPM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 18.19
       - name: Configure NPM
         env:
           TOKEN: ${{ secrets.ARTIFACTORY_CLOUD_AUTH }} 

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -12,7 +12,7 @@ jobs:
       WEBEX_OPSROOMID: "a34fd430-f65e-11ed-8216-57006ce5beb1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v34
       - name: woke
         uses: get-woke/woke-action@v0
         with:


### PR DESCRIPTION
Gets rid of the node 16 deprecation warning in the actions log