### PR TITLE
fix: AAccordionBody content hidden in collapsed state

### DIFF
--- a/framework/components/AAccordion/AAccordion.mdx
+++ b/framework/components/AAccordion/AAccordion.mdx
@@ -20,26 +20,55 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
   code={`() => {
   const buttonRef = useRef(null);
   const [active, setActive] = useState(false);
-  return (
+ 
+  const items = [
+  {id: 1, name: "Bread, Cereal, Rice, and Pasta"},
+  {id: 2, name: "Vegetables"},
+  {id: 3, name: "Fruit", selected: true},
+  {id: 4, name: "Milk, Yogurt, and Cheese"},
+  {id: 5, name: "Meat, Poultry, Fish", disabled: true},
+  {id: 6, name: "Fats, Oils, and Sweets"}
+  ];
+  const [selectedItem, setSelectedItem] = useState(items[2]);
+
+return (
+
     <AAccordion bordered>
       <AAccordionPanel>
         <AAccordionHeader>
           <AAccordionHeaderTitle chevron={false}>
             Accordion Item 1
           </AAccordionHeaderTitle>
-          <AButton ref={buttonRef} icon tertiaryAlt onClick={() => setActive(!active)}>
+          <AButton
+            ref={buttonRef}
+            icon
+            tertiaryAlt
+            onClick={() => setActive(!active)}>
             <AIcon>ellipsis-horizontal</AIcon>
           </AButton>
-          <AMenu anchorRef={buttonRef} open={active} onClose={() => setActive(false)}>
+          <AMenu
+            anchorRef={buttonRef}
+            open={active}
+            onClose={() => setActive(false)}>
             <AListItem>See More</AListItem>
           </AMenu>
         </AAccordionHeader>
       </AAccordionPanel>
       <AAccordionPanel collapsed={false}>
         <AAccordionHeader>
-          <AAccordionHeaderTitle>Accordion Item 2</AAccordionHeaderTitle>
+          <AAccordionHeaderTitle>Accordion Item 2 (with embedded ASelect)</AAccordionHeaderTitle>
         </AAccordionHeader>
-        <AAccordionBody>{LoremIpsum}</AAccordionBody>
+        <AAccordionBody>
+          <ASelect
+            label="Food Group"
+            items={items}
+            itemText="name"
+            itemValue="id"
+            placeholder="Pick a Food Group"
+            onSelected={(item) => setSelectedItem(item)}
+            hints={"Selected Item:" + JSON.stringify(selectedItem)}
+          />
+        </AAccordionBody>
       </AAccordionPanel>
       <AAccordionPanel>
         <AAccordionHeader>
@@ -52,17 +81,14 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/canary/framewor
       </AAccordionPanel>
       <AAccordionPanel collapsed={false}>
         <AAccordionHeader>
-          <AAccordionHeaderTitle>
-            Additional Accordion Item
-          </AAccordionHeaderTitle>
+          <AAccordionHeaderTitle>Additional Accordion Item</AAccordionHeaderTitle>
         </AAccordionHeader>
         <AAccordionBody>{LoremIpsum}</AAccordionBody>
       </AAccordionPanel>
     </AAccordion>
-  );
-}
-`}
-/>
+
+);
+} `} />
 
 #### Controlled Usage
 

--- a/framework/components/AAccordion/AAccordion.scss
+++ b/framework/components/AAccordion/AAccordion.scss
@@ -170,6 +170,7 @@ $accordion-divider-border-width: thin;
     &--state-collapsed {
       .a-accordion__body {
         max-height: 0;
+        overflow: hidden;
         visibility: hidden;
         opacity: 0;
         margin: 0;


### PR DESCRIPTION
- height of element is now reduced to visible part when it is in collapsed state

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally
- [x] The component should accept a class name as a prop, if appropriate
- [x] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?**

Closes: #743

**What is the new behavior (if this is a feature change)?**

Now the `AAccordion` when collapse has height related to its headers. Body content does not enlarge element height now.
In "incident-manager" it fixes two places when `AAccordion` is used - "report tab" and "response tab".

**Does this PR introduce a breaking change?** 

Yes, this fixed behaviour could be breaking change.




