### PR TITLE
change to node 18.19 to workaround node issue on the action runner

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 18.19
       - name: Configure NPM
         env:
           TOKEN: ${{ secrets.ARTIFACTORY_CLOUD_AUTH }} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 18.19
       - name: Configure NPM
         env:
           TOKEN: ${{ secrets.ARTIFACTORY_CLOUD_AUTH }} 


### PR DESCRIPTION
Seems there's an issue with the node version on the action runner causing npm ci to fail. This works around it for now