### PR TITLE
Fix usage of line height variables

### DIFF
--- a/framework/components/AApp/base/typography.scss
+++ b/framework/components/AApp/base/typography.scss
@@ -7,7 +7,7 @@
   font-size: $font-size--md;
   font-family: $font-family;
   font-weight: $font-weight;
-  line-height: $line-height;
+  line-height: $line-height--md;
   height: 100%;
   margin: 0;
   text-transform: none;

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -1,7 +1,7 @@
 @import "../../styles";
 
 $btn-font-weight: $font-weight-bold;
-$btn-line-height: $line-height;
+$btn-line-height: $line-height--md;
 $btn-padding: 0 $base-padding;
 $btn-margin: 0;
 $btn-min-width: rem(4.6875); // 75px

--- a/framework/components/AToast/AToast.scss
+++ b/framework/components/AToast/AToast.scss
@@ -22,14 +22,16 @@ $toast-max-width: 465px;
 
   &__body {
     margin: 0 24px;
-    font-size: 14px;
-    font-weight: 400;
+    font-size: $font-size--md;
+    font-weight: $font-weight-normal;
+    line-height: $line-height--md;
     flex-grow: 1;
     color: var(--base-text-default);
   }
 
   &__title {
-    font-weight: 700;
+    font-size: $font-size--md;
+    font-weight: $font-weight-bold;
     color: var(--base-text-default);
   }
 

--- a/framework/components/ATooltip/ATooltip.scss
+++ b/framework/components/ATooltip/ATooltip.scss
@@ -3,7 +3,7 @@
 .a-tooltip {
   display: inline-block;
   font-size: $font-size--sm;
-  line-height: $line-height;
+  line-height: $line-height--sm;
   min-width: 75px;
   max-width: 400px;
   padding: 8px 12px;

--- a/framework/styles/utilities/variables.scss
+++ b/framework/styles/utilities/variables.scss
@@ -22,7 +22,7 @@ $font-weight-xbold: 800 !default;
 $font-weight: $font-weight-normal !default;
 
 $font-weight--bold: $font-weight-bold !default;
-$line-height: 1.25 !default;
+$line-height: rem(1.25) !default;
 $line-height--xl: rem(1.5) !default; // 24px
 $line-height--lg: rem(1.375) !default; // 22px
 $line-height--md: rem(1.25) !default; // 20px


### PR DESCRIPTION
Some places were using `$line-height`, which computes to `1.25`. This doesn't affect the css, without the `rem` added.


#### Review Notes

Make sure nothing was trying to use the raw number, vs the intended `rem` value