### PR TITLE
span wrapper on ADrawer should have 100% height

### DIFF
--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -18,10 +18,14 @@ $common-transitions: transform $transition-props, width $transition-props,
     top: unset;
     left: unset;
 
-    > span > div {
-      display: flex;
-      flex-direction: column;
+    > span {
       height: 100%;
+
+      > div {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
     }
   }
 


### PR DESCRIPTION
Causes scroll on body element to now show otherwise