### PR TITLE
Use .call in debounce function

### DIFF
--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -395,7 +395,7 @@ export const debounce = (func, timeout = 100) => {
   return (...args) => {
     clearTimeout(timer);
     timer = setTimeout(() => {
-      func.apply(this, args);
+      func.call(...args);
     }, timeout);
   };
 };


### PR DESCRIPTION
using `func.apply(this, ...)` causes the compilation in the lib build to generate `var _this = this;`. This isn't good practice, and causes warnings in some environments 