### PR TITLE
fix(`AButton`): do not ignore `component` prop when rendered with `href` prop

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -104,7 +104,7 @@ const AButton = forwardRef(
     }
 
     if (href) {
-      TagName = "a";
+      TagName = component || "a";
       if (!disabled) {
         props.href = href;
         props.target = target;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally
- [ ] The component should accept a class name as a prop, if appropriate
- [ ] The component should accept a forward ref, if appropriate

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
Closes #776 

**What is the current behavior?** <!--(You can also link to an open issue here)-->

When rendering `AButton`, passing the `component` prop simultaneously with the `href` prop ignores the `component` prop.


**What is the new behavior (if this is a feature change)?**

When rendering `AButton`, passing the `component` prop simultaneously with the `href` prop **does not** ignore the `component` prop.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No