### PR TITLE
Move css rules to resolve deprecation warnings in ordering

### DIFF
--- a/framework/components/AAccordion/AAccordion.scss
+++ b/framework/components/AAccordion/AAccordion.scss
@@ -163,8 +163,9 @@ $accordion-divider-border-width: thin;
       padding: 0 14px;
       visibility: visible;
       opacity: 1;
-      @include transition($accordion-transition);
       margin: 0 0 15px 0;
+
+      @include transition($accordion-transition);
     }
 
     &--state-collapsed {
@@ -174,6 +175,7 @@ $accordion-divider-border-width: thin;
         visibility: hidden;
         opacity: 0;
         margin: 0;
+
         @include transition($accordion--state-collapsed-transition);
       }
     }

--- a/framework/components/ACard/ACard.scss
+++ b/framework/components/ACard/ACard.scss
@@ -121,6 +121,10 @@
   border-radius: 8px;
   padding: 0;
 
+  background: var(--base-bg-weak-default);
+  box-shadow: none;
+  border: 2px solid var(--control-border-weak-default);
+
   .a-card__content {
     margin: 12px 0;
     &:first-child {
@@ -130,10 +134,6 @@
       margin-bottom: 0;
     }
   }
-
-  background: var(--base-bg-weak-default);
-  box-shadow: none;
-  border: 2px solid var(--control-border-weak-default);
 
   &.a-card-basic {
     &--lifted {

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -37,6 +37,8 @@ $common-transitions: transform $transition-props, width $transition-props,
   }
 
   &--hidden {
+    box-shadow: none;
+
     &.a-drawer--left {
       transform: translateX(-100%);
     }
@@ -48,8 +50,6 @@ $common-transitions: transform $transition-props, width $transition-props,
     &.a-drawer--bottom {
       transform: translateY(100%);
     }
-
-    box-shadow: none;
   }
 
   &--show {

--- a/framework/components/AInputBase/AInputBase.scss
+++ b/framework/components/AInputBase/AInputBase.scss
@@ -65,7 +65,6 @@ $input-transition: border-color $transition-duration--extra-fast
 
   &--disabled {
     .a-input-base__surface {
-      @include disabled;
       color: var(--base-text-disabled);
       border-color: var(--control-border-disabled);
       background: var(--control-bg-weak-disabled);
@@ -74,8 +73,9 @@ $input-transition: border-color $transition-duration--extra-fast
       .a-icon {
         fill: var(--base-text-disabled);
       }
+
+      @include disabled;
     }
-    cursor: not-allowed;
   }
 
   &--readonly {

--- a/framework/components/APagination/APagination.scss
+++ b/framework/components/APagination/APagination.scss
@@ -56,7 +56,15 @@
     margin: 0 4px;
 
     .a-button {
+      padding: 0 7px;
+      height: 23px;
+      border-radius: $border-radius--lg;
+      border: 2px solid transparent !important;
+      background-color: transparent !important;
+      font-weight: 400;
+      margin-right: 4px;
       color: var(--base-text-default);
+
       &--selected {
         border: 2px solid var(--control-border-medium-active) !important;
         color: var(--base-text-default);
@@ -78,13 +86,6 @@
         color: var(--inverse-text-default);
       }
 
-      padding: 0 7px;
-      height: 23px;
-      border-radius: $border-radius--lg;
-      border: 2px solid transparent !important;
-      background-color: transparent !important;
-      font-weight: 400;
-      margin-right: 4px;
       &:last-child {
         margin-right: 0;
       }

--- a/framework/components/ASimpleTable/ASimpleTable.scss
+++ b/framework/components/ASimpleTable/ASimpleTable.scss
@@ -89,11 +89,11 @@ $table-cell-spacious-padding-top-bottom: math.div(
     height: $table-row-height;
     vertical-align: inherit;
     border-bottom: thin solid;
+    border-color: var(--control-border-weak-default);
 
     td {
       color: var(--base-text-default);
     }
-    border-color: var(--control-border-weak-default);
   }
 
   th,

--- a/framework/components/ATag/ATag.scss
+++ b/framework/components/ATag/ATag.scss
@@ -113,10 +113,11 @@ $icon-width: 1.167rem;
 
   //Status tags
   &--status {
+    padding: 4px 8px 4px 4px;
+
     .a-icon--status {
       width: 18px;
     }
-    padding: 4px 8px 4px 4px;
     &.a-tag--sm {
       padding: 1px 8px 1px 4px;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "remark-slug": "6.1.0",
         "remove-markdown": "0.5.0",
         "rimraf": "3.0.2",
-        "sass": "1.54.9",
+        "sass": "1.77.8",
         "start-server-and-test": "2.0.3",
         "webpack": "^5.76.0",
         "webpack-dev-server": "^4.11.1"
@@ -13993,9 +13993,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.54.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.9.tgz",
-      "integrity": "sha512-xb1hjASzEH+0L0WI9oFjqhRi51t/gagWnxLiwUNMltA0Ab6jIDkAacgKiGYKM9Jhy109osM7woEEai6SXeJo5Q==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -14006,7 +14006,7 @@
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "remark-slug": "6.1.0",
     "remove-markdown": "0.5.0",
     "rimraf": "3.0.2",
-    "sass": "1.54.9",
+    "sass": "1.77.8",
     "start-server-and-test": "2.0.3",
     "webpack": "^5.76.0",
     "webpack-dev-server": "^4.11.1"


### PR DESCRIPTION
Resolves #781

New sass versions throw warnings about css rules being ordered after child groups and include/extend statements. Moving the CSS around to fit the standard.