### PR TITLE
Remove margin right for spinner inside button

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -124,7 +124,9 @@ const AButton = forwardRef(
 
     return (
       <TagName {...props}>
-        {loading && <ASpinner size="small" />}
+        {loading && (
+          <ASpinner size="small" style={{marginRight: children ? "4px" : ""}} />
+        )}
         {children}
         {dropdown && <AIcon className="ml-1">{dropdownIcon}</AIcon>}
       </TagName>

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -253,21 +253,6 @@ return (
 </div>
 ); } `} />
 
-#### Loading
-
-<Playground
-  code={`() => {
-
-return (
-
-<div>
-  <AButton loading></AButton>
-  <br />
-  <br />
-  <AButton loading>Loading with label</AButton>
-</div>
-); } `} />
-
 ## Button Props
 
 The `AButton` component inherits passed props.

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -253,6 +253,21 @@ return (
 </div>
 ); } `} />
 
+#### Loading
+
+<Playground
+  code={`() => {
+
+return (
+
+<div>
+  <AButton loading></AButton>
+  <br />
+  <br />
+  <AButton loading>Loading with label</AButton>
+</div>
+); } `} />
+
 ## Button Props
 
 The `AButton` component inherits passed props.

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -40,7 +40,6 @@ $btn-transition: color $transition-duration--extra-fast
   }
 
   .a-spinner {
-    margin-right: 4px;
     height: 16px;
     width: 16px;
 


### PR DESCRIPTION
Should be centered inside the button container

![Screenshot 2024-07-16 at 11 32 49 AM](https://github.com/user-attachments/assets/c7ed3f46-9ddd-4ba3-8aa9-c37a349846e4)
