### PR TITLE
Add auto menu flip logic on bounds checking

### DIFF
--- a/framework/components/AMenuBase/AMenuBase.tsx
+++ b/framework/components/AMenuBase/AMenuBase.tsx
@@ -265,7 +265,6 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
     const [pointerLeft, setPointerLeft] = useState<number | null>(null);
     const [pointerTop, setPointerTop] = useState<number | null>(null);
 
-    // @ts-ignore
     const {checkMenuSpacing, menuPlacement}: AMenuFlip = useMenuFlip(
       useFlipLogic,
       anchorRef,
@@ -274,8 +273,6 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
       pointer,
       placement
     );
-
-    console.log("placement", placement, menuPlacement);
 
     useEffect(() => {
       if (open && menuRef.current) {

--- a/framework/components/AMenuBase/AMenuBase.tsx
+++ b/framework/components/AMenuBase/AMenuBase.tsx
@@ -275,6 +275,8 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
       placement
     );
 
+    console.log("placement", placement, menuPlacement);
+
     useEffect(() => {
       if (open && menuRef.current) {
         checkMenuSpacing();

--- a/framework/components/AMenuBase/AMenuBase.tsx
+++ b/framework/components/AMenuBase/AMenuBase.tsx
@@ -10,8 +10,11 @@ import ReactDOM from "react-dom";
 import AAppContext from "../AApp/AAppContext";
 import {useCombinedRefs} from "../../utils/hooks";
 import {getRoundedBoundedClientRect} from "../../utils/helpers";
+
+import {useMenuFlip} from "./hooks";
 import "./AMenuBase.scss";
 import {
+  AMenuFlip,
   AMenuBaseProps,
   calculateMenuPositionType,
   calculatePointerPositionType
@@ -248,6 +251,7 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
       pointer,
       style: propsStyle,
       removeSpacer = false,
+      useFlipLogic = false,
       ...rest
     },
     ref
@@ -261,13 +265,29 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
     const [pointerLeft, setPointerLeft] = useState<number | null>(null);
     const [pointerTop, setPointerTop] = useState<number | null>(null);
 
+    // @ts-ignore
+    const {checkMenuSpacing, menuPlacement}: AMenuFlip = useMenuFlip(
+      useFlipLogic,
+      anchorRef,
+      combinedRef,
+      wrapRef,
+      pointer,
+      placement
+    );
+
+    useEffect(() => {
+      if (open && menuRef.current) {
+        checkMenuSpacing();
+      }
+    }, [open, checkMenuSpacing, menuRef, placement]);
+
     useEffect(() => {
       const calculateMenuPositionProps = {
         combinedRef,
         appRef,
         wrapRef,
         anchorRef,
-        placement,
+        placement: menuPlacement,
         setMenuLeft,
         setMenuTop,
         setInvisible,
@@ -279,7 +299,7 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
       open,
       anchorRef,
       combinedRef,
-      placement,
+      menuPlacement,
       appRef,
       wrapRef,
       removeSpacer,
@@ -291,12 +311,12 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
         combinedRef,
         anchorRef,
         pointer,
-        placement,
+        placement: menuPlacement,
         setPointerLeft,
         setPointerTop
       };
       calculatePointerPosition(pointerPositionProps);
-    }, [anchorRef, combinedRef, placement, pointer, menuLeft, menuTop]);
+    }, [anchorRef, combinedRef, menuPlacement, pointer, menuLeft, menuTop]);
 
     useEffect(() => {
       const screenChangeHandler = () => {
@@ -388,7 +408,7 @@ const AMenuBase = forwardRef<HTMLElement, AMenuBaseProps>(
       };
     }, [anchorRef, combinedRef, onClose, open]);
 
-    let className = `a-menu-base a-menu-base--${placement}`;
+    let className = `a-menu-base a-menu-base--${menuPlacement}`;
     if (!invisible && open) {
       className += " a-menu-base--active";
     }

--- a/framework/components/AMenuBase/hooks.js
+++ b/framework/components/AMenuBase/hooks.js
@@ -31,3 +31,127 @@ const useMenuSpacing = (surfaceRef, menuRef, maxHeight) => {
 };
 
 export default useMenuSpacing;
+
+/**
+ * If enabled, automatically flip vertically or horizontally if the menu would
+ * otherwise be rendered out of bounds of either the AMount wrap or the window.
+ * @param {*} enabled
+ * @param {*} anchorRef
+ * @param {*} menuRef
+ * @param {*} wrapRef
+ * @param {*} pointer
+ * @param {*} placement
+ * @returns
+ */
+
+export const useMenuFlip = (
+  enabled,
+  anchorRef,
+  menuRef,
+  wrapRef,
+  pointer = false,
+  placement = "top"
+) => {
+  const [menuPlacement, setMenuPlacement] = useState(placement);
+  const pointerAdjust = pointer && 14;
+
+  const checkMenuSpacing = useCallback(() => {
+    const {
+      top: anchorTop,
+      right: anchorRight,
+      bottom: anchorBottom,
+      left: anchorLeft
+    } = anchorRef?.current?.getBoundingClientRect() || {};
+    const {
+      top: wrapTop,
+      right: wrapRight,
+      bottom: wrapBottom,
+      left: wrapLeft
+    } = wrapRef?.current?.getBoundingClientRect() || {};
+
+    const upperBound = Math.max(0, wrapTop);
+    const rightBound = Math.max(window.innerWidth, wrapRight);
+    const lowerBound = Math.min(window.innerHeight, wrapBottom);
+    const leftBound = Math.min(0, wrapLeft);
+
+    const verticalSpaceAbove = anchorTop ? anchorTop - upperBound : 0;
+    const verticalSpaceBelow = anchorBottom ? lowerBound - anchorBottom : 0;
+
+    const horizontalSpaceBefore = anchorLeft ? anchorLeft - leftBound : 0;
+    const horizontalSpaceAfter = anchorRight ? rightBound - anchorRight : 0;
+
+    const menuHeight = menuRef?.current?.clientHeight + pointerAdjust || 0;
+    const menuWidth = menuRef?.current?.clientWidth || 0;
+
+    let computedPlacement;
+
+    switch (placement) {
+      case "top":
+        computedPlacement = menuHeight < verticalSpaceAbove ? "top" : "bottom";
+        break;
+
+      case "top-right":
+        computedPlacement = menuHeight < verticalSpaceAbove ? "top" : "bottom";
+        computedPlacement += `-right`;
+        break;
+
+      case "right-top":
+        computedPlacement = menuWidth < horizontalSpaceAfter ? "right" : "left";
+        computedPlacement += "-top";
+        break;
+
+      case "right":
+        computedPlacement = menuWidth < horizontalSpaceAfter ? "right" : "left";
+        break;
+
+      case "right-bottom":
+        computedPlacement = menuWidth < horizontalSpaceAfter ? "right" : "left";
+        computedPlacement += "-bottom";
+        break;
+
+      case "bottom-right":
+        computedPlacement = menuHeight < verticalSpaceBelow ? "bottom" : "top";
+        computedPlacement += "-right";
+        break;
+
+      case "bottom":
+        computedPlacement = menuHeight < verticalSpaceBelow ? "bottom" : "top";
+        break;
+
+      case "bottom-left":
+        computedPlacement = menuHeight < verticalSpaceBelow ? "bottom" : "top";
+        computedPlacement += "-left";
+        break;
+
+      case "left-bottom":
+        computedPlacement =
+          menuWidth < horizontalSpaceBefore ? "left" : "right";
+        computedPlacement += "-bottom";
+        break;
+
+      case "left":
+        computedPlacement =
+          menuWidth < horizontalSpaceBefore ? "left" : "right";
+        break;
+
+      case "left-top":
+        computedPlacement =
+          menuWidth < horizontalSpaceBefore ? "left" : "right";
+        computedPlacement += "-top";
+        break;
+
+      case "top-left":
+        computedPlacement = menuHeight < verticalSpaceAbove ? "top" : "bottom";
+        computedPlacement += "-left";
+        break;
+    }
+
+    setMenuPlacement(computedPlacement);
+  }, [anchorRef, menuRef, wrapRef, pointerAdjust, placement]);
+
+  if (!enabled) {
+    return {checkMenuSpacing: () => {}, placement};
+  }
+
+  return {checkMenuSpacing, menuPlacement};
+};

--- a/framework/components/AMenuBase/hooks.js
+++ b/framework/components/AMenuBase/hooks.js
@@ -150,7 +150,7 @@ export const useMenuFlip = (
   }, [anchorRef, menuRef, wrapRef, pointerAdjust, placement]);
 
   if (!enabled) {
-    return {checkMenuSpacing: () => {}, placement};
+    return {checkMenuSpacing: () => {}, menuPlacement: placement};
   }
 
   return {checkMenuSpacing, menuPlacement};

--- a/framework/components/AMenuBase/types.ts
+++ b/framework/components/AMenuBase/types.ts
@@ -28,6 +28,10 @@ export type AMenuBaseProps = Override<
      * Option to remove the space between the anchor and the menu for bottom placement
      */
     removeSpacer?: boolean;
+    /**
+     * Flip vertically or horizontally is the menu would otherwise render out of bounds
+     */
+    useFlipLogic?: boolean;
     style?: React.CSSProperties;
     role?: React.AriaRole;
   }
@@ -53,4 +57,9 @@ export type calculatePointerPositionType = {
   placement: APlacement;
   setPointerLeft: React.Dispatch<React.SetStateAction<number | null>>;
   setPointerTop: React.Dispatch<React.SetStateAction<number | null>>;
+};
+
+export type AMenuFlip = {
+  menuPlacement: APlacement;
+  checkMenuSpacing: () => void;
 };

--- a/framework/components/ATooltip/ATooltip.tsx
+++ b/framework/components/ATooltip/ATooltip.tsx
@@ -10,6 +10,7 @@ const ATooltip = forwardRef<HTMLElement, ATooltipProps>(
   (
     {
       anchorRef,
+      autoFlip = true,
       children,
       className: propsClassName,
       onClose,
@@ -53,7 +54,7 @@ const ATooltip = forwardRef<HTMLElement, ATooltipProps>(
         removeSpacer={true}
         anchorRef={anchorRef}
         pointer={pointer}
-        useFlipLogic>
+        useFlipLogic={autoFlip}>
         {children}
       </AMenuBase>
     );

--- a/framework/components/ATooltip/ATooltip.tsx
+++ b/framework/components/ATooltip/ATooltip.tsx
@@ -52,7 +52,8 @@ const ATooltip = forwardRef<HTMLElement, ATooltipProps>(
         placement={placement}
         removeSpacer={true}
         anchorRef={anchorRef}
-        pointer={pointer}>
+        pointer={pointer}
+        useFlipLogic>
         {children}
       </AMenuBase>
     );

--- a/framework/components/ATooltip/types.ts
+++ b/framework/components/ATooltip/types.ts
@@ -9,6 +9,10 @@ export type ATooltipProps = Override<
      */
     anchorRef: AAnchorRef;
     /**
+     * Automatically flip horizontally or vertically if rendering into a boundary
+     */
+    autoFlip?: boolean;
+    /**
      * Handles the request to close the menu.
      */
     onClose?: () => void;

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.cy.js
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.cy.js
@@ -233,7 +233,16 @@ function CustomTriggerTest(triggerTooltipProps) {
   const btnRef = useRef();
 
   return (
-    <div data-testid="custom-trigger-container">
+    <div
+      data-testid="custom-trigger-container"
+      style={{
+        height: "400px",
+        width: "400px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+      }}
+    >
       <AButton data-testid="custom-trigger" ref={btnRef}>
         outer trigger
       </AButton>

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -133,7 +133,7 @@ return (
 <br />
 <br />
 <span style={{verticalAlign: "super", margin: "0 4px 0 0"}}>{"Tooltip is "}{disabled?"disabled":"enabled"}</span>
-<ATriggerTooltip disabled={disabled} placement="top" content="Contionally enabled tooltip">
+<ATriggerTooltip disabled={disabled} placement="top" content="Conditionally enabled tooltip">
   <AIcon>information</AIcon>
 </ATriggerTooltip>
 


### PR DESCRIPTION
Adds a hook, enabled on `ATooltip`, that checks the outer bounds for `AMenu` placement, and flips it it to the opposite if it would render out of bounds.

This only applies to the starting placement - top, right, bottom, left. It does not affect the secondary, in placements such as `top-right`. 

