### PR TITLE
794 - don't validate disabled fields in forms; validate required empty array for multiselects

### DIFF
--- a/framework/components/ACheckbox/ACheckbox.js
+++ b/framework/components/ACheckbox/ACheckbox.js
@@ -61,10 +61,11 @@ const ACheckbox = forwardRef(
       if (register) {
         register(`a-checkbox_${checkboxId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, checked, value, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, checked, value, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {

--- a/framework/components/ACombobox/ACombobox.js
+++ b/framework/components/ACombobox/ACombobox.js
@@ -84,10 +84,11 @@ const ACombobox = forwardRef(
       if (register) {
         register(`a-combobox_${comboboxId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, value, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, value, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {

--- a/framework/components/AForm/AForm.js
+++ b/framework/components/AForm/AForm.js
@@ -15,8 +15,15 @@ const AForm = forwardRef(({children}, ref) => {
     validate: () => {
       let errors = [];
       Object.values(fields).forEach((x) => {
+        if (x.disabled) {
+          x.reset();
+          return;
+        }
+
         let fieldError = x.validate();
-        if (fieldError) errors.push(fieldError);
+        if (fieldError) {
+          errors.push(fieldError);
+        }
       });
       return errors;
     }

--- a/framework/components/AInputBase/AInputBase.js
+++ b/framework/components/AInputBase/AInputBase.js
@@ -152,31 +152,37 @@ AInputBase.propTypes = {
   /**
    * Sets hint or multiple hints.
    */
-  hints: PropTypes.arrayOf(
-    PropTypes.shape({
-      /**
-       * Hint content.
-       */
-      content: PropTypes.node.isRequired,
-      /**
-       * Style the hint with the component validation state. Default: false.
-       */
-      hintUsesValidationState: PropTypes.bool,
-      /**
-       * Override the validation state of the hint by incorporating the desired state.
-       * The component validation state is disregarded when this property is configured.
-       */
-      validationStateOverride: PropTypes.oneOf([
-        "default",
-        "warning",
-        "danger"
-      ]),
-      /**
-       * Do not show hint when there are validation errors.
-       */
-      hideHintOnError: PropTypes.bool
-    })
-  ),
+  hints: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        /**
+         * Hint content.
+         */
+        content: PropTypes.node.isRequired,
+        /**
+         * Style the hint with the component validation state. Default: false.
+         */
+        hintUsesValidationState: PropTypes.bool,
+        /**
+         * Override the validation state of the hint by incorporating the desired state.
+         * The component validation state is disregarded when this property is configured.
+         */
+        validationStateOverride: PropTypes.oneOf([
+          "default",
+          "warning",
+          "danger"
+        ]),
+        /**
+         * Do not show hint when there are validation errors.
+         */
+        hideHintOnError: PropTypes.bool
+      })
+    ),
+    // Accept a string and use default AHint rendering
+    PropTypes.string,
+    // Pass a custom renderable object as the hint
+    PropTypes.node
+  ]),
   /**
    * Sets the label content.
    */

--- a/framework/components/AMultiSelect/AMultiSelect.cy.js
+++ b/framework/components/AMultiSelect/AMultiSelect.cy.js
@@ -177,6 +177,36 @@ describe("<AMultiSelect />", () => {
 
     getMenuContent().should("not.exist");
   });
+
+  it("should show error when required", () => {
+    cy.mount(<AMultiSelectTest required />);
+
+    cy.get(".a-multiselect__input").focus();
+
+    cy.get(".a-multiselect__input").blur();
+
+    cy.get(".a-alert--state-danger").should("exist");
+  });
+
+  it("should show error when required with empty undefined value", () => {
+    cy.mount(<AMultiSelectTest required value={undefined} />);
+
+    cy.get(".a-multiselect__input").focus();
+
+    cy.get(".a-multiselect__input").blur();
+
+    cy.get(".a-alert--state-danger").should("exist");
+  });
+
+  it("should show error when required with empty array value", () => {
+    cy.mount(<AMultiSelectTest required value={[]} />);
+
+    cy.get(".a-multiselect__input").focus();
+
+    cy.get(".a-multiselect__input").blur();
+
+    cy.get(".a-alert--state-danger").should("exist");
+  });
 });
 
 const items = [
@@ -188,7 +218,11 @@ const items = [
   {id: 6, name: "Fats, Oils, and Sweets"}
 ];
 
-const AMultiSelectTest = ({value: propsValue = [], withTags = false}) => {
+const AMultiSelectTest = ({
+  value: propsValue = [],
+  withTags = false,
+  ...rest
+}) => {
   const [value, setValue] = useState(propsValue);
 
   return (
@@ -208,6 +242,7 @@ const AMultiSelectTest = ({value: propsValue = [], withTags = false}) => {
           setValue(newValue);
         }}
         value={value}
+        {...rest}
       />
     </div>
   );

--- a/framework/components/AMultiSelect/AMultiSelect.js
+++ b/framework/components/AMultiSelect/AMultiSelect.js
@@ -104,6 +104,7 @@ const AMultiSelect = forwardRef(
       counterClass = `${className}__counter`;
 
     const {register, unregister} = useContext(AFormContext);
+
     useEffect(() => {
       setWorkingValidationState(validationState);
     }, [validationState]);
@@ -116,10 +117,11 @@ const AMultiSelect = forwardRef(
       if (register) {
         register(`a-multiselect_${multiselectId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, value, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, value, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {
@@ -162,7 +164,9 @@ const AMultiSelect = forwardRef(
         if (required) {
           workingRules = [
             {
-              test: (v) => !!v || `${label ? label + " is r" : "R"}equired`,
+              test: (v) =>
+                (v && Array.isArray(v) && v.length > 0) ||
+                `${label ? label + " is r" : "R"}equired`,
               level: "danger"
             },
             ...workingRules
@@ -393,8 +397,6 @@ const AMultiSelect = forwardRef(
       }
 
       const handleClick = () => {
-        validate(itemValue);
-
         let newValue = Array.isArray(value) ? [...value] : [];
         if (value.includes(computedValue)) {
           newValue = newValue.filter((v) => v !== computedValue);
@@ -404,6 +406,8 @@ const AMultiSelect = forwardRef(
             (value, i, arr) => arr.indexOf(value) === i
           );
         }
+
+        validate(newValue);
 
         onSelected && onSelected(newValue);
       };

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -118,10 +118,11 @@ const ASelect = forwardRef(
       if (register) {
         register(`a-select_${selectId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, selectedItem, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, selectedItem, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {
@@ -238,6 +239,9 @@ const ASelect = forwardRef(
     const reset = () => {
       setWorkingValidationState(validationState);
       setError("");
+
+      setSelectedItem();
+      onSelected && onSelected();
     };
 
     const chevronProps = {

--- a/framework/components/ASlider/ASlider.js
+++ b/framework/components/ASlider/ASlider.js
@@ -68,10 +68,11 @@ const ASlider = forwardRef(
       if (register) {
         register(`a-slider_${sliderId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, value, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, value, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {

--- a/framework/components/ASwitch/ASwitch.js
+++ b/framework/components/ASwitch/ASwitch.js
@@ -51,10 +51,11 @@ const ASwitch = forwardRef(
       if (register) {
         register(`a-switch_${switchId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, checked, value, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, checked, value, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -106,10 +106,11 @@ const ATextInput = forwardRef(
       if (register) {
         register(`a-text-input_${textInputId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, nativeInputValue, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, nativeInputValue, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {
@@ -485,31 +486,37 @@ ATextInput.propTypes = {
   /**
    * Sets hint or multiple hints.
    */
-  hints: PropTypes.arrayOf(
-    PropTypes.shape({
-      /**
-       * Hint content.
-       */
-      content: PropTypes.node.isRequired,
-      /**
-       * Style the hint with the component validation state. Default: false.
-       */
-      hintUsesValidationState: PropTypes.bool,
-      /**
-       * Override the validation state of the hint by incorporating the desired state.
-       * The component validation state is disregarded when this property is configured.
-       */
-      validationStateOverride: PropTypes.oneOf([
-        "default",
-        "warning",
-        "danger"
-      ]),
-      /**
-       * Do not show hint when there are validation errors.
-       */
-      hideHintOnError: PropTypes.bool
-    })
-  ),
+  hints: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        /**
+         * Hint content.
+         */
+        content: PropTypes.node.isRequired,
+        /**
+         * Style the hint with the component validation state. Default: false.
+         */
+        hintUsesValidationState: PropTypes.bool,
+        /**
+         * Override the validation state of the hint by incorporating the desired state.
+         * The component validation state is disregarded when this property is configured.
+         */
+        validationStateOverride: PropTypes.oneOf([
+          "default",
+          "warning",
+          "danger"
+        ]),
+        /**
+         * Do not show hint when there are validation errors.
+         */
+        hideHintOnError: PropTypes.bool
+      })
+    ),
+    // Accept a string and use default AHint rendering
+    PropTypes.string,
+    // Pass a custom renderable object as the hint
+    PropTypes.node
+  ]),
   /**
    * Sets the label content.
    */

--- a/framework/components/ATextarea/ATextarea.js
+++ b/framework/components/ATextarea/ATextarea.js
@@ -87,10 +87,11 @@ const ATextarea = forwardRef(
       if (register) {
         register(`a-textarea_${textareaId}`, {
           reset,
-          validate
+          validate,
+          disabled
         });
       }
-    }, [validationState, value, rules]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [validationState, value, disabled, rules]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
       if (unregister) {


### PR DESCRIPTION
Fixes for #794 

Changes

- `AForm` will no longer validate disabled fields. 
- `AForm` will reset the validation state if a field becomes disabled and the form is re-validated
- `AMultiSelect` now validates `required` as non-empty value AND non-empty array. Array is the only valid type for the `value`
- `ASelect` will be properly reset when reset function is called