### PR TITLE
797 - Add tooltip prop pass through for the counter tag

### DIFF
--- a/framework/components/AMultiSelect/AMultiSelect.js
+++ b/framework/components/AMultiSelect/AMultiSelect.js
@@ -55,6 +55,7 @@ const AMultiSelect = forwardRef(
       validationState,
       value = [],
       filterFunction: propsFilterFunction,
+      counterTooltipProps = {},
       ...rest
     },
     ref
@@ -356,6 +357,7 @@ const AMultiSelect = forwardRef(
         onSelected={onSelected}
         itemValue={itemValue}
         itemText={itemText}
+        {...counterTooltipProps}
       />
     );
 
@@ -607,7 +609,11 @@ AMultiSelect.propTypes = {
   /**
    * Function to filter items when the input value changes
    */
-  filterFunction: PropTypes.func
+  filterFunction: PropTypes.func,
+  /**
+   * Pass props to the tag tooltip. Can pass any props for ATooltip, including `children`
+   */
+  counterTooltipProps: PropTypes.object
 };
 
 AMultiSelect.displayName = "AMultiSelect";

--- a/framework/components/AMultiSelect/AMultiSelectCounter.js
+++ b/framework/components/AMultiSelect/AMultiSelectCounter.js
@@ -14,8 +14,6 @@ const AMultiSelectCounter = ({
   const {isOpen, open, close} = useToggle();
   const iconRef = useRef(null);
 
-  console.log(children, rest);
-
   const itemsMap = new Map(
     items.map((item) =>
       typeof item === "string"

--- a/framework/components/AMultiSelect/AMultiSelectCounter.js
+++ b/framework/components/AMultiSelect/AMultiSelectCounter.js
@@ -3,9 +3,18 @@ import {ATooltip} from "../ATooltip";
 import ATag from "../ATag";
 import useToggle from "../../hooks/useToggle/useToggle";
 
-const AMultiSelectCounter = ({items, value, itemValue, itemText}) => {
+const AMultiSelectCounter = ({
+  items,
+  value,
+  itemValue,
+  itemText,
+  children,
+  ...rest
+}) => {
   const {isOpen, open, close} = useToggle();
   const iconRef = useRef(null);
+
+  console.log(children, rest);
 
   const itemsMap = new Map(
     items.map((item) =>
@@ -31,8 +40,9 @@ const AMultiSelectCounter = ({items, value, itemValue, itemText}) => {
         open={isOpen}
         placement="top"
         pointer
+        {...rest}
       >
-        {selectedItems.join(", ")}
+        {children ? children : selectedItems.join(", ")}
       </ATooltip>
     </>
   );


### PR DESCRIPTION
Resolves #797

Adds `counterTooltipProps` to `AMultiSelect`. This will pass the object through to the `ATooltip` component and spread it as props. This allows for setting a style and overriding the content