### PR TITLE
ASelect don't fire onSelected when resetting

### DIFF
--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -239,9 +239,6 @@ const ASelect = forwardRef(
     const reset = () => {
       setWorkingValidationState(validationState);
       setError("");
-
-      setSelectedItem();
-      onSelected && onSelected();
     };
 
     const chevronProps = {

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -82,3 +82,26 @@ export const usePrevious = (value) => {
   }, [value]);
   return ref.current;
 };
+
+export const useHasScrolled = (callback) => {
+  const _tickRef = useRef();
+
+  useEffect(() => {
+    document.addEventListener(
+      "scroll",
+      () => {
+        const lastKnownScrollPosition = window.scrollY;
+
+        if (!_tickRef.current) {
+          window.requestAnimationFrame(() => {
+            callback(lastKnownScrollPosition);
+            _tickRef.current = false;
+          });
+
+          _tickRef.current = true;
+        }
+      },
+      []
+    );
+  });
+};


### PR DESCRIPTION
onSelected is getting called on select menu open

was called to reset value when AForm called reset. But reset gets called when the select is opened. Will investigate a different solution to proper resetting, this will fix the issue for now