### PR TITLE
Reposition open menus on scroll of a container

### DIFF
--- a/framework/components/AModal/AModal.mdx
+++ b/framework/components/AModal/AModal.mdx
@@ -363,7 +363,6 @@ return (
           secondary
           className="mr-2"
           onClick={() => {
-            console.log("reset??");
             setErrors([]);
             formRef.current.reset();
           }}>

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -399,3 +399,20 @@ export const debounce = (func, timeout = 100) => {
     }, timeout);
   };
 };
+
+export const throttleLimit = 1000 / 60;
+
+export const throttle = (fn, limit = throttleLimit) => {
+  let inThrottle;
+
+  return function () {
+    const args = arguments;
+    if (!inThrottle) {
+      fn.apply(this, args);
+
+      inThrottle = true;
+
+      setTimeout(() => (inThrottle = false), limit);
+    }
+  };
+};


### PR DESCRIPTION
Resolves #794 

Adds a scroll detection hook, and recalculates menu position when any container is scrolled iff the menu is open.

The handler to recalculate position is throttled to 60fps on window animation frame to reduce the amount of rerenders