### PR TITLE
Remove redundant usePopupQuickExit in drawer hook

### DIFF
--- a/framework/components/ADrawer/hooks.js
+++ b/framework/components/ADrawer/hooks.js
@@ -1,15 +1,8 @@
 import {useEffect, useState} from "react";
-import usePopupQuickExit from "../../hooks/usePopupQuickExit/usePopupQuickExit";
 
 export const useDrawerToggle = (drawerRef, delay = 300) => {
   const [isDrawerOpen, setIsOpen] = useState(false);
   let handler;
-
-  usePopupQuickExit({
-    popupRef: drawerRef,
-    isEnabled: isDrawerOpen,
-    onExit: () => setIsOpen(false)
-  });
 
   useEffect(() => {
     if (isDrawerOpen) {


### PR DESCRIPTION
Now that ADrawer gets that hook in both modal and non modal cases, no need to have it in the transition hook