### PR TITLE
fix: skip .js files from d.ts generation for ts libraries

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,17 @@
     "resolveJsonModule": true,
     "declaration": true,
     "outDir": "./lib",
+    "checkJs": false,
     "noEmit": false //DO NOT LET VERCEL OVERRIDE THIS DURING NPM RUN DEV.   WE NEED TO EMIT FOR LIBRARY. This is an ongoing request: https://github.com/vercel/next.js/discussions/39942
   },
-  "include": ["framework/**/*"],
-  "exclude": ["node_modules"]
+  "include": [
+    "./framework/components/**/*.ts",
+    "./framework/components/**/*.tsx",
+    "./framework/hooks/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "framework/components/**/*.js",
+    "framework/components/**/*.jsx"
+  ]
 }


### PR DESCRIPTION
**Goal:** This will allow groups to use the types we have now, while also supporting old js files that we have.

**Problem:** Typescript libraries that consume our library are reading d.ts files for components we haven't changed over yet.  (this is non issue in js libraries using our typescript library however).

**Solution:**
This change aims to `skip` over components that aren't ready to be "read" by other libraries.  However, the catch is components will result in "any" in other typescript libraries so they will need to temporarily enable:
**`"noImplicitAny": false,`**
while we work through this transition.

Note: None of our typescript changes impact the IM team as they have their own magna types they use for the time being.