### PR TITLE
Respect closeOnOutsideClick prop simimilar to AModal

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -43,7 +43,7 @@ const ADrawer = forwardRef(
 
     usePopupQuickExit({
       popupRef: combinedRef,
-      isEnabled: !propsAsModal && isOpen,
+      isEnabled: !propsAsModal && closeOnOutsideClick && isOpen,
       onExit: onClose
     });
 


### PR DESCRIPTION
Disables click outside functionality by default, which is the same as `AModal`