### PR TITLE
Fix instantiation of usePopupQuickExit in drawer

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -42,8 +42,8 @@ const ADrawer = forwardRef(
     });
 
     usePopupQuickExit({
-      popupRef: combinedRef,
-      isEnabled: !propsAsModal && closeOnOutsideClick && isOpen,
+      popupRef: closeOnOutsideClick && combinedRef,
+      isEnabled: !propsAsModal && isOpen,
       onExit: onClose
     });
 


### PR DESCRIPTION
Pass the `closeOnOutside` click to the ref so it doesn't affect the escape key to close hook