### PR TITLE
Use useEscapeKeyDown for drawer

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -5,6 +5,7 @@ import AModal from "../AModal/AModal";
 
 import "./ADrawer.scss";
 import useEscapeKeydown from "../../hooks/useEscapeKeydown/useEscapeKeydown";
+import useOutsideClick from "../../hooks/useOutsideClick/useOutsideClick";
 import {useCombinedRefs, useDelayUnmount, usePrevious} from "../../utils/hooks";
 
 const DrawerContext = createContext({});
@@ -44,6 +45,12 @@ const ADrawer = forwardRef(
     useEscapeKeydown({
       isEnabled: isOpen,
       onKeydown: onClose
+    });
+
+    useOutsideClick({
+      rootRef: !propsAsModal && combinedRef,
+      isEnabled: isOpen && closeOnOutsideClick,
+      onExit: onClose
     });
 
     // A fixed drawer should automatically render as a modal unless specified

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import AModal from "../AModal/AModal";
 
 import "./ADrawer.scss";
-import usePopupQuickExit from "../../hooks/usePopupQuickExit/usePopupQuickExit";
+import useEscapeKeydown from "../../hooks/useEscapeKeydown/useEscapeKeydown";
 import {useCombinedRefs, useDelayUnmount, usePrevious} from "../../utils/hooks";
 
 const DrawerContext = createContext({});
@@ -41,10 +41,9 @@ const ADrawer = forwardRef(
       isEnabled: withTransitions
     });
 
-    usePopupQuickExit({
-      popupRef: closeOnOutsideClick && combinedRef,
-      isEnabled: !propsAsModal && isOpen,
-      onExit: onClose
+    useEscapeKeydown({
+      isEnabled: isOpen,
+      onKeydown: onClose
     });
 
     // A fixed drawer should automatically render as a modal unless specified

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -43,7 +43,7 @@ const ADrawer = forwardRef(
     });
 
     useEscapeKeydown({
-      isEnabled: isOpen,
+      isEnabled: !propsAsModal && isOpen,
       onKeydown: onClose
     });
 

--- a/framework/components/ADrawer/hooks.js
+++ b/framework/components/ADrawer/hooks.js
@@ -1,8 +1,13 @@
 import {useEffect, useState} from "react";
+import useReturnFocusOnClose from "../../hooks/useReturnFocusOnClose/useReturnFocusOnClose";
 
 export const useDrawerToggle = (drawerRef, delay = 300) => {
   const [isDrawerOpen, setIsOpen] = useState(false);
   let handler;
+
+  useReturnFocusOnClose({
+    isOpen: isDrawerOpen
+  });
 
   useEffect(() => {
     if (isDrawerOpen) {

--- a/framework/hooks/usePopupQuickExit/usePopupQuickExit.d.ts
+++ b/framework/hooks/usePopupQuickExit/usePopupQuickExit.d.ts
@@ -1,3 +1,0 @@
-declare const usePopupQuickExit: () => unknown;
-
-export default usePopupQuickExit;

--- a/framework/hooks/usePopupQuickExit/usePopupQuickExit.ts
+++ b/framework/hooks/usePopupQuickExit/usePopupQuickExit.ts
@@ -2,7 +2,13 @@ import useEscapeKeydown from "../useEscapeKeydown/useEscapeKeydown";
 import useOutsideClick from "../useOutsideClick/useOutsideClick";
 import useReturnFocusOnClose from "../useReturnFocusOnClose/useReturnFocusOnClose";
 
-const usePopupQuickExit = (options) => {
+interface PopupQuickExitProps {
+  popupRef?: React.RefObject<HTMLElement>;
+  onExit: () => void;
+  isEnabled: boolean;
+}
+
+const usePopupQuickExit = (options: PopupQuickExitProps) => {
   const {popupRef, isEnabled, onExit} = options;
   useOutsideClick({
     rootRef: popupRef,


### PR DESCRIPTION
usePopupQuickExit seems to cause conflicts with existing custom slide in/out controllers for ADrawer. 

Reduce the scope down to just handle escape for accessibility, and let products handle focus accessibility on their own if they aren't using `useDrawerToggle`