### PR TITLE
Remove logic around scrollLeft/scrollTop for menu placement

### DIFF
--- a/framework/components/AMenuBase/AMenuBase.tsx
+++ b/framework/components/AMenuBase/AMenuBase.tsx
@@ -38,7 +38,6 @@ const calculateMenuPosition = ({
     return;
   }
 
-  const appCoords = getRoundedBoundedClientRect(appRef.current);
   const wrapCoords = getRoundedBoundedClientRect(wrapRef.current);
   const anchorCoords =
     anchorRef instanceof DOMRect
@@ -47,7 +46,7 @@ const calculateMenuPosition = ({
   const menuCoords = getRoundedBoundedClientRect(combinedRef.current);
   const magneticSpacer = removeSpacer ? 0 : 4;
 
-  if (!anchorCoords || !menuCoords || !wrapCoords || !appCoords) {
+  if (!anchorCoords || !menuCoords || !wrapCoords) {
     return;
   }
   let baseLeft = 0,

--- a/framework/components/AMenuBase/AMenuBase.tsx
+++ b/framework/components/AMenuBase/AMenuBase.tsx
@@ -147,38 +147,38 @@ const calculateMenuPosition = ({
     pageHeight = wrapCoords.height;
   } else {
     // Calculate positioning relative to window or app/wrap elements
-    xOffset = appRefEl.offsetParent?.isSameNode(document.body)
-      ? window.pageXOffset
-      : wrapCoords.left - appCoords.left; // this was incorrectly set to "scrollLeft" when scrollLeft is not a return value in appCoords
+    if (appRefEl.offsetParent?.isSameNode(document.body)) {
+      xOffset = window.pageXOffset;
 
-    yOffset = appRefEl.offsetParent?.isSameNode(document.body)
-      ? window.pageYOffset
-      : wrapCoords.top - appCoords.top; // this was incorrectly set to "scrollTop" when scrollLeft is not a return value in appCoords
+      pageWidth =
+        document.documentElement.clientWidth + xOffset - wrapRefEl.offsetLeft;
+    }
 
-    pageWidth =
-      document.documentElement.clientWidth + xOffset - wrapRefEl.offsetLeft;
+    if (appRefEl.offsetParent?.isSameNode(document.body)) {
+      yOffset = window.pageYOffset;
 
-    pageHeight =
-      document.documentElement.clientHeight + yOffset - wrapRefEl.offsetTop;
+      pageHeight =
+        document.documentElement.clientHeight + yOffset - wrapRefEl.offsetTop;
+    }
   }
 
   // Edge detection: max x
-  if (baseLeft + menuCoords.width + marginLeft > pageWidth) {
+  if (pageWidth && baseLeft + menuCoords.width + marginLeft > pageWidth) {
     baseLeft = pageWidth - menuCoords.width - marginLeft;
   }
 
   // Edge detection: min x
-  if (baseLeft + marginLeft < xOffset) {
+  if (xOffset && baseLeft + marginLeft < xOffset) {
     baseLeft = xOffset - marginLeft;
   }
 
   // Edge detection: max y
-  if (baseTop + menuCoords.height + marginTop > pageHeight) {
+  if (pageHeight && baseTop + menuCoords.height + marginTop > pageHeight) {
     baseTop = pageHeight - menuCoords.height - marginTop;
   }
 
   // Edge detection: min y
-  else if (baseTop < yOffset) {
+  else if (yOffset && baseTop < yOffset) {
     baseTop = yOffset - marginTop;
   }
 


### PR DESCRIPTION
Previously the code used `appCoords.scrollLeft` and `appCoords.scrollTop` to calculate offsets of the wrapper when not using `withNewWrappingContext`. 

However, both of those values would always be undefined, as they aren't part of `DOMRect`.

This caused every `AMount` container without `offsetParent` of `document.body` to use undefined values in the offset calculation. This led to the values always computing to `NaN`.

The values being used were changed in https://github.com/cisco-sbg-ui/magna-react/pull/773/files#diff-bcc8104da7921ce69a5415f3862dc9c690e7515fee36da98867d8bec28feae41R148

By changing `appCoords.scrollLeft` and `appCoords.scrollTop` to `appCoords.left` and `appCoords.top`, the calculations started working, but were using values that were often positioned relative to the page vs relative to the intended position of the menu around the anchor.

---------

This PR removes the code that would never actually work, and conditionalized the page level logic to retain its functionality.