### PR TITLE
dep: bump cypress to 13.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "babel-plugin-typescript-to-proptypes": "2.1.0",
         "codecov": "3.8.3",
         "cross-env": "7.0.3",
-        "cypress": "^13.13.0",
+        "cypress": "^13.13.2",
         "cypress-plugin-tab": "^1.0.5",
         "cypress-visual-regression": "1.7.0",
         "cypress-wait-until": "3.0.1",
@@ -5405,13 +5405,13 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.0.tgz",
-      "integrity": "sha512-ou/MQUDq4tcDJI2FsPaod2FZpex4kpIK43JJlcBgWrX8WX7R/05ZxGTuxedOuZBfxjZxja+fbijZGyxiLP6CFA==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-plugin-typescript-to-proptypes": "2.1.0",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
-    "cypress": "^13.13.0",
+    "cypress": "^13.13.2",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-visual-regression": "1.7.0",
     "cypress-wait-until": "3.0.1",


### PR DESCRIPTION
Might resolve connection timeout issues, but it doesn't look like it'll resolve intermittent test failures when bundles load

https://docs.cypress.io/guides/references/changelog#13-13-1