### PR TITLE
fix: Stray progressbar fixes

### DIFF
--- a/framework/components/AProgressbar/AProgressbar.mdx
+++ b/framework/components/AProgressbar/AProgressbar.mdx
@@ -19,7 +19,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
   <div>
     <h3 style={{textAlign: "center"}}>Status</h3>
     <div className="d-flex flex-column gap-3 mb-5">
-         <AProgressbar stacked label="Active" status="active" percentage={50} />
+      <AProgressbar stacked label="Active" percentage={50.23476} />
       <AProgressbar stacked label="Success" status="success" percentage={100} />
       <AProgressbar stacked label="Error" status="error" percentage={50} />
     </div>
@@ -27,7 +27,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
     <h3 style={{textAlign: "center"}}>Inline</h3>
     <div className="d-flex flex-column gap-3 mb-5 mt-2">
       <AProgressbar status="active" label="Label" percentage={50} />
-      <AProgressbar status="success" label="Label" percentage={100} />
+      <AProgressbar status="success" label={<span>Label</span>} percentage={100} />
       <AProgressbar status="error" label="Label" percentage={50} />
     </div>
 

--- a/framework/components/AProgressbar/AProgressbar.scss
+++ b/framework/components/AProgressbar/AProgressbar.scss
@@ -45,6 +45,8 @@ $progressbar-animation-timing: 2s linear infinite !default;
     &__content-right {
       display: flex;
       margin-left: 12px;
+      font-size: 12px;
+      font-weight: $font-weight-normal;
     }
   }
 

--- a/framework/components/AProgressbar/AProgressbar.tsx
+++ b/framework/components/AProgressbar/AProgressbar.tsx
@@ -71,8 +71,8 @@ const AProgressbar = forwardRef<HTMLDivElement, AProgressbarProps>(
     }
 
     const fixedPercentage =
-      percentage && Math.max(0, Math.min(percentage, 100));
-    const hasPercentage = percentage && percentage >= 0;
+      percentage && Math.max(0, Math.min(Math.round(percentage), 100));
+    const hasPercentage = percentage !== undefined && percentage >= 0;
     const showPercentage = status === "active" && hasPercentage;
 
     return (
@@ -101,7 +101,7 @@ const AProgressbar = forwardRef<HTMLDivElement, AProgressbarProps>(
           </div>
           <div className={contentRightClass}>
             {status && <AIcon size={20}>{STATUS_ICON[status]}</AIcon>}
-            {showPercentage && <span>{percentage}%</span>}
+            {showPercentage && <span>{fixedPercentage}%</span>}
           </div>
         </div>
 

--- a/framework/components/AProgressbar/types.ts
+++ b/framework/components/AProgressbar/types.ts
@@ -71,7 +71,7 @@ export type AProgressbarProps = Override<
     /**
      * Label for the progress bar
      */
-    label?: string;
+    label?: React.ReactNode;
     /**
      * Label and helper text block positioning
      */


### PR DESCRIPTION
- Takes in node for label for `<Trans />` translation
- ROUNDS percentages, not sure how we got away with that all this time.
- Set styles on texts so they don't inherit
- Makes sure zero shows percentage sign as well.