### PR TITLE
Tag focus/hover fixes; hideStatusIcon prop

### DIFF
--- a/framework/components/ATag/ATag.js
+++ b/framework/components/ATag/ATag.js
@@ -41,13 +41,15 @@ const ATag = forwardRef(
       status,
       color,
       customIcon = false,
+      hideStatusIcon = false,
       ...rest
     },
     ref
   ) => {
+    const interactable = href || onClick;
     let className = "a-tag focus-box-shadow";
 
-    if (href || onClick) {
+    if (interactable) {
       className += ` interactable`;
     }
 
@@ -69,6 +71,10 @@ const ATag = forwardRef(
 
     if (color) {
       className += ` a-tag--${color}`;
+    }
+
+    if (hideStatusIcon) {
+      className += ` a-tag--hide-status-icon`;
     }
 
     let TagName = "div";
@@ -110,7 +116,7 @@ const ATag = forwardRef(
     if (status) {
       tagWithIcon = (
         <>
-          {!customIcon && (
+          {!customIcon && !hideStatusIcon && (
             <AIcon className="a-icon--status" left>
               {STATUS_ICON[status]}
             </AIcon>
@@ -181,7 +187,13 @@ ATag.propTypes = {
   /**
    * Option for custom icon, can pass through children or directly into props.
    */
-  customIcon: PropTypes.oneOfType([PropTypes.bool, PropTypes.node])
+  customIcon: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
+  /**
+   * Hide the status icon
+   *
+   * default `false`
+   */
+  hideStatusIcon: PropTypes.bool
 };
 
 ATag.displayName = "ATag";

--- a/framework/components/ATag/ATag.mdx
+++ b/framework/components/ATag/ATag.mdx
@@ -185,6 +185,25 @@ Basic variants for the standard status states
 `}
 />
 
+#### Status without icon
+
+In some cases using a status tag without an icon is helpful, such as showing
+informational counts
+
+<Playground
+  code={`() => {
+  return (
+    <>
+      <div style={{minHeight: "50px"}}>
+        <ATag hideStatusIcon status="disabled" className="ma-1">0 Products</ATag>
+        <ATag hideStatusIcon status="info" className="ma-1">6 Products</ATag>
+      </div>
+    </>
+);
+}
+`}
+/>
+
 #### Colors
 
 Accent colors

--- a/framework/components/ATag/ATag.scss
+++ b/framework/components/ATag/ATag.scss
@@ -37,6 +37,23 @@ $icon-width: 1.167rem;
     &:focus {
       text-decoration: none;
       color: var(--base-text-default);
+      border-radius: $tag-border-radius !important;
+    }
+
+    &:focus {
+      @include a-control-focus();
+    }
+
+    &.a-tag--status-positive:focus {
+      @include a-control-focus("positive");
+    }
+
+    &.a-tag--status-warning:focus {
+      @include a-control-focus("warning");
+    }
+
+    &.a-tag--status-negative:focus {
+      @include a-control-focus("negative");
     }
   }
   div {
@@ -102,6 +119,7 @@ $icon-width: 1.167rem;
   &--status-deny,
   &--status-alert {
     background-color: var(--negative-bg-strong-default);
+
     .a-icon {
       fill: var(--negative-icon-default);
     }
@@ -113,7 +131,7 @@ $icon-width: 1.167rem;
   }
 
   //Status tags
-  &--status {
+  &--status:not(&--hide-status-icon) {
     padding: 4px 8px 4px 4px;
 
     .a-icon--status {
@@ -132,4 +150,10 @@ $icon-width: 1.167rem;
       background-color: $color;
     }
   }
+}
+
+// If ATag has an onClick, the component gets set to "button"
+// for accessibility
+button.a-tag {
+  border: 0px;
 }

--- a/framework/components/ATag/ATag.tsx
+++ b/framework/components/ATag/ATag.tsx
@@ -37,14 +37,16 @@ const ATag = forwardRef<HTMLElement, ATagProps<React.ElementType>>(
       large,
       status,
       color,
+      hideStatusIcon = false,
       customIcon = false,
       ...rest
     },
     ref
   ) => {
+    const interactable = href || onClick;
     let className = "a-tag focus-box-shadow";
 
-    if (href || onClick) {
+    if (interactable) {
       className += ` interactable`;
     }
 
@@ -66,6 +68,10 @@ const ATag = forwardRef<HTMLElement, ATagProps<React.ElementType>>(
 
     if (color) {
       className += ` a-tag--${color}`;
+    }
+
+    if (hideStatusIcon) {
+      className += ` a-tag--hide-status-icon`;
     }
 
     let TagName: React.ElementType = "div";
@@ -108,7 +114,7 @@ const ATag = forwardRef<HTMLElement, ATagProps<React.ElementType>>(
     if (status) {
       tagWithIcon = (
         <>
-          {!customIcon && (
+          {!customIcon && !hideStatusIcon && (
             <AIcon className="a-icon--status" left>
               {STATUS_ICON[status]}
             </AIcon>

--- a/framework/components/ATag/types.ts
+++ b/framework/components/ATag/types.ts
@@ -48,6 +48,8 @@ export type ATagProps<C extends React.ElementType> =
       customIcon?: boolean | React.ReactNode;
       /**
        * Hide the status icon
+       *
+       * @defaultValue `false`
        */
       hideStatusIcon?: boolean;
       "data-testid"?: string;

--- a/framework/components/ATag/types.ts
+++ b/framework/components/ATag/types.ts
@@ -46,6 +46,10 @@ export type ATagProps<C extends React.ElementType> =
        * @defaultValue `false`
        */
       customIcon?: boolean | React.ReactNode;
+      /**
+       * Hide the status icon
+       */
+      hideStatusIcon?: boolean;
       "data-testid"?: string;
       /**
        * Set the tag to be a link


### PR DESCRIPTION
- Adds the standard button control focus/hover states to "interactive" tags
- Adds `hideStatusIcon` prop so tags like info/disabled can be used in more contexts 
![Screenshot 2024-08-28 at 2 49 24 PM](https://github.com/user-attachments/assets/bda02d0b-dee2-4bf2-bcd2-c0f15ac4bae7)
- Fixes hover border-radius on interactive tags


@wlorand3 fyi