### PR TITLE
fix: add info and adjust mdx to latest figma

### DIFF
--- a/framework/components/AEmptyState/AEmptyState.js
+++ b/framework/components/AEmptyState/AEmptyState.js
@@ -37,16 +37,16 @@ const AEmptyState = forwardRef(
       className += ` ${propsClassName}`;
     }
 
-    if (variant === "success") {
+    if (variant === "success" || variant === "positive") {
       className += ` ${baseClass}--state-success`;
       icon = "positive";
     } else if (variant === "warning") {
       className += ` ${baseClass}--state-warning`;
       icon = "warning";
-    } else if (variant === "danger") {
+    } else if (variant === "danger" || variant === "negative") {
       className += ` ${baseClass}--state-danger`;
       icon = "negative";
-    } else if (!propsIcon) {
+    } else if (variant === "info" || !propsIcon) {
       className += ` ${baseClass}--state-info`;
       icon = "info";
     }
@@ -87,7 +87,22 @@ AEmptyState.propTypes = {
   /**
    * Empty state variant
    */
-  variant: PropTypes.oneOf(["success", "positive", "warning", "danger"]),
+  /**
+   * Empty state variant
+   * default `"info"`
+   *
+   * deprecations - use "negative" instead of "danger"
+   * deprecations = use "positive" instead of "success"
+   *
+   */
+  variant: PropTypes.oneOf([
+    "success",
+    "positive",
+    "negative",
+    "warning",
+    "danger",
+    "info"
+  ]),
   /**
    * Custom icn name
    */

--- a/framework/components/AEmptyState/AEmptyState.mdx
+++ b/framework/components/AEmptyState/AEmptyState.mdx
@@ -30,9 +30,8 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
   withTwoPanes
   code={`
 <>
-  <AEmptyState variant="success" />
   <AEmptyState variant="positive" />
-  <AEmptyState variant="warning" />
+  <AEmptyState variant="info" />
   <AEmptyState variant="danger" />
 </>`}
 />
@@ -48,11 +47,10 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
   };
   return (
     <>
-      <AEmptyState variant="success" xsmall {...props} />
-      <AEmptyState variant="success" small {...props} />
+      <AEmptyState variant="positive" xsmall {...props} />
+      <AEmptyState variant="positive" small {...props} />
       <AEmptyState variant="positive" medium {...props} />
-      <AEmptyState variant="warning" large {...props} />
-      <AEmptyState variant="danger" xlarge {...props} />
+      <AEmptyState variant="negative" xlarge {...props} />
     </>
   );
 }

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -195,11 +195,13 @@ $container-xl: 400px;
     .a-empty-state__label {
       font-weight: 700;
       font-size: 30px;
+      margin-bottom: 18px;
     }
 
     .a-empty-state__message {
       font-weight: 400;
       font-size: 24px;
+      line-height: 30px;
     }
   }
 }

--- a/framework/components/AEmptyState/types.ts
+++ b/framework/components/AEmptyState/types.ts
@@ -1,12 +1,24 @@
 import {Override} from "../../types";
 
-export type AEmptyStateVariant = "success" | "positive" | "warning" | "danger";
+export type AEmptyStateVariant =
+  | "success"
+  | "positive"
+  | "warning"
+  | "danger"
+  | "negative"
+  | "info";
 
 export type AEmptyStateProps = Override<
   React.ComponentPropsWithRef<"div">,
   {
     /**
      * Empty state variant
+     * @defaultValue `"info"`
+     *
+     * deprecations - use "negative" instead of "danger"
+     * deprecations = use "positive" instead of "success"
+     * deprecations = "warning" style is deprecated
+     *
      */
     variant?: AEmptyStateVariant;
     /**


### PR DESCRIPTION
Not including `info` in prop list was causing issues in TS repos.  Fixed up mdx and added notes on variant deprecations, however this is still backwards compatible.


![Screenshot 2024-08-28 at 4 25 35 PM](https://github.com/user-attachments/assets/7dbd2a2e-a178-4e20-8c57-539d4b15072e)
