### PR TITLE
feat: add floating btn style, fix various styles and shadows across app

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -31,6 +31,7 @@ const AButton = forwardRef(
       noPadding = false,
       open = false,
       dropdown = false,
+      floating = false,
       ...rest
     },
     ref
@@ -47,6 +48,8 @@ const AButton = forwardRef(
       className += "tertiary";
     } else if (tertiaryAlt) {
       className += "tertiary-alt";
+    } else if (floating) {
+      className += "floating";
     } else {
       className += destructive ? "primary-destructive" : "primary";
     }
@@ -202,7 +205,11 @@ AButton.propTypes = {
   /**
    * Removes padding on any button, defaults to false
    */
-  noPadding: PropTypes.bool
+  noPadding: PropTypes.bool,
+  /**
+   * Toggles the floating variant style
+   */
+  floating: PropTypes.bool
 };
 
 AButton.displayName = "AButton";

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -112,7 +112,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
     </p>
     <p>
       <AButton tertiaryAlt disabled>
-        Floating Disabled
+        Tertiary Alt Disabled
       </AButton>
     </p>
   </div>

--- a/framework/components/AButton/AButton.mdx
+++ b/framework/components/AButton/AButton.mdx
@@ -31,7 +31,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
 
 <Playground
   fullWidthPreview
-  code={`<div className="container"><div className="d-flex">
+  code={`<div className="container"><div className="d-flex flex-wrap">
   <div>
     <p>
       <AButton>Primary</AButton>
@@ -112,7 +112,28 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
     </p>
     <p>
       <AButton tertiaryAlt disabled>
-        Tertiary Alt Disabled
+        Floating Disabled
+      </AButton>
+    </p>
+  </div>
+    <div className="ml-4">
+    <p>
+      <AButton floating>Floating</AButton>
+    </p>
+    <p>
+      <AButton floating>
+        <AIcon left>edit</AIcon>
+        Floating with Icon
+      </AButton>
+    </p>
+    <p>
+      <AButton floating icon>
+        <AIcon>sync</AIcon>
+      </AButton>
+    </p>
+    <p>
+      <AButton floating disabled>
+        Floating Disabled
       </AButton>
     </p>
   </div>
@@ -207,6 +228,46 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
 `}
 />
 
+#### Size Variants
+
+<Playground
+  code={`<div className="d-flex gap-3">
+  <div>
+    <AButton small>
+      <AIcon left>edit</AIcon>
+      Small
+    </AButton>
+    <br />
+    <br />
+    <AButton>
+      <AIcon left>edit</AIcon>
+      Medium
+    </AButton>
+  </div>
+  <div>
+    <AButton secondary icon small>
+      <AIcon>sync</AIcon>
+    </AButton>
+    <br />
+    <br />
+    <AButton secondary icon>
+      <AIcon>sync</AIcon>
+    </AButton>
+  </div>
+  <div>
+    <AButton floating icon small>
+      <AIcon>sync</AIcon>
+    </AButton>
+    <br />
+    <br />
+    <AButton floating icon>
+      <AIcon>sync</AIcon>
+    </AButton>
+  </div>
+</div>
+`}
+/>
+
 #### Dropdown Button Styles
 
 Use with `AMenu`'s prop `open` to toggle the dropdown icon.
@@ -237,21 +298,6 @@ If the `href` property is used, the component will render as an HTML anchor.
 </AButton>
 </>`}
 />
-
-#### Size Variants
-
-<Playground
-  code={`() => {
-
-return (
-
-<div>
-  <AButton small>Small Magnetic Button</AButton>
-  <br />
-  <br />
-  <AButton medium>Medium Magnetic Button</AButton>
-</div>
-); } `} />
 
 ## Button Props
 

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -182,7 +182,6 @@ $btn-transition: color $transition-duration--extra-fast
 
     &.disabled,
     &:disabled {
-      box-shadow: none;
       color: var(--interact-text-disabled);
       background-color: var(--interact-bg-weak-disabled);
       border-color: var(--interact-border-disabled);

--- a/framework/components/AButton/AButton.scss
+++ b/framework/components/AButton/AButton.scss
@@ -76,7 +76,7 @@ $btn-transition: color $transition-duration--extra-fast
     padding: 10px;
     height: auto;
     .a-spinner {
-      margin-right: unset;
+      margin-right: unset !important;
     }
   }
 
@@ -244,6 +244,12 @@ $btn-transition: color $transition-duration--extra-fast
       background-color: transparent;
       color: var(--interact-text-disabled);
     }
+  }
+
+  &--floating {
+    @extend .a-button--secondary;
+    border-radius: 60px;
+    box-shadow: var(--panel-shadow);
   }
 
   &.a-button--tertiary-alt {

--- a/framework/components/AButton/types.ts
+++ b/framework/components/AButton/types.ts
@@ -88,6 +88,13 @@ export type AButtonProps<C extends React.ElementType> =
        *
        * @defaultValue `false`
        */
+      /**
+       *
+       * Toggles the `floating` style variant.
+       *
+       * @defaultValue `false`
+       */
+      floating?: boolean;
       open?: boolean;
       onClick?: React.MouseEventHandler;
       "data-testid"?: string;

--- a/framework/components/AContextualNotificationMenu/AContextualNotificationMenu.scss
+++ b/framework/components/AContextualNotificationMenu/AContextualNotificationMenu.scss
@@ -3,7 +3,7 @@
 .a-contextual-notification-menu {
   margin: 0;
   width: auto;
-  box-shadow: $default-box-shadow;
+  box-shadow: var(--panel-shadow);
   overflow: visible;
   position: absolute;
 

--- a/framework/components/APanel/APanel.scss
+++ b/framework/components/APanel/APanel.scss
@@ -34,7 +34,7 @@
 
   &--type-dialog {
     .a-panel__header {
-      box-shadow: $default-box-shadow;
+      box-shadow: var(--panel-shadow);
       padding-bottom: 15px;
       padding-top: 16px;
       background: var(--base-icon-in-default);

--- a/framework/components/APopover/APopover.scss
+++ b/framework/components/APopover/APopover.scss
@@ -2,7 +2,6 @@
 
 .a-popover {
   width: 600px;
-  box-shadow: $default-box-shadow;
   position: absolute !important;
   filter: drop-shadow(var(--panel-shadow));
 

--- a/framework/components/ATheme/ATheme.scss
+++ b/framework/components/ATheme/ATheme.scss
@@ -1,7 +1,6 @@
 @import "../../../tokens/cds-magnetic-theme-web-css/dist/token-theme-variables";
 
 :root {
-  --panel-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.18);
   --card-shadow-lifted: 0px 3px 8px 0px;
   --warning-border-darken: darken(#cc8604, 5%);
   --negative-border-darken: darken(#cc2d37, 5%);
@@ -9,6 +8,7 @@
 
 .theme--default,
 .theme--classic-light {
+  --panel-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.18);
   --card-shadow-color: rgba(0, 0, 0, 0.08);
   --text-input-shadow-color: var(--control-border-medium-hover);
   --row-effect-image: none;
@@ -16,6 +16,7 @@
 
 .theme--dusk,
 .theme--classic-dark {
+  --panel-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.78);
   --card-shadow-color: rgba(0, 0, 0, 0.48);
   --text-input-shadow-color: #5191f080; //TODO waiting for new shadow color/tokens
   --row-effect-image: (

--- a/framework/styles/utilities/mixins.scss
+++ b/framework/styles/utilities/mixins.scss
@@ -137,14 +137,19 @@
 
 @mixin medium-button {
   height: 34px;
-  padding: 8px 12px;
+  padding: 7px 12px;
 
   svg.a-icon {
     width: 16px;
   }
 
   &.a-button--icon {
-    padding: 8.25px;
+    justify-content: center;
+    padding: 0;
+    width: 34px;
+    .a-icon {
+      width: 18px;
+    }
   }
 
   &.a-button--inline-btn {
@@ -162,7 +167,12 @@
     width: 14px;
   }
   &.a-button--icon {
-    padding: 8.25px;
+    justify-content: center;
+    padding: 0;
+    width: 28px;
+    .a-icon {
+      width: 16px;
+    }
   }
   &.a-button--inline-btn {
     height: 18px;

--- a/framework/styles/utilities/variables.scss
+++ b/framework/styles/utilities/variables.scss
@@ -157,7 +157,6 @@ $display-breakpoints: (
 // -----------------------------------------------------------------------------
 // Alert box shadow
 // -----------------------------------------------------------------------------
-$default-box-shadow: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.18));
 $info-box-shadow: 0 0 2px 2px rgba(100, 187, 227, 0.4);
 $success-box-shadow: 0 0 2px 2px rgba(108, 192, 74, 0.4);
 $warning-box-shadow: 0 0 2px 2px rgba(255, 115, 0, 0.4);


### PR DESCRIPTION
**Resolves #868 Adds Floating button variant, fixes various style updates**

1) **Floating button**

![Screenshot 2024-09-11 at 4 07 10 PM](https://github.com/user-attachments/assets/0907cf85-f127-4ef6-878e-566f917105ba)

<img width="269" alt="Screenshot 2024-09-11 at 4 06 54 PM" src="https://github.com/user-attachments/assets/a99ef741-605d-401d-8bee-aa99bedabcad">

2) **Adds new dark mode box shadow**

3)  **Fixes Icon button widths and fixed margin that was still applying to icon btns**
Before
![Screenshot 2024-09-11 at 4 07 56 PM](https://github.com/user-attachments/assets/c5a0fa04-ce7f-49a9-b5bb-86168a93af0f)
After
![Screenshot 2024-09-11 at 4 07 22 PM](https://github.com/user-attachments/assets/f635bae7-543c-4a73-9759-540a063e4a18)
