### PR TITLE
Stop checking tab overflow once overflow is hit

### DIFF
--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 import React, {
   forwardRef,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   useCallback
@@ -154,7 +153,7 @@ const ATabGroup = forwardRef(
       setMenuItems(overflowMenuItems);
     }, [combinedRef, vertical]);
 
-    useLayoutEffect(() => {
+    useEffect(() => {
       handleOverflow();
     }, [handleOverflow, selectedTab]);
 

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React, {
   forwardRef,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useCallback
@@ -13,6 +14,8 @@ import OverflowMenuTab from "./OverflowMenuTab";
 import AListItem from "../AList/AListItem";
 import ATabContext from "./ATabContext";
 import "./ATabs.scss";
+
+const hiddenTabClass = "a-tab-group__tab--hide";
 
 const isTabSelectedAndNotMenuTab = (el) => {
   return (
@@ -29,7 +32,7 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
 
     while (
       !toFocus ||
-      toFocus?.classList?.contains("a-tab-group__tab--hide") ||
+      toFocus?.classList?.contains(hiddenTabClass) ||
       isTabSelectedAndNotMenuTab(toFocus)
     ) {
       if (!toFocus) {
@@ -45,7 +48,7 @@ const getNextFocusId = (direction, containerEl, focusedEl) => {
 
     while (
       !toFocus ||
-      toFocus?.classList?.contains("a-tab-group__tab--hide") ||
+      toFocus?.classList?.contains(hiddenTabClass) ||
       isTabSelectedAndNotMenuTab(toFocus)
     ) {
       if (!toFocus) {
@@ -104,6 +107,7 @@ const ATabGroup = forwardRef(
         return;
       }
 
+      let overflowing = false;
       const overflowMenuItems = [];
       const tabWrapper = combinedRef.current;
 
@@ -123,30 +127,34 @@ const ATabGroup = forwardRef(
         }
 
         //Show all elements initially while we calculate size
-        item.classList.remove("a-tab-group__tab--hide");
+        item.classList.remove(hiddenTabClass);
         //Tab item's width
         const tabWidth = item.offsetWidth + tabMargin;
         //If items' total width falls under overall container width, skip
-        if (tabWrapper.offsetWidth >= overflowLimit + tabWidth) {
+        if (
+          tabWrapper.offsetWidth >= overflowLimit + tabWidth &&
+          !overflowing
+        ) {
           overflowLimit += tabWidth;
         } else if (!item.classList.contains("a-tab-group__menu-tab")) {
           //If items' total width exceeds overall container width, hide and push to overflow menu
-          item.classList.add("a-tab-group__tab--hide");
+          item.classList.add(hiddenTabClass);
           overflowMenuItems.push(i);
+          overflowing = true; // Once we detect an overflow, don't bother checking the rest
         }
       });
 
       //Handles overflow tab's visibility
       if (!overflowMenuItems.length) {
-        overflowTab.classList.add("a-tab-group__tab--hide");
+        overflowTab.classList.add(hiddenTabClass);
       } else if (overflowMenuItems.length) {
-        overflowTab.classList.remove("a-tab-group__tab--hide");
+        overflowTab.classList.remove(hiddenTabClass);
       }
 
       setMenuItems(overflowMenuItems);
     }, [combinedRef, vertical]);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       handleOverflow();
     }, [handleOverflow, selectedTab]);
 

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -19,6 +19,7 @@ $tab-heading-margin: 0;
   background-color: transparent;
   display: flex;
   align-items: center;
+  overflow: hidden;
 
   //Remove link style from tabs
   a {

--- a/framework/components/ATabs/ATabs.scss
+++ b/framework/components/ATabs/ATabs.scss
@@ -19,7 +19,6 @@ $tab-heading-margin: 0;
   background-color: transparent;
   display: flex;
   align-items: center;
-  overflow: hidden;
 
   //Remove link style from tabs
   a {


### PR DESCRIPTION
If tab n+1 is smaller than tab n, and tab n overflows but tab n+1 doesn't, n+1 can show and cause the list to be out of order