### PR TITLE
fix: allow empty display

### DIFF
--- a/framework/components/AFloatingMenu/useFloatingDropdown.tsx
+++ b/framework/components/AFloatingMenu/useFloatingDropdown.tsx
@@ -31,7 +31,7 @@ const useFloatingDropdown: UseFloatingDropdown = (open, onOpenChange) => {
     placement: "bottom-start",
     open,
     onOpenChange,
-    middleware: [flip(), hide(), offset(4)]
+    middleware: [flip(), offset(4), hide()]
   });
 
   const dismiss = useDismiss(context);

--- a/framework/components/AMultiSelect/AMultiSelect.js
+++ b/framework/components/AMultiSelect/AMultiSelect.js
@@ -58,7 +58,7 @@ const AMultiSelect = forwardRef(
     const [error, setError] = useState("");
     const [workingValidationState, setWorkingValidationState] =
       useState(validationState);
-    const open = Boolean((items.length || noDataContent) && isOpen);
+    const open = isOpen;
 
     const noDataContent = propsNoDataContent ?? (
       <AEmptyState


### PR DESCRIPTION
**Before**
Menu stays closed when no items present
![Screenshot 2024-09-17 at 1 41 33 PM](https://github.com/user-attachments/assets/fbd6e7f6-069c-4267-b5ac-d76a226f6d4f)

**After**
![Screenshot 2024-09-17 at 1 45 53 PM](https://github.com/user-attachments/assets/99accb36-0689-4ae6-9c55-573a437cf928)
