### PR TITLE
Attempt at fixing flakey tab test

### DIFF
--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -41,14 +41,16 @@ describe("<ATabGroup />", () => {
     cy.mount(<ATabTest />);
     cy.get(".a-tab-group").focus();
 
-    cy.get(".a-tab-group").type("{leftarrow}");
+    cy.get(".a-tab-group__tab--selected").should("exist").contains("Three");
+
+    cy.get(".a-tab-group").type("{leftArrow}");
 
     cy.get(".a-tab-group__tab")
       .first()
       .next()
       .should("have.class", "a-tab-group__tab--focused");
 
-    cy.get(".a-tab-group").type("{rightarrow}");
+    cy.get(".a-tab-group").type("{rightArrow}");
 
     cy.get(".a-tab-group__tab")
       .first()


### PR DESCRIPTION
I think this stems from ATab setting the selected tab state in a useEffect, which would take place after the initial render. My guess is cypress is running leftArrow type command before that state has been set, so no tab is actually focused at the start.

Added a check that should retry and wait until there is a selected/focused tab available to navigate from