### PR TITLE
chore: alternative to the alternative a tab test

### DIFF
--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -41,11 +41,11 @@ describe("<ATabGroup />", () => {
     cy.mount(<ATabTest />);
     cy.get(".a-tab-group").focus();
 
-    cy.get(".a-tab-group__tab--selected")
-      .should("exist")
+    cy.get(".a-tab-group__tab")
+      .should("have.class", "a-tab-group__tab--selected")
       .contains("Three")
-      .type("{leftArrow}")
       .type("{leftArrow}");
+
     cy.get(".a-tab-group__tab")
       .first()
       .next()


### PR DESCRIPTION
CI tests are passing with updated a-tab test from #891, however the test could be more succinct. Seeing if this works as well