### PR TITLE
ACopyButton - Don't apply button icon style when there's text

### DIFF
--- a/framework/components/ACopyButton/ACopyButton.js
+++ b/framework/components/ACopyButton/ACopyButton.js
@@ -55,7 +55,7 @@ const ACopyButton = forwardRef(
         <AButton
           ref={combinedRef}
           className={className}
-          icon
+          icon={!children && !defaultLabel}
           onClick={() => {
             copyToClipboard(value, containerId);
             setClicked(true);


### PR DESCRIPTION
<img width="245" alt="Screenshot 2024-09-20 at 11 33 20 AM" src="https://github.com/user-attachments/assets/16c2b00c-1285-4a36-b879-ffb6e2fadd59">


https://github.com/cisco-sbg-ui/magna-react/commit/d17d584bc8a669eeedec41d7610f222f59489770#diff-966cc622ccfa356f0b786b6d2e927430f02cf877c24b3878c30b5879a152cb9cR149

Not sure what else that may break