### PR TITLE
Input disabled state should take precendence over readOnly

### DIFF
--- a/framework/components/AInputBase/AInputBase.scss
+++ b/framework/components/AInputBase/AInputBase.scss
@@ -65,6 +65,19 @@ $input-transition: border-color $transition-duration--extra-fast
     }
   }
 
+  &--readonly {
+    .a-input-base__surface {
+      box-shadow: none;
+
+      border-color: var(--control-border-default);
+      background: var(--control-bg-weak-default);
+    }
+
+    input {
+      cursor: default;
+    }
+  }
+
   &--disabled {
     .a-input-base__surface {
       @include disabled;
@@ -77,19 +90,6 @@ $input-transition: border-color $transition-duration--extra-fast
       .a-icon {
         fill: var(--base-text-disabled);
       }
-    }
-  }
-
-  &--readonly {
-    .a-input-base__surface {
-      box-shadow: none;
-
-      border-color: var(--control-border-default);
-      background: var(--control-bg-weak-default);
-    }
-
-    input {
-      cursor: default;
     }
   }
 


### PR DESCRIPTION
```
<AInputBase
  append="[Append]"
  prepend="[Prepend]"
  className="mb-3"
  clearable
  readOnly
  disabled
  onClear={() => alert("cleared")}
  label="Label - Focused"
  hints="This is a sample of hint text below a form input"
  focused
>
  [Children]
</AInputBase>
```

Try on Extend -> Input Base. Note the input's background color. Disabled should gray it out even if `readOnly` is set