### PR TITLE
Sync classes for AEmptyState variants with magnetic

### DIFF
--- a/framework/components/AEmptyState/AEmptyState.js
+++ b/framework/components/AEmptyState/AEmptyState.js
@@ -37,14 +37,18 @@ const AEmptyState = forwardRef(
       className += ` ${propsClassName}`;
     }
 
+    // @deprecation
+    // Remove non-magnetic states and classes in next major version
     if (variant === "success" || variant === "positive") {
-      className += ` ${baseClass}--state-success`;
+      className += ` ${baseClass}--state-success`; // deprecated
+      className += ` ${baseClass}--state-positive`;
       icon = "positive";
     } else if (variant === "warning") {
       className += ` ${baseClass}--state-warning`;
       icon = "warning";
     } else if (variant === "danger" || variant === "negative") {
-      className += ` ${baseClass}--state-danger`;
+      className += ` ${baseClass}--state-danger`; // deprecated
+      className += ` ${baseClass}--state-negative`;
       icon = "negative";
     } else if (variant === "info" || !propsIcon) {
       className += ` ${baseClass}--state-info`;

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -38,6 +38,7 @@ $container-xl: 400px;
     color: var(--base-text-medium-default);
   }
 
+  &--state-positive,
   &--state-success {
     .a-empty-state__icon {
       color: var(--accent-a-default);
@@ -66,6 +67,7 @@ $container-xl: 400px;
     }
   }
 
+  &--state-negative,
   &--state-danger {
     border-color: var(--negative-border-default);
 

--- a/framework/components/AEmptyState/types.ts
+++ b/framework/components/AEmptyState/types.ts
@@ -1,10 +1,10 @@
 import {Override} from "../../types";
 
 export type AEmptyStateVariant =
-  | "success"
+  | "success" // deprecated
   | "positive"
   | "warning"
-  | "danger"
+  | "danger" // deprecated
   | "negative"
   | "info";
 


### PR DESCRIPTION
Adds positive/negative classes to the dom for corresponding variants, marks in code as deprecated as a reminder to clean up for next major version