### PR TITLE
Re-enable isReferenceHidden check

### DIFF
--- a/framework/components/AFloatingMenu/useFloatingDropdown.tsx
+++ b/framework/components/AFloatingMenu/useFloatingDropdown.tsx
@@ -52,10 +52,7 @@ const useFloatingDropdown: UseFloatingDropdown = (open, onOpenChange) => {
     middlewareData,
     getReferenceProps,
     getFloatingProps,
-    // For now, disable this feature since it breaks tests cases in some environments
-    // TODO re-enable this as a breaking change, since it is nice to have
-    // menus hide when their anchor reference is scrolled out of view
-    isReferenceHidden: false //!!middlewareData.hide?.referenceHidden
+    isReferenceHidden: !!middlewareData.hide?.referenceHidden
   };
 };
 


### PR DESCRIPTION
This was not the cause of test cases failing. 

This feature allows the menu to hide when the anchor is scrolled out of view. In theory UI test cases will have the anchor in view, and rarely cover scroll scenarios, so this change should be safe.