### PR TITLE
Add extra specificity for multiselect width unset

### DIFF
--- a/framework/components/AMultiSelect/AMultiSelect.scss
+++ b/framework/components/AMultiSelect/AMultiSelect.scss
@@ -132,3 +132,7 @@
     @include a-control-focus();
   }
 }
+
+.a-field-base.a-multiselect {
+  width: unset;
+}


### PR DESCRIPTION
In some envs if another component brings in the a-field-base css due to loader order, this can get overridden. Increasing specificity should help