### PR TITLE
Add AEmptyState horizontal layout; align magnetic small/medium/large sizes

### DIFF
--- a/framework/components/AEmptyState/AEmptyState.js
+++ b/framework/components/AEmptyState/AEmptyState.js
@@ -5,6 +5,12 @@ import React, {forwardRef} from "react";
 import AIcon from "../AIcon";
 import "./AEmptyState.scss";
 
+const baseClass = "a-empty-state",
+  backgroundClass = `${baseClass}__background`,
+  labelClass = `${baseClass}__label`,
+  messageClass = `${baseClass}__message`,
+  messageContainerClass = `${baseClass}__message-container`;
+
 const AEmptyState = forwardRef(
   (
     {
@@ -20,14 +26,11 @@ const AEmptyState = forwardRef(
       medium,
       large,
       xlarge,
+      horizontal = false,
       ...rest
     },
     ref
   ) => {
-    const baseClass = "a-empty-state",
-      backgroundClass = `${baseClass}__background`,
-      labelClass = `${baseClass}__label`,
-      messageClass = `${baseClass}__message`;
     let className = baseClass,
       iconClass = `${baseClass}__icon`,
       containerClass = `${baseClass}__container`,
@@ -55,6 +58,10 @@ const AEmptyState = forwardRef(
       icon = "info";
     }
 
+    if (horizontal) {
+      className += ` ${baseClass}--layout-horizontal`;
+    }
+
     if (xsmall) {
       className += ` ${baseClass}--xsmall`;
     } else if (small) {
@@ -75,9 +82,11 @@ const AEmptyState = forwardRef(
           <AIcon className={backgroundClass}>empty-background</AIcon>
           <AIcon className={iconClass}>{propsIcon || icon}</AIcon>
         </div>
-        {label && <div className={labelClass}>{label}</div>}
-        {message && <div className={messageClass}>{message}</div>}
-        {children}
+        <div className={messageContainerClass}>
+          {label && <div className={labelClass}>{label}</div>}
+          {message && <div className={messageClass}>{message}</div>}
+          {children}
+        </div>
       </div>
     );
   }

--- a/framework/components/AEmptyState/AEmptyState.mdx
+++ b/framework/components/AEmptyState/AEmptyState.mdx
@@ -48,15 +48,6 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
   >
     <ATag>Intermediate</ATag>
   </AEmptyState>
-  <AEmptyState
-    horizontal
-    large
-    variant="positive"
-    label="Creature of Fenkenstrain"
-    message="Dr Fenkenstrain, master and sole occupant of the castle to the north-east of Canifis, needs a new servant to go on a dark errand for him. Do you have the stomach to help Fenkenstrain complete his twisted purpose?"
-  >
-    <ATag>Intermediate</ATag>
-  </AEmptyState>
 </>
 `}
 />

--- a/framework/components/AEmptyState/AEmptyState.mdx
+++ b/framework/components/AEmptyState/AEmptyState.mdx
@@ -36,6 +36,20 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
 </>`}
 />
 
+#### Layout
+
+<Playground
+  code={`<AEmptyState
+  horizontal
+  variant="positive"
+  label="Creature of Fenkenstrain"
+  message="Dr Fenkenstrain, master and sole occupant of the castle to the north-east of Canifis, needs a new servant to go on a dark errand for him. Do you have the stomach to help Fenkenstrain complete his twisted purpose?"
+>
+  <ATag>Intermediate</ATag>
+</AEmptyState>
+`}
+/>
+
 ##### Sizes
 
 <Playground
@@ -50,6 +64,7 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
       <AEmptyState variant="positive" xsmall {...props} />
       <AEmptyState variant="positive" small {...props} />
       <AEmptyState variant="positive" medium {...props} />
+      <AEmptyState variant="negative" large {...props} />
       <AEmptyState variant="negative" xlarge {...props} />
     </>
   );

--- a/framework/components/AEmptyState/AEmptyState.mdx
+++ b/framework/components/AEmptyState/AEmptyState.mdx
@@ -39,14 +39,25 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
 #### Layout
 
 <Playground
-  code={`<AEmptyState
-  horizontal
-  variant="positive"
-  label="Creature of Fenkenstrain"
-  message="Dr Fenkenstrain, master and sole occupant of the castle to the north-east of Canifis, needs a new servant to go on a dark errand for him. Do you have the stomach to help Fenkenstrain complete his twisted purpose?"
->
-  <ATag>Intermediate</ATag>
-</AEmptyState>
+  code={`<>
+  <AEmptyState
+    horizontal
+    variant="positive"
+    label="Creature of Fenkenstrain"
+    message="Dr Fenkenstrain, master and sole occupant of the castle to the north-east of Canifis, needs a new servant to go on a dark errand for him. Do you have the stomach to help Fenkenstrain complete his twisted purpose?"
+  >
+    <ATag>Intermediate</ATag>
+  </AEmptyState>
+  <AEmptyState
+    horizontal
+    large
+    variant="positive"
+    label="Creature of Fenkenstrain"
+    message="Dr Fenkenstrain, master and sole occupant of the castle to the north-east of Canifis, needs a new servant to go on a dark errand for him. Do you have the stomach to help Fenkenstrain complete his twisted purpose?"
+  >
+    <ATag>Intermediate</ATag>
+  </AEmptyState>
+</>
 `}
 />
 

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -4,7 +4,7 @@
 
 $icon-xs: 12px;
 $icon-sm: 31px;
-$icon-md: 52px;
+$icon-md: 43px;
 $icon-lg: 117px;
 $icon-xl: 192px;
 $container-xs: 20px;

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -54,6 +54,10 @@ $container-xl: 300px;
   &--layout-horizontal {
     flex-direction: row;
 
+    .a-empty-state__container {
+      flex: 0 0 auto;
+    }
+
     .a-empty-state__message-container {
       align-items: flex-start;
 

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -5,11 +5,11 @@
 $icon-xs: 12px;
 $icon-sm: 31px;
 $icon-md: 52px;
-$icon-lg: 156px;
+$icon-lg: 117px;
 $icon-xl: 192px;
 $container-xs: 20px;
 $container-sm: 45px;
-$container-md: 72px;
+$container-md: 76px;
 $container-lg: 224px;
 $container-xl: 300px;
 

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -3,12 +3,12 @@
 @import "../../styles";
 
 $icon-xs: 12px;
-$icon-sm: 31px;
-$icon-md: 43px;
-$icon-lg: 117px;
+$icon-sm: 23px;
+$icon-md: 49px;
+$icon-lg: 134px;
 $icon-xl: 192px;
 $container-xs: 20px;
-$container-sm: 45px;
+$container-sm: 36px;
 $container-md: 76px;
 $container-lg: 224px;
 $container-xl: 300px;

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -2,16 +2,16 @@
 
 @import "../../styles";
 
-$icon-xs: 20px;
-$icon-sm: 50px;
-$icon-md: 100px;
-$icon-lg: 150px;
+$icon-xs: 12px;
+$icon-sm: 16px;
+$icon-md: 52px;
+$icon-lg: 156px;
 $icon-xl: 200px;
-$container-xs: 40px;
-$container-sm: 100px;
-$container-md: 200px;
-$container-lg: 300px;
-$container-xl: 400px;
+$container-xs: 20px;
+$container-sm: 36px;
+$container-md: 72px;
+$container-lg: 224px;
+$container-xl: 300px;
 
 .a-empty-state {
   display: flex;
@@ -21,6 +21,8 @@ $container-xl: 400px;
   margin: 20px 0;
 
   &__container {
+    display: flex;
+    flex: 1 0 auto;
     position: relative;
   }
 
@@ -33,9 +35,30 @@ $container-xl: 400px;
     position: absolute;
   }
 
+  &__message-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   &__message {
     text-align: center;
     color: var(--base-text-medium-default);
+    padding: 12px 0px;
+  }
+
+  &--layout-horizontal {
+    flex-direction: row;
+
+    .a-empty-state__message-container {
+      align-items: flex-start;
+
+      margin-left: 12px;
+
+      .a-empty-state__message {
+        text-align: left;
+      }
+    }
   }
 
   &--state-positive,
@@ -121,12 +144,14 @@ $container-xl: 400px;
 
     .a-empty-state__label {
       font-weight: 700;
-      font-size: 16px;
+      font-size: $font-size--md;
+      line-height: $line-height--md;
     }
 
     .a-empty-state__message {
       font-weight: 400;
-      font-size: 12px;
+      font-size: $font-size--sm;
+      line-height: $line-height--sm;
     }
   }
 
@@ -146,12 +171,14 @@ $container-xl: 400px;
 
     .a-empty-state__label {
       font-weight: 700;
-      font-size: 18px;
+      font-size: $font-size--lg;
+      line-height: $line-height--lg;
     }
 
     .a-empty-state__message {
       font-weight: 400;
-      font-size: 14px;
+      font-size: $font-size--md;
+      line-height: $line-height--md;
     }
   }
 
@@ -172,11 +199,13 @@ $container-xl: 400px;
     .a-empty-state__label {
       font-weight: 700;
       font-size: 24px;
+      line-height: $line-height--xl;
     }
 
     .a-empty-state__message {
       font-weight: 400;
       font-size: 18px;
+      line-height: $line-height--lg;
     }
   }
 

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -3,12 +3,12 @@
 @import "../../styles";
 
 $icon-xs: 12px;
-$icon-sm: 16px;
+$icon-sm: 31px;
 $icon-md: 52px;
 $icon-lg: 156px;
-$icon-xl: 200px;
+$icon-xl: 192px;
 $container-xs: 20px;
-$container-sm: 36px;
+$container-sm: 45px;
 $container-md: 72px;
 $container-lg: 224px;
 $container-xl: 300px;

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -41,10 +41,14 @@ $container-xl: 300px;
     align-items: center;
   }
 
+  &__label {
+    margin: 0 0 12px 0;
+  }
+
   &__message {
     text-align: center;
     color: var(--base-text-medium-default);
-    padding: 12px 0px;
+    margin: 0 0 12px 0;
   }
 
   &--layout-horizontal {

--- a/framework/components/AEmptyState/AEmptyState.scss
+++ b/framework/components/AEmptyState/AEmptyState.scss
@@ -41,14 +41,9 @@ $container-xl: 300px;
     align-items: center;
   }
 
-  &__label {
-    margin: 0 0 12px 0;
-  }
-
   &__message {
     text-align: center;
     color: var(--base-text-medium-default);
-    margin: 0 0 12px 0;
   }
 
   &--layout-horizontal {
@@ -60,8 +55,6 @@ $container-xl: 300px;
 
     .a-empty-state__message-container {
       align-items: flex-start;
-
-      margin-left: 12px;
 
       .a-empty-state__message {
         text-align: left;
@@ -154,6 +147,7 @@ $container-xl: 300px;
       font-weight: 700;
       font-size: $font-size--md;
       line-height: $line-height--md;
+      margin: 0 0 2px 0;
     }
 
     .a-empty-state__message {
@@ -181,12 +175,15 @@ $container-xl: 300px;
       font-weight: 700;
       font-size: $font-size--lg;
       line-height: $line-height--lg;
+      margin: 0 0 4px 0;
     }
 
     .a-empty-state__message {
       font-weight: 400;
       font-size: $font-size--md;
       line-height: $line-height--md;
+
+      margin: 0 0 8px 0;
     }
   }
 
@@ -206,14 +203,16 @@ $container-xl: 300px;
 
     .a-empty-state__label {
       font-weight: 700;
-      font-size: 24px;
+      font-size: 18px;
       line-height: $line-height--xl;
+      margin: 0 0 8px 0;
     }
 
     .a-empty-state__message {
       font-weight: 400;
-      font-size: 18px;
+      font-size: 16px;
       line-height: $line-height--lg;
+      margin: 0 0 12px 0;
     }
   }
 
@@ -241,6 +240,36 @@ $container-xl: 300px;
       font-weight: 400;
       font-size: 24px;
       line-height: 30px;
+    }
+  }
+
+  &--layout-horizontal#{&}--xsmall {
+    .a-empty-state__container {
+      margin-right: 12px;
+    }
+  }
+
+  &--layout-horizontal#{&}--small {
+    .a-empty-state__container {
+      margin-right: 20px;
+    }
+  }
+
+  &--layout-horizontal#{&}--medium {
+    .a-empty-state__container {
+      margin-right: 32px;
+    }
+  }
+
+  &--layout-horizontal#{&}--large {
+    .a-empty-state__container {
+      margin-right: 40px;
+    }
+  }
+
+  &--layout-horizontal#{&}--xlarge {
+    .a-empty-state__container {
+      margin-right: 60px;
     }
   }
 }

--- a/framework/components/AEmptyState/types.ts
+++ b/framework/components/AEmptyState/types.ts
@@ -22,6 +22,10 @@ export type AEmptyStateProps = Override<
      */
     variant?: AEmptyStateVariant;
     /**
+     * Align the icon to the left of the text
+     */
+    horizontal?: boolean;
+    /**
      * Custom icon name
      */
     icon?: string;


### PR DESCRIPTION
Magnetic figma shows smaller icon sizes and a larger gap under the label. Note this does not align with current CDS implementation, but is less comically large than before. 

![Screenshot 2024-10-09 at 5 03 51 PM](https://github.com/user-attachments/assets/730face1-7e2f-490d-8885-eaf76c5f83f9)
