### PR TITLE
Start keyboard selection index on selected item, if available

### DIFF
--- a/framework/components/ADropdown/ADropdown.mdx
+++ b/framework/components/ADropdown/ADropdown.mdx
@@ -416,6 +416,11 @@ Component props are passed to the anchor element
     <div>
       <ADropdown ref={ref} component={ATag} title="Has a ref" small status="positive">
         <AListItem onClick={() => {console.log(ref.current)}}>List item</AListItem>
+        <AListItem onClick={() => {console.log(ref.current)}}>List item</AListItem>
+        <AListItem selected onClick={() => {console.log(ref.current)}}>List item</AListItem>
+        <AListItem onClick={() => {console.log(ref.current)}}>List item</AListItem>
+        <AListItem onClick={() => {console.log(ref.current)}}>List item</AListItem>
+        <AListItem onClick={() => {console.log(ref.current)}}>List item</AListItem>
       </ADropdown>
     </div>
   );

--- a/framework/components/AFloatingMenu/AFloatingMenu.tsx
+++ b/framework/components/AFloatingMenu/AFloatingMenu.tsx
@@ -25,7 +25,7 @@ const AFloatingMenu = forwardRef<
       closeOnClick = true,
       compact = false,
       focusOnOpen = true,
-      initialFocus,
+      initialFocus: propsInitialFocus,
       hoverable,
       onClick,
       onClose,
@@ -41,6 +41,23 @@ const AFloatingMenu = forwardRef<
     },
     ref
   ) => {
+    const getSelectedIndex = () => {
+      const listItems = menuRef?.current?.querySelectorAll(".a-list-item");
+
+      if (!listItems?.length) {
+        return undefined;
+      }
+
+      let index = undefined;
+      listItems.forEach((x: HTMLElement, i: number) => {
+        if (x.classList.contains("a-list-item--selected")) {
+          index = i;
+        }
+      });
+
+      return index;
+    };
+
     const getPrevious = useCallback(() => {
       if (!menuRef.current) {
         return;
@@ -144,6 +161,8 @@ const AFloatingMenu = forwardRef<
 
     const attrs: {[key: string]: any} = {};
     attrs["data-ignore-outside-click"] = true;
+
+    const initialFocus = propsInitialFocus || getSelectedIndex();
 
     return (
       <AFloatingMenuContainer


### PR DESCRIPTION
Before, notice on open that the first item is "selected", even though the third item is actually selected

![Screenshot 2024-10-21 at 3 12 15 PM](https://github.com/user-attachments/assets/145c2b4b-e960-4b79-b58f-6707174f006a)

After

![Screenshot 2024-10-21 at 3 11 55 PM](https://github.com/user-attachments/assets/6e781c07-57d0-492d-af0f-aa6beb503bd7)
