### PR TITLE
fix flex spacing properties

### DIFF
--- a/framework/components/AInputBase/AInputBase.scss
+++ b/framework/components/AInputBase/AInputBase.scss
@@ -45,6 +45,8 @@ $input-transition: border-color $transition-duration--extra-fast
 
   &__control {
     flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: 0;
     display: inline-flex;
     align-items: center;
   }


### PR DESCRIPTION
This fixes an issue spotted in an Incident Manager PR: https://github.com/advthreat/incident-manager/pull/3009#issuecomment-2427565813

When the `AInput` is narrower (< 220px), it eventually makes the "close" button shrink.

Before fix:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/4518484e-c8a5-4f77-8a28-93d0d2d8a773">

After fix:
<img width="431" alt="image" src="https://github.com/user-attachments/assets/580e299d-2cf8-4ddc-97cb-8e20b6982f93">
