### PR TITLE
Proposal: Responsive Width Drawer

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -19,6 +19,7 @@ const ADrawer = forwardRef(
       children,
       openHeight,
       openWidth,
+      autoWidth,
       isOpen,
       onClose,
       closeOnOutsideClick,
@@ -91,6 +92,10 @@ const ADrawer = forwardRef(
         style.height = slimHeight;
         style.maxHeight = slimHeight;
       }
+    }
+
+    if (autoWidth) {
+      className += " a-drawer--auto-width";
     }
 
     if (isOpen && !slim && openWidth) {
@@ -211,6 +216,8 @@ ADrawer.propTypes = {
    * to 400px.
    */
   openWidth: PropTypes.string,
+
+  autoWidth: PropTypes.bool,
 
   /**
    * Specifies the positioning strategy of the drawer. A drawer specified with

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -19,7 +19,7 @@ const ADrawer = forwardRef(
       children,
       openHeight,
       openWidth,
-      autoWidth,
+      responsiveWidth,
       isOpen,
       onClose,
       closeOnOutsideClick,
@@ -94,15 +94,16 @@ const ADrawer = forwardRef(
       }
     }
 
-    if (autoWidth) {
-      className += " a-drawer--auto-width";
+    if (isOpen && !slim) {
+      if (openWidth) {
+        style.width = openWidth;
+      } else if (responsiveWidth) {
+        className += " a-drawer--auto-width";
+      } else if (openHeight) {
+        style.height = openHeight;
+      }
     }
 
-    if (isOpen && !slim && openWidth) {
-      style.width = openWidth;
-    } else if (isOpen && !slim && openHeight) {
-      style.height = openHeight;
-    }
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
@@ -217,7 +218,14 @@ ADrawer.propTypes = {
    */
   openWidth: PropTypes.string,
 
-  autoWidth: PropTypes.bool,
+  /**
+   * Automatically adjust the width of the drawer based on the viewport
+   * width, (when not using the slim variant, and a fixed openWidth prop is
+   * not specified).
+   * The Drawer renders with the Magnetic defined widths for the Magnetic
+   * defined breakpoints.
+   */
+  responsiveWidth: PropTypes.bool,
 
   /**
    * Specifies the positioning strategy of the drawer. A drawer specified with

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -98,7 +98,7 @@ const ADrawer = forwardRef(
       if (openWidth) {
         style.width = openWidth;
       } else if (responsiveWidth) {
-        className += " a-drawer--auto-width";
+        className += " a-drawer--responsive-width";
       } else if (openHeight) {
         style.height = openHeight;
       }

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -36,8 +36,6 @@ The drawer can slide-in from the left, right, or bottom of the page.
     const bottomDrawerContentRef = useRef();
     const [isBottomOpen, setIsBottomOpen] = useState(false);
 
-    const autoWidthDrawerContentRef = useRef();
-    const [isAutoWidthOpen, setIsAutoWidthOpen] = useState(false);
 
     return (
       <>
@@ -109,30 +107,6 @@ The drawer can slide-in from the left, right, or bottom of the page.
             <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>
           </ADrawerFooter>
         </ADrawer>
-
-        <p>Auto Width Drawer</p>
-        <AButton onClick={() => setIsAutoWidthOpen(true)} data-test-drawer-trigger-bottom>Open Auto-width</AButton>
-        <ADrawer
-            aria-labelledby='bottom-drawer-title'
-            autoWidth={true}
-            slideIn='right'
-            ref={autoWidthDrawerContentRef}
-            isOpen={isAutoWidthOpen}
-            onClose={() => setIsAutoWidthOpen(false)}
-            data-test-drawer-auto-width>
-          <ADrawerHeader>
-          <ADrawerTitle>
-            <h1 id='left-drawer-title'>Auto Width Drawer</h1>
-          </ADrawerTitle>
-          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
-          </ADrawerHeader>
-          <ADrawerBody>
-             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
-            </ADrawerBody>
-          <ADrawerFooter>
-            <AButton onClick={() => setIsAutoWidthOpen(false)} data-test-drawer-close-bottom>Close</AButton>
-          </ADrawerFooter>
-        </ADrawer>
       </>
     )
 
@@ -202,6 +176,51 @@ The drawer can slide-in from the left, right, or bottom of the page.
           </ADrawerHeader>
           <ADrawerBody>
              This drawer has a custom width of 800px set.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerFooter>
+        </ADrawer>
+      </>
+    )
+
+}`}
+/>
+
+#### Responsive Width
+
+<Playground
+  code={`() => {
+
+    const rightDrawerContentRef = useRef();
+    const [isRightOpen, setIsRightOpen] = useState(false);
+
+    return (
+      <>
+        <p>Right slide-in</p>
+        <AButton onClick={() => setIsRightOpen(true)} data-test-drawer-trigger-right>Open Right</AButton>
+        <ADrawer
+            responsiveWidth={true}
+            aria-labelledby='right-drawer-title'
+            slideIn='right'
+            ref={rightDrawerContentRef}
+            isOpen={isRightOpen}
+            onClose={() => setIsRightOpen(false)}
+            data-test-drawer-right>
+           <ADrawerHeader>
+          <ADrawerTitle>
+            <h1 id='left-drawer-title'>Responsive Width Drawer</h1>
+          </ADrawerTitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+            <p>
+              This Drawers width is set automatically to align with Magnetic breakpoints.
+            </p>
+            <ul>
+              <li>Drawer has width of 400px by default at Small and Medium breakpoints</li>
+              <li>Drawer has width of 576px at Large breakpoint (>1680px)</li>
+              <li>Drawer has width of 768px at XLarge breakpoint (>2080px)</li>
+            </ul>
             </ADrawerBody>
           <ADrawerFooter>
             <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -36,6 +36,9 @@ The drawer can slide-in from the left, right, or bottom of the page.
     const bottomDrawerContentRef = useRef();
     const [isBottomOpen, setIsBottomOpen] = useState(false);
 
+    const autoWidthDrawerContentRef = useRef();
+    const [isAutoWidthOpen, setIsAutoWidthOpen] = useState(false);
+
     return (
       <>
         <p>Left slide-in</p>
@@ -104,6 +107,30 @@ The drawer can slide-in from the left, right, or bottom of the page.
             </ADrawerBody>
           <ADrawerFooter>
             <AButton onClick={() => setIsBottomOpen(false)} data-test-drawer-close-bottom>Close</AButton>
+          </ADrawerFooter>
+        </ADrawer>
+
+        <p>Auto Width Drawer</p>
+        <AButton onClick={() => setIsAutoWidthOpen(true)} data-test-drawer-trigger-bottom>Open Auto-width</AButton>
+        <ADrawer
+            aria-labelledby='bottom-drawer-title'
+            autoWidth={true}
+            slideIn='right'
+            ref={autoWidthDrawerContentRef}
+            isOpen={isAutoWidthOpen}
+            onClose={() => setIsAutoWidthOpen(false)}
+            data-test-drawer-auto-width>
+          <ADrawerHeader>
+          <ADrawerTitle>
+            <h1 id='left-drawer-title'>Auto Width Drawer</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsAutoWidthOpen(false)} data-test-drawer-close-bottom>Close</AButton>
           </ADrawerFooter>
         </ADrawer>
       </>
@@ -658,20 +685,20 @@ This hook can be used in cases there isn't a global drawer controller.
 
 <Playground
   code={`() => {
-    
+
     const list = {
       a: {
-        title: "Merlin's Crystal", 
-        subtitle: "Short", 
+        title: "Merlin's Crystal",
+        subtitle: "Short",
         body: "The wizard Merlin has been trapped in a magical crystal by the witch Morgan Le Faye. So far, King Arthur hasn't been able to figure out how to free his mentor from his crystal prison. Can you help?"
-      }, 
+      },
       b: {
-        title: "Gertrude's Cat", 
-        subtitle: "Very Short", 
+        title: "Gertrude's Cat",
+        subtitle: "Very Short",
         body: "Gertrude has lost her cat Fluffs and desperately wants to find her. Can you help bring her home?"
       }
     }
-   
+
     const drawerRef = useRef();
     const {setDrawerOpen, isDrawerOpen} = useDrawerToggle(drawerRef);
     const [contentId, setContentId] = useState();

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -148,7 +148,7 @@ $common-transitions: transform $transition-props, width $transition-props,
     top: unset;
   }
 
-  &--auto-width {
+  &--responsive-width {
     width: 400px;
 
     @media screen and (min-width: 1680px) {

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -147,6 +147,18 @@ $common-transitions: transform $transition-props, width $transition-props,
     left: 0;
     top: unset;
   }
+
+  &--auto-width {
+    width: 400px;
+
+    @media screen and (min-width: 1680px) {
+      width: 576px;
+    }
+
+    @media screen and (min-width: 2080px) {
+      width: 768px;
+    }
+  }
 }
 
 @media (prefers-reduced-motion) {

--- a/framework/components/ADrawer/types.ts
+++ b/framework/components/ADrawer/types.ts
@@ -43,6 +43,7 @@ export type ADrawerProps<C extends React.ElementType> = Override<
        * to 400px.
        */
       openWidth?: string;
+      autoWidth?: boolean;
       /**
        * Specifies the positioning strategy of the drawer. A drawer specified with
        * "fixed" is useful when the drawer should take up the entire page and cover

--- a/framework/components/ADrawer/types.ts
+++ b/framework/components/ADrawer/types.ts
@@ -43,7 +43,14 @@ export type ADrawerProps<C extends React.ElementType> = Override<
        * to 400px.
        */
       openWidth?: string;
-      autoWidth?: boolean;
+      /**
+       * Automatically adjust the width of the drawer based on the viewport
+       * width, (when not using the slim variant, and a fixed openWidth prop is
+       * not specified).
+       * The Drawer renders with the Magnetic defined widths for the Magnetic
+       * defined breakpoints.
+       */
+      responsiveWidth?: boolean;
       /**
        * Specifies the positioning strategy of the drawer. A drawer specified with
        * "fixed" is useful when the drawer should take up the entire page and cover


### PR DESCRIPTION
Figma for reference: https://www.figma.com/design/zYfa9Hqw0D8b5hpuVwqMeQ/Reusable-Drawer-components-FY24?node-id=1823-23370&node-type=rounded_rectangle&m=dev

Magnetic Drawer Width guidelines

Incident manager needs to implement most `ADrawer`s to have a variable width depending on the viewport width. This follows Magnetic guidelines for Drawer width and responsive breakpoints.

|Breakpoint|Viewport|Drawer|
|---|---|---|
|SM|960px|400px|
|md|1280px|400px|
|LG|1680px|576px|
XL|2080px|768px|

This PR implements a new prop `responsiveWidth` on `ADrawer`.

```ts
<ADrawer 
  responsiveWidth={true} 
  {...otherProps}
/>
```

When `responsiveWidth={true}` prop is set, the Drawer width will automatically be responsive. 
For backward compatibility, when the `openWidth` prop is set, then it will supersede the `responsiveWidth` prop and the Drawer will have a fixed width. If neither prop are provided, then the Drawer will remain at it's default width at all times.