### PR TITLE
Fix the tab keyboard navigation initialization and test case

### DIFF
--- a/framework/components/ATabs/ATab.cy.js
+++ b/framework/components/ATabs/ATab.cy.js
@@ -44,12 +44,14 @@ describe("<ATabGroup />", () => {
     cy.get(".a-tab-group__tab")
       .should("have.class", "a-tab-group__tab--selected")
       .contains("Three");
-    //Focus into tab group, by tabbing in.
-    cy.get(".a-tab-group")
-      .tab()
-      .focused()
-      .type("{leftArrow}")
-      .type("{leftArrow}") //In firefox, Cypress selector is no active until we type another leftArrow
+
+    //Focus into tab group
+    cy.get(".a-tab-group").focus();
+
+    cy.get(".a-tab-group").type("{leftArrow}");
+
+    cy.get(".a-tab-group__tab")
+      .should("have.class", "a-tab-group__tab--selected")
       .prev()
       .should("have.class", "a-tab-group__tab--focused");
 
@@ -145,7 +147,6 @@ const ATabTest = ({width = "30rem", vertical = false, secondary = false}) => {
           </ATab>
         ))}
       </ATabGroup>
-      ;
     </div>
   );
 };

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -77,6 +77,7 @@ const ATabGroup = forwardRef(
   ) => {
     const [selectedTab, _setSelectedTab] = useState(false);
     const [focusedTab, setFocusedTab] = useState(null); // for keyboard support
+    const focusedTabRef = useRef({current: null});
     const [menuItems, setMenuItems] = useState([]);
     const tabGroupRef = useRef(null);
     const tabContainerRef = useRef(null);
@@ -87,9 +88,11 @@ const ATabGroup = forwardRef(
     const setSelectedTab = useCallback(
       (tabId) => {
         _setSelectedTab(tabId);
+
+        focusedTabRef.current = tabId;
         setFocusedTab(tabId);
       },
-      [_setSelectedTab, setFocusedTab]
+      [_setSelectedTab, setFocusedTab, focusedTabRef]
     );
 
     const handleOverflow = useCallback(() => {
@@ -251,7 +254,7 @@ const ATabGroup = forwardRef(
           e.stopPropagation();
 
           const focusedEl = tabContainerRef.current?.querySelector(
-            `[data-tabid='${focusedTab}']`
+            `[data-tabid='${focusedEl || focusedTabRef.current}']`
           );
 
           if (["ArrowLeft", "ArrowRight"].includes(e.key)) {


### PR DESCRIPTION
Use a ref as a backup to track focused element, for when rendering doesn't trigger immediately