### PR TITLE
Move popover tabIndex to original place; remove ineffective option

### DIFF
--- a/framework/components/AFloatingMenu/useFloatingDropdown.tsx
+++ b/framework/components/AFloatingMenu/useFloatingDropdown.tsx
@@ -34,13 +34,7 @@ const useFloatingDropdown: UseFloatingDropdown = (open, onOpenChange) => {
     strategy: "fixed", // breaks it out of a container (like a modal)
     open,
     onOpenChange,
-    middleware: [
-      offset(4),
-      flip({
-        boundary: document.body
-      }),
-      hide()
-    ]
+    middleware: [offset(4), flip(), hide()]
   });
 
   const dismiss = useDismiss(context);

--- a/framework/components/APopover/APopover.js
+++ b/framework/components/APopover/APopover.js
@@ -57,14 +57,9 @@ const APopover = forwardRef(
         role={role}
         hideIfReferenceHidden={hideIfReferenceHidden}
         pointer
+        tabIndex={-1}
       >
-        <APanel
-          {...rest}
-          ref={combinedRef}
-          className={className}
-          type="dialog"
-          tabIndex={-1}
-        >
+        <APanel {...rest} ref={combinedRef} className={className} type="dialog">
           {children}
         </APanel>
       </AFloatingBase>


### PR DESCRIPTION
Minor cleanup

1) move tabIndex on `APopover` to the container, to mimic how it was before
2) remove `boundary` option in useFloatingDropdown flip, since it doesn't do anything (according to the docs, it's not referenced https://floating-ui.com/docs/flip)