### PR TITLE
fix: add back string sizing in AIcon

### DIFF
--- a/framework/components/AIcon/AIcon.mdx
+++ b/framework/components/AIcon/AIcon.mdx
@@ -18,19 +18,32 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
 
 <Playground
   code={`<>
-  <AIcon size={16}>
-    warning
-  </AIcon>
-  <AIcon size={32}>
-    bell
-  </AIcon>
-  <AIcon>
-    plus
-  </AIcon>
-  <AIcon size={16}>
-    allow
-  </AIcon>
-</>
+  <div>
+    <AIcon size={16}>
+      warning
+    </AIcon>
+    <AIcon size={32}>
+      bell
+    </AIcon>
+    <AIcon>
+      plus
+    </AIcon>
+    <AIcon size={16}>
+      allow
+    </AIcon>
+    </div>
+    <div>
+      <AIcon size="small">{/*16px*/}
+        eye
+      </AIcon>
+      <AIcon size="medium">{/*24px*/}
+        rocket
+      </AIcon>
+      <AIcon size="large">{/*32px*/}
+        leaf
+      </AIcon>
+    </div>
+  </>
 `}
 />
 

--- a/framework/components/AIcon/AIcon.scss
+++ b/framework/components/AIcon/AIcon.scss
@@ -15,6 +15,18 @@ svg.a-icon {
     fill: var(--base-icon-in-default);
   }
 
+  &--size-large {
+    width: 32px;
+  }
+
+  &--size-medium {
+    width: 24px;
+  }
+
+  &--size-small {
+    width: 16px;
+  }
+
   &--left {
     margin-right: 4px;
   }
@@ -257,7 +269,8 @@ svg.a-icon {
   &--wan-application,
   &--wireless-lan-controller,
   &--ubuntu,
-  &--redhat {
+  &--redhat,
+  &--rocket {
     fill: var(--interact-icon-weak-default);
   }
 

--- a/framework/components/AIcon/AIcon.tsx
+++ b/framework/components/AIcon/AIcon.tsx
@@ -72,7 +72,9 @@ const AIcon = forwardRef<SVGSVGElement, AIconProps>(
   ) => {
     let className = `a-icon`;
 
-    if (size && typeof size === "number" && isNaN(size)) {
+    const isSizeNum = size && !isNaN(Number(size));
+
+    if (!isSizeNum) {
       className += ` a-icon--size-${size}`;
     }
 
@@ -106,7 +108,7 @@ const AIcon = forwardRef<SVGSVGElement, AIconProps>(
       componentProps.style = {};
     }
 
-    if (size && typeof size === "number" && !isNaN(size)) {
+    if (isSizeNum) {
       componentProps.style.width = size;
     }
 

--- a/framework/components/AIcon/types.ts
+++ b/framework/components/AIcon/types.ts
@@ -1,6 +1,6 @@
 import {Override} from "../../types";
 
-export type AIconSize = number;
+export type AIconSize = number | "small" | "medium" | "large";
 
 export type AIconProps = Override<
   React.ComponentPropsWithRef<"svg">,


### PR DESCRIPTION
Added back string sizing option as this was being used in IM and caused breaking change.  Updated the sizes to _reasonable_ values as `48px` is gargantuan as a default large. 

![Screenshot 2024-11-04 at 12 53 16 PM](https://github.com/user-attachments/assets/e5669963-66c2-425e-9f05-feefef7f5af5)
