### PR TITLE
Add onShow/onHide callbacks for ATriggerTooltip

### DIFF
--- a/framework/components/ATriggerBase/ATriggerBase.tsx
+++ b/framework/components/ATriggerBase/ATriggerBase.tsx
@@ -19,7 +19,7 @@ const ATriggerTooltip = ({
   trigger = "hover",
   openDelay = 300,
   closeDelay,
-  onShow,
+  onShow: propsOnShow,
   onHide,
   onClose,
   content,
@@ -58,26 +58,16 @@ const ATriggerTooltip = ({
     );
   }, [onlyIfTruncated, anchorRef, childrenRef]);
 
+  const onShow = useCallback(() => {
+    propsOnShow && propsOnShow(tooltipRef);
+  }, [tooltipRef, propsOnShow]);
+
   const {
     isOpen,
     open,
     close: toggleClose,
     toggle
-  } = useToggle(openDelay, closeDelay, checkForTruncation);
-
-  useEffect(() => {
-    let timeout: number | undefined;
-
-    if (isOpen) {
-      timeout = onShow && onShow(tooltipRef);
-    } else {
-      onHide && onHide();
-    }
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [tooltipRef, onShow, onHide, isOpen]);
+  } = useToggle(openDelay, closeDelay, checkForTruncation, onShow, onHide);
 
   const close = useCallback(() => {
     const tooltipHover = tooltipRef?.current?.matches(":hover");

--- a/framework/components/ATriggerBase/ATriggerBase.tsx
+++ b/framework/components/ATriggerBase/ATriggerBase.tsx
@@ -19,6 +19,8 @@ const ATriggerTooltip = ({
   trigger = "hover",
   openDelay = 300,
   closeDelay,
+  onShow,
+  onHide,
   onClose,
   content,
   onlyIfTruncated,
@@ -62,6 +64,20 @@ const ATriggerTooltip = ({
     close: toggleClose,
     toggle
   } = useToggle(openDelay, closeDelay, checkForTruncation);
+
+  useEffect(() => {
+    let timeout: number | undefined;
+
+    if (isOpen) {
+      timeout = onShow && onShow(tooltipRef);
+    } else {
+      onHide && onHide();
+    }
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [tooltipRef, onShow, onHide, isOpen]);
 
   const close = useCallback(() => {
     const tooltipHover = tooltipRef?.current?.matches(":hover");

--- a/framework/components/ATriggerBase/types.ts
+++ b/framework/components/ATriggerBase/types.ts
@@ -35,6 +35,14 @@ export type ATriggerBaseProps = Omit<
    */
   disabled?: boolean;
   /**
+   * Callback for when the tooltip is shown
+   */
+  onShow?: (tooltipRef?: React.RefObject<HTMLElement>) => number | undefined;
+  /**
+   * Callback for when the tooltip is hidden
+   */
+  onHide?: () => void;
+  /**
    * Wrap the children elements in a div to allow tooltips on
    * disabled elements.
    * @defaultValue `false`

--- a/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
+++ b/framework/components/ATriggerTooltip/ATriggerTooltip.mdx
@@ -218,6 +218,43 @@ When the tooltip has interactive elements
   `}
 />
 
+#### onShow / onHide
+
+Useful for tracking telemetry on open and close states
+
+<Playground
+  code={`() => {
+    return (
+        <>
+          <span style={{verticalAlign: "super", margin: "0 4px 0 0"}}>
+            Show/hide callbacks
+          </span>
+          <ATriggerTooltip
+            onShow={(tooltipRef) => {
+              // Only fire if it's been open for 1 second
+              return setTimeout(() => {
+                if (!tooltipRef?.current) {
+                  return;
+                }
+
+                console.log("Tooltip has been open for over a second");
+              }, 1000);
+            }}
+            onHide={() => {
+              console.log("Tooltip has been hidden");
+            }}
+            placement="right"
+            content="Tooltip with callbacks">
+            <AIcon>
+            information</AIcon>
+          </ATriggerTooltip>
+        </>
+    );
+    }
+
+`}
+/>
+
 ## Component Props
 
 The `ATriggerTooltip` component inherits passed props.

--- a/framework/hooks/useToggle/useToggle.d.ts
+++ b/framework/hooks/useToggle/useToggle.d.ts
@@ -1,7 +1,9 @@
 declare const useToggle: (
   openDelay?: number,
   closeDelay?: number,
-  canOpen?: () => boolean
+  canOpen?: () => boolean,
+  onShow?: () => void,
+  onHide?: () => void
 ) => {
   isOpen: boolean;
   open: () => void;

--- a/framework/hooks/useToggle/useToggle.d.ts
+++ b/framework/hooks/useToggle/useToggle.d.ts
@@ -2,8 +2,8 @@ declare const useToggle: (
   openDelay?: number,
   closeDelay?: number,
   canOpen?: () => boolean,
-  onShow?: () => void,
-  onHide?: () => void
+  onOpen?: (() => any) | null,
+  onClose?: (() => any) | null
 ) => {
   isOpen: boolean;
   open: () => void;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
	•	[-] This change has been integrated and tested against 2 out of 3 typescript applications
	•	[-] This change passed unit tests in these applications
	•	[x] The changes are documented in component docs and changelog
	•	[-] The ESLint plugin has been updated if a new component is added
	•	[-] Test have been added or modified, if appropriate
  • [-] Convert component to tsx, if reasonable


**Other information**:

Usage, with a delay for cases such as telemetry 

```js
onShow={({tooltipRef}) => {
  // Only fire if it's been open for 1 second
  return setTimeout(() => {
    if (!tooltipRef?.current) {
      return;
    }

    console.log("Tooltip has been open for over a second");
  }, 1000);
}}
onHide={() => {
  console.log("Tooltip has been hidden");
}}
```

Note that it's necessary to return the `setTimeout` handle so the show/hide logic can cancel it if the tooltip is opened->closed->opened before the timeout fires