### PR TITLE
style: remove hover color on tables

### DIFF
--- a/framework/components/ASimpleTable/ASimpleTable.scss
+++ b/framework/components/ASimpleTable/ASimpleTable.scss
@@ -65,7 +65,7 @@ $table-cell-spacious-padding-top-bottom: math.div(
   }
 
   &--striped {
-    tbody tr:nth-child(even):not(:hover) {
+    tbody tr:nth-child(even) {
       background: var(--base-bg-disabled);
     }
   }
@@ -79,10 +79,6 @@ $table-cell-spacious-padding-top-bottom: math.div(
 
   tbody {
     vertical-align: middle;
-  }
-
-  tbody tr:hover {
-    background: var(--control-bg-weak-hover);
   }
 
   tr {


### PR DESCRIPTION
This came up due to tags blending in with the background of the hover color in dark mode.  After investigating, it turned out all colors are accurate, however there is NO hover interaction on tables after checking our neighboring resources and designs.  This is still an "active" state when something is selected however.