### PR TITLE
Prevent inline edit icon from shrinking when at the edge of a container

### DIFF
--- a/framework/components/AInlineInputBase/AInlineInputBase.scss
+++ b/framework/components/AInlineInputBase/AInlineInputBase.scss
@@ -21,6 +21,7 @@
   &__editIcon,
   &__clearIcon {
     display: flex;
+    flex: 0 0 auto;
     opacity: 0;
     align-items: center;
     margin: 0 0 0 4px;


### PR DESCRIPTION
After
![Screenshot 2024-11-18 at 12 47 01 PM](https://github.com/user-attachments/assets/07a6c666-0313-475b-b351-bdb8ff1cbab1)

Before 
![Screenshot 2024-11-18 at 12 47 26 PM](https://github.com/user-attachments/assets/9daf434e-07e3-4a7c-b4d3-2ce413d21411)
