### PR TITLE
ADrawer specified responsive sizes

### DIFF
--- a/framework/components/ADrawer/ADrawer.cy.js
+++ b/framework/components/ADrawer/ADrawer.cy.js
@@ -103,6 +103,24 @@ describe("<ADrawer />", () => {
     testCoreFunctionality(<DrawerTest position="relative" />);
   });
 
+  describe("when the size prop is set", () => {
+    it("should render with the set size", () => {
+      cy.mount(<ADrawer data-testid="drawer" isOpen size="md" />);
+
+      getDrawer().should("have.class", "a-drawer--size-md");
+
+      getDrawer().should("have.css", "width", "576px");
+    });
+
+    it("should render with the size of the first value in the size array", () => {
+      cy.mount(<ADrawer data-testid="drawer" isOpen size={["lg", "xl"]} />);
+
+      getDrawer().should("have.class", "a-drawer--size-lg");
+
+      getDrawer().should("have.css", "width", "768px");
+    });
+  });
+
   describe("when rendered within another <AMount /> component", () => {
     testCoreFunctionality(<MountTest />);
   });
@@ -269,9 +287,9 @@ describe("<ADrawer />", () => {
       // Open the first drawer
       cy.getByDataTestId("trigger-a").click();
 
-      cy.getByDataTestId("drawer-trigger").should("exist");
+      cy.getByDataTestId("drawer-toggle").should("exist");
 
-      cy.getByDataTestId("drawer-trigger").contains("The wizard Merlin");
+      cy.getByDataTestId("drawer-toggle").contains("The wizard Merlin");
 
       // Close the drawer
       cy.get(".a-drawer__title-close").find(".a-button").click();
@@ -280,14 +298,14 @@ describe("<ADrawer />", () => {
       cy.getByDataTestId("trigger-a").should("have.focus");
 
       // Make sure drawer is closed
-      cy.getByDataTestId("drawer-trigger").should("not.be.visible");
+      cy.getByDataTestId("drawer-toggle").should("not.be.visible");
 
       // Open the second drawer
       cy.getByDataTestId("trigger-b").click();
 
-      cy.getByDataTestId("drawer-trigger").should("exist");
+      cy.getByDataTestId("drawer-toggle").should("exist");
 
-      cy.getByDataTestId("drawer-trigger").contains(
+      cy.getByDataTestId("drawer-toggle").contains(
         "Gertrude has lost her cat Fluffs and desperately"
       );
 
@@ -298,16 +316,16 @@ describe("<ADrawer />", () => {
       cy.getByDataTestId("trigger-b").should("have.focus");
 
       // Make sure drawer is closed
-      cy.getByDataTestId("drawer-trigger").should("not.be.visible");
+      cy.getByDataTestId("drawer-toggle").should("not.be.visible");
 
       // Click the first trigger, check, click second tigger, check
       cy.getByDataTestId("trigger-a").click();
-      cy.getByDataTestId("drawer-trigger").contains("The wizard Merlin");
+      cy.getByDataTestId("drawer-toggle").contains("The wizard Merlin");
 
       //cy.wait(301);
 
       cy.getByDataTestId("trigger-b").click();
-      cy.getByDataTestId("drawer-trigger").contains(
+      cy.getByDataTestId("drawer-toggle").contains(
         "Gertrude has lost her cat Fluffs and desperately"
       );
 
@@ -626,7 +644,7 @@ const DrawerHookTest = () => {
         onClose={() => {
           setDrawerOpen(false);
         }}
-        data-testid="drawer-trigger"
+        data-testid="drawer-toggle"
       >
         <ADrawerHeader>
           <ADrawerTitle>

--- a/framework/components/ADrawer/ADrawer.cy.js
+++ b/framework/components/ADrawer/ADrawer.cy.js
@@ -103,9 +103,9 @@ describe("<ADrawer />", () => {
     testCoreFunctionality(<DrawerTest position="relative" />);
   });
 
-  describe("when the size prop is set", () => {
+  describe("when the responsiveWidth prop is set", () => {
     it("should render with the set size", () => {
-      cy.mount(<ADrawer data-testid="drawer" isOpen size="md" />);
+      cy.mount(<ADrawer data-testid="drawer" isOpen responsiveWidth="md" />);
 
       getDrawer().should("have.class", "a-drawer--size-md");
 
@@ -113,7 +113,9 @@ describe("<ADrawer />", () => {
     });
 
     it("should render with the size of the first value in the size array", () => {
-      cy.mount(<ADrawer data-testid="drawer" isOpen size={["lg", "xl"]} />);
+      cy.mount(
+        <ADrawer data-testid="drawer" isOpen responsiveWidth={["lg", "xl"]} />
+      );
 
       getDrawer().should("have.class", "a-drawer--size-lg");
 

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -115,8 +115,6 @@ const ADrawer = forwardRef(
       }
     }
 
-    console.log(className);
-
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -238,7 +238,10 @@ ADrawer.propTypes = {
    * The Drawer renders with the Magnetic defined widths for the Magnetic
    * defined breakpoints.
    */
-  responsiveWidth: PropTypes.bool,
+  responsiveWidth: PropTypes.oneOfType([
+    PropTypes.arrayOf(["sm", "md", "lg", "xl"]),
+    PropTypes.string
+  ]),
 
   /**
    * Specifies the positioning strategy of the drawer. A drawer specified with

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -112,10 +112,6 @@ const ADrawer = forwardRef(
         else if (typeof responsiveWidth === "string") {
           className += ` a-drawer--size-${responsiveWidth}`;
         }
-        // Otherwise let it have generic responsive breakpoints
-        else {
-          className += " a-drawer--responsive-width";
-        }
       } else if (openHeight) {
         style.height = openHeight;
       }

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -20,7 +20,6 @@ const ADrawer = forwardRef(
       openHeight,
       openWidth,
       responsiveWidth,
-      size,
       isOpen,
       onClose,
       closeOnOutsideClick,
@@ -98,18 +97,25 @@ const ADrawer = forwardRef(
     if (isOpen && !slim) {
       if (openWidth) {
         style.width = openWidth;
-      } else if (size) {
-        if (Array.isArray(size)) {
+      } else if (responsiveWidth) {
+        // If it's an array, it means we want to make the drawer responsive at
+        // the corresponding breakpoints
+        if (Array.isArray(responsiveWidth)) {
           // Use the first size as the smallest width
-          className += ` a-drawer--size-${size[0]}`;
+          className += ` a-drawer--size-${responsiveWidth[0]}`;
           // Make the drawer responsive to the other sizes
           className +=
-            " " + size.map((s) => `a-drawer--responsive-${s}`).join(" ");
-        } else {
-          className += ` a-drawer--size-${size}`;
+            " " +
+            responsiveWidth.map((s) => `a-drawer--responsive-${s}`).join(" ");
         }
-      } else if (responsiveWidth) {
-        className += " a-drawer--responsive-width";
+        // For a string we want to set a fixed width
+        else if (typeof responsiveWidth === "string") {
+          className += ` a-drawer--size-${responsiveWidth}`;
+        }
+        // Otherwise let it have generic responsive breakpoints
+        else {
+          className += " a-drawer--responsive-width";
+        }
       } else if (openHeight) {
         style.height = openHeight;
       }

--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -20,6 +20,7 @@ const ADrawer = forwardRef(
       openHeight,
       openWidth,
       responsiveWidth,
+      size,
       isOpen,
       onClose,
       closeOnOutsideClick,
@@ -97,12 +98,24 @@ const ADrawer = forwardRef(
     if (isOpen && !slim) {
       if (openWidth) {
         style.width = openWidth;
+      } else if (size) {
+        if (Array.isArray(size)) {
+          // Use the first size as the smallest width
+          className += ` a-drawer--size-${size[0]}`;
+          // Make the drawer responsive to the other sizes
+          className +=
+            " " + size.map((s) => `a-drawer--responsive-${s}`).join(" ");
+        } else {
+          className += ` a-drawer--size-${size}`;
+        }
       } else if (responsiveWidth) {
         className += " a-drawer--responsive-width";
       } else if (openHeight) {
         style.height = openHeight;
       }
     }
+
+    console.log(className);
 
     if (propsClassName) {
       className += ` ${propsClassName}`;

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -232,6 +232,73 @@ The drawer can slide-in from the left, right, or bottom of the page.
 }`}
 />
 
+#### Specific Size
+
+The drawer can be set to a specific Magnetic size, or an array of sizes. If an array is specified the first value in the array will be used as the smallest size. The rest will act as responsive breakpoints based on browser width.
+
+<Playground
+  code={`() => {
+    const fixedRef = useRef();
+    const [isFixedOpen, setIsFixedOpen] = useState(false);
+
+    const variableRef = useRef();
+    const [isVariableOpen, setIsVariableOpen] = useState(false);
+
+    return (
+      <>
+        <p>Fixed width by size</p>
+        <AButton onClick={() => setIsFixedOpen(true)} data-test-drawer-trigger-left>Open Fixed Large</AButton>
+        <ADrawer
+            size="lg"
+            aria-labelledby='left-drawer-title'
+            slideIn='right'
+            ref={fixedRef}
+            isOpen={isFixedOpen}
+            onClose={() => setIsFixedOpen(false)}
+            data-test-drawer-left>
+          <ADrawerHeader>
+          <ADrawerTitle>
+            <h1 id='left-drawer-title'>Fixed Width</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsFixedOpen(false)} data-test-drawer-close-left>Close</AButton>
+          </ADrawerFooter>
+        </ADrawer>
+
+        <p>Responsize width, minimum medium size</p>
+        <AButton onClick={() => setIsVariableOpen(true)} data-test-drawer-trigger-right>Open Sized Responsive</AButton>
+        <ADrawer
+            size={["md", "lg", "xl"]}
+            aria-labelledby='variable-drawer-title'
+            slideIn='right'
+            ref={variableRef}
+            isOpen={isVariableOpen}
+            onClose={() => setIsVariableOpen(false)}
+            data-test-drawer-right>
+           <ADrawerHeader>
+          <ADrawerTitle>
+            <h1 id='left-drawer-title'>Responsize with minimum width</h1>
+          </ADrawerTitle>
+          <ADrawerSubtitle>Old School RuneScape is an MMORPG with adventure elements.</ADrawerSubtitle>
+          </ADrawerHeader>
+          <ADrawerBody>
+             It features a persistent world in which players can interact with each other and the environment. The basic mechanics are largely the same as RuneScape on 10 August 2007.
+            </ADrawerBody>
+          <ADrawerFooter>
+            <AButton onClick={() => setIsVariableOpen(false)} data-test-drawer-close-right>Close</AButton>
+          </ADrawerFooter>
+        </ADrawer>
+      </>
+    )
+
+}`}
+/>
+
 #### Modal Options
 
 Becuase `ADrawer` is a `fixed` element by default, it also defaults to rendering as [a modal](/components/modal). This can be easily overriden by passing `false` to the `asModal` prop of `ADrawer`.

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -187,52 +187,7 @@ The drawer can slide-in from the left, right, or bottom of the page.
 }`}
 />
 
-#### Responsive Width
-
-<Playground
-  code={`() => {
-
-    const rightDrawerContentRef = useRef();
-    const [isRightOpen, setIsRightOpen] = useState(false);
-
-    return (
-      <>
-        <p>Right slide-in</p>
-        <AButton onClick={() => setIsRightOpen(true)} data-test-drawer-trigger-right>Open Right</AButton>
-        <ADrawer
-            responsiveWidth={true}
-            aria-labelledby='right-drawer-title'
-            slideIn='right'
-            ref={rightDrawerContentRef}
-            isOpen={isRightOpen}
-            onClose={() => setIsRightOpen(false)}
-            data-test-drawer-right>
-           <ADrawerHeader>
-          <ADrawerTitle>
-            <h1 id='left-drawer-title'>Responsive Width Drawer</h1>
-          </ADrawerTitle>
-          </ADrawerHeader>
-          <ADrawerBody>
-            <p>
-              This Drawers width is set automatically to align with Magnetic breakpoints.
-            </p>
-            <ul>
-              <li>Drawer has width of 400px by default at Small and Medium breakpoints</li>
-              <li>Drawer has width of 576px at XLarge breakpoint (>1680px)</li>
-              <li>Drawer has width of 768px at XXLarge breakpoint (>2080px)</li>
-            </ul>
-            </ADrawerBody>
-          <ADrawerFooter>
-            <AButton onClick={() => setIsRightOpen(false)} data-test-drawer-close-right>Close</AButton>
-          </ADrawerFooter>
-        </ADrawer>
-      </>
-    )
-
-}`}
-/>
-
-#### Specific Size
+#### Specific Responsive Size
 
 The drawer can be set to a specific Magnetic size, or an array of sizes. If an array is specified the first value in the array will be used as the smallest size. The rest will act as responsive breakpoints based on browser width.
 

--- a/framework/components/ADrawer/ADrawer.mdx
+++ b/framework/components/ADrawer/ADrawer.mdx
@@ -249,7 +249,7 @@ The drawer can be set to a specific Magnetic size, or an array of sizes. If an a
         <p>Fixed width by size</p>
         <AButton onClick={() => setIsFixedOpen(true)} data-test-drawer-trigger-left>Open Fixed Large</AButton>
         <ADrawer
-            size="lg"
+            responsiveWidth="lg"
             aria-labelledby='left-drawer-title'
             slideIn='right'
             ref={fixedRef}
@@ -273,7 +273,7 @@ The drawer can be set to a specific Magnetic size, or an array of sizes. If an a
         <p>Responsize width, minimum medium size</p>
         <AButton onClick={() => setIsVariableOpen(true)} data-test-drawer-trigger-right>Open Sized Responsive</AButton>
         <ADrawer
-            size={["md", "lg", "xl"]}
+            responsiveWidth={["md", "lg", "xl"]}
             aria-labelledby='variable-drawer-title'
             slideIn='right'
             ref={variableRef}

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -154,18 +154,6 @@ $common-transitions: transform $transition-props, width $transition-props,
     top: unset;
   }
 
-  &--responsive-width {
-    width: $drawer-width-default;
-
-    @media screen and (min-width: map-get($grid-breakpoints, "xl")) {
-      width: $drawer-width-md;
-    }
-
-    @media screen and (min-width: map-get($grid-breakpoints, "xxl")) {
-      width: $drawer-width-lg;
-    }
-  }
-
   &--size-sm {
     width: $drawer-width-sm;
   }

--- a/framework/components/ADrawer/ADrawer.scss
+++ b/framework/components/ADrawer/ADrawer.scss
@@ -5,8 +5,10 @@ $transition-timing: ease-in-out;
 $transition-props: $transition-duration $transition-timing;
 
 $drawer-width-default: 400px;
-$drawer-width-xl: 576px;
-$drawer-width-xxl: 768px;
+$drawer-width-sm: 400px;
+$drawer-width-md: 576px;
+$drawer-width-lg: 768px;
+$drawer-width-xl: 992px;
 
 //limit transition properties to avoid animating other properties coming form outside
 $common-transitions: transform $transition-props, width $transition-props,
@@ -156,11 +158,47 @@ $common-transitions: transform $transition-props, width $transition-props,
     width: $drawer-width-default;
 
     @media screen and (min-width: map-get($grid-breakpoints, "xl")) {
-      width: $drawer-width-xl;
+      width: $drawer-width-md;
     }
 
     @media screen and (min-width: map-get($grid-breakpoints, "xxl")) {
-      width: $drawer-width-xxl;
+      width: $drawer-width-lg;
+    }
+  }
+
+  &--size-sm {
+    width: $drawer-width-sm;
+  }
+  &--responsive-sm {
+    @media screen and (min-width: map-get($grid-breakpoints, "md")) {
+      width: $drawer-width-sm;
+    }
+  }
+
+  &--size-md {
+    width: $drawer-width-md;
+  }
+  &--responsive-md {
+    @media screen and (min-width: map-get($grid-breakpoints, "lg")) {
+      width: $drawer-width-md;
+    }
+  }
+
+  &--size-lg {
+    width: $drawer-width-lg;
+  }
+  &--responsive-lg {
+    @media screen and (min-width: map-get($grid-breakpoints, "xl")) {
+      width: $drawer-width-lg;
+    }
+  }
+
+  &--size-xl {
+    width: $drawer-width-xl;
+  }
+  &--responsive-xl {
+    @media screen and (min-width: map-get($grid-breakpoints, "xxl")) {
+      width: $drawer-width-xl;
     }
   }
 }

--- a/framework/components/ADrawer/types.ts
+++ b/framework/components/ADrawer/types.ts
@@ -51,13 +51,11 @@ export type ADrawerProps<C extends React.ElementType> = Override<
        * not specified).
        * The Drawer renders with the Magnetic defined widths for the Magnetic
        * defined breakpoints.
+       * This can accept an also accept an array to be responsive to specified sizes,
+       * or a string for a single fixed size.
        */
-      responsiveWidth?: boolean;
-      /**
-       * Specify the width of the drawer based on width variables. This can accept an
-       * array to be responsive to specified sizes, or a string for a single fixed size.
-       */
-      size?: ADrawerSize | ADrawerSize[];
+      responsiveWidth?: boolean | ADrawerSize | ADrawerSize[];
+
       /**
        * Specifies the positioning strategy of the drawer. A drawer specified with
        * "fixed" is useful when the drawer should take up the entire page and cover

--- a/framework/components/ADrawer/types.ts
+++ b/framework/components/ADrawer/types.ts
@@ -54,7 +54,7 @@ export type ADrawerProps<C extends React.ElementType> = Override<
        * This can accept an also accept an array to be responsive to specified sizes,
        * or a string for a single fixed size.
        */
-      responsiveWidth?: boolean | ADrawerSize | ADrawerSize[];
+      responsiveWidth?: ADrawerSize | ADrawerSize[];
 
       /**
        * Specifies the positioning strategy of the drawer. A drawer specified with

--- a/framework/components/ADrawer/types.ts
+++ b/framework/components/ADrawer/types.ts
@@ -7,6 +7,8 @@ export type ADrawerPosition = "absolute" | "fixed" | "relative";
 
 export type ADrawerSlideIn = "left" | "right" | "bottom";
 
+export type ADrawerSize = "sm" | "md" | "lg" | "xl";
+
 export type ADrawerProps<C extends React.ElementType> = Override<
   AModalProps<C>,
   PolymorphicComponentPropWithRef<
@@ -51,6 +53,11 @@ export type ADrawerProps<C extends React.ElementType> = Override<
        * defined breakpoints.
        */
       responsiveWidth?: boolean;
+      /**
+       * Specify the width of the drawer based on width variables. This can accept an
+       * to be responsive to specified sizes
+       */
+      size?: ADrawerSize | ADrawerSize[];
       /**
        * Specifies the positioning strategy of the drawer. A drawer specified with
        * "fixed" is useful when the drawer should take up the entire page and cover

--- a/framework/components/ADrawer/types.ts
+++ b/framework/components/ADrawer/types.ts
@@ -55,7 +55,7 @@ export type ADrawerProps<C extends React.ElementType> = Override<
       responsiveWidth?: boolean;
       /**
        * Specify the width of the drawer based on width variables. This can accept an
-       * to be responsive to specified sizes
+       * array to be responsive to specified sizes, or a string for a single fixed size.
        */
       size?: ADrawerSize | ADrawerSize[];
       /**

--- a/framework/components/ATriggerBase/ATriggerBase.tsx
+++ b/framework/components/ATriggerBase/ATriggerBase.tsx
@@ -41,6 +41,8 @@ const ATriggerTooltip = ({
   const tooltipAnchorRef = anchorRef || triggerRef || firstChildRef;
   const tooltipRef = useRef<HTMLElement>(null);
 
+  console.log(tooltipAnchorRef, firstChildRef);
+
   const checkForTruncation = useCallback(() => {
     if (!onlyIfTruncated) {
       return true;
@@ -48,15 +50,26 @@ const ATriggerTooltip = ({
 
     const element = anchorRef?.current || childrenRef.current[0];
 
+    console.log("???", element);
     if (!element) {
       return true;
     }
+
+    console.log(
+      "foopbar",
+      element.offsetHeight,
+      element.scrollHeight,
+      element.offsetWidth,
+      element.scrollWidth,
+      element.offsetHeight < element.scrollHeight ||
+        element.offsetWidth < element.scrollWidth
+    );
 
     return (
       element.offsetHeight < element.scrollHeight ||
       element.offsetWidth < element.scrollWidth
     );
-  }, [onlyIfTruncated, anchorRef, childrenRef]);
+  }, [onlyIfTruncated, tooltipAnchorRef, childrenRef]);
 
   const onShow = useCallback(() => {
     propsOnShow && propsOnShow(tooltipRef);
@@ -133,6 +146,7 @@ const ATriggerTooltip = ({
   }, [
     trigger,
     childrenRefCurrent,
+    tooltipAnchorRef,
     triggerRef,
     close,
     open,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
	-	[-] This change has been integrated and tested against 2 out of 3 typescript applications
	-	[-] This change passed unit tests in these applications
	-	[x] The changes are documented in component docs and changelog
	-	[ ] The ESLint plugin has been updated if a new component is added
	-	[x] Test have been added or modified, if appropriate
  
This adds a `size` prop to drawers. The value can either be a string

`type ADrawerSize = "sm" | "md" | "lg" | "xl"`

or an array containing any of those values.

If the value is a string, the drawer width will be set to the corresponding magnetic size width (vs specifying a width in pixels).

If the value is an array, the drawer width will default to (and be no smaller than) the size of the first value in the array, and responsively change size for the remaining values.


---------
Note that this is technically a breaking change, so Typescript validation in certain repositories will fail without a matching update.

Migration step:

`responsiveWidth` is no longer a boolean, but will need to take an array of sizes. 