### PR TITLE
Fix: removed unused anchorRef in useFloatingBase

### DIFF
--- a/framework/components/AFloatingBase/AFloatingBase.tsx
+++ b/framework/components/AFloatingBase/AFloatingBase.tsx
@@ -69,7 +69,6 @@ const AFloatingBase = forwardRef<HTMLElement, AFloatingBaseProps>(
     const {context, floatingRefs, floatingStyles, isReferenceHidden} =
       useFloatingBase(
         !!open,
-        anchorRef,
         arrowRef,
         onClose,
         placement,

--- a/framework/components/AFloatingBase/useFloatingBase.tsx
+++ b/framework/components/AFloatingBase/useFloatingBase.tsx
@@ -1,5 +1,3 @@
-import {AAnchorRef} from "../../types";
-
 import {
   useFloating,
   arrow,
@@ -19,7 +17,6 @@ import {flip, shift, type Placement} from "@floating-ui/dom";
 
 type UseFloatingBase = (
   open: boolean,
-  anchorRef: AAnchorRef,
   arrowRef: React.RefObject<SVGSVGElement>,
   onOpenChange?: (
     open: boolean,
@@ -43,7 +40,6 @@ type UseFloatingBase = (
 
 const useFloatingBase: UseFloatingBase = (
   open,
-  anchorRef,
   arrowRef,
   onOpenChange,
   placement = "top",


### PR DESCRIPTION
Ticket: https://cisco-sbg.atlassian.net/browse/XDR-16386

![image](https://github.com/user-attachments/assets/c603738f-6cdd-42db-af4d-0796b6e1257b)


- [ ] This change has been run and tested against at least 2 typescript applications
- [x] This change passed unit tests in the applications the build was tested against
- [ ] The changes are documented in component docs and changelog
- [ ] Test have been added or modified, if appropriate
- [ ] Convert component to tsx, if reasonable
  
For new components
- [ ] The component should be in typescript
- [ ] The component should accept a class name as a prop, if appropriate
- [ ] The component should accept a forward ref, if appropriate
- [ ] Add tests in typescript, cypress/tests/*, if reasonable


** NOTE **
I've only verified this in one Typescript app which is our Administration MFE on a development branch in `securex-ui-monorepo` via local linking. If you have another app I can test this against, please let me know.
