### PR TITLE
Feat/#978 timeline-updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Please check if the PR fulfills these requirements**
 
-- [ ] This change has been run and tested against at least 2 typescript applications
+- [ ] This change has been run and tested against at least 1 typescript application.  (If extensive change, 2 is best)
 - [ ] This change passed unit tests in the applications the build was tested against
 - [ ] The changes are documented in component docs and changelog
 - [ ] Test have been added or modified, if appropriate

--- a/framework/components/AActivityTimeline/AActivityTimeline.cy.js
+++ b/framework/components/AActivityTimeline/AActivityTimeline.cy.js
@@ -1,6 +1,7 @@
 import React, {useState} from "react";
 import AActivityTimeline from "./AActivityTimeline";
 import AActivityTimelineItem from "./AActivityTimelineItem";
+import APagination from "../APagination/APagination";
 
 const DEFAULT_BORDER_STYLE = "2px solid rgb(225, 228, 232)";
 const COMPLETE_STATUS_BORDER_STYLE = "2px solid rgb(29, 105, 204)";
@@ -28,6 +29,15 @@ describe("<AActivityTimeline />", () => {
       .then((borderStyle) => {
         expect(borderStyle).contains(DEFAULT_BORDER_STYLE);
       });
+  });
+
+  it("should show the correct numbers in paginated timeline after navigating to next page", () => {
+    cy.mount(<PaginatedTimelineTest numbered />);
+
+    cy.get("[aria-label='Next']").click();
+    cy.get(
+      "[data-testid='mock-content-5'] .a-activity-timeline__list-item--num"
+    ).contains("5)");
   });
 
   it("should always render a timeline item connector if the prop for it is passed", () => {
@@ -330,5 +340,41 @@ function ControlledTimelineTest({children, itemCount = 1}) {
             </AActivityTimelineItem>
           ))}
     </AActivityTimeline>
+  );
+}
+
+function PaginatedTimelineTest(...props) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [resultsPerPage, setResultsPerPage] = useState(3);
+
+  const paginatedData = [...new Array(resultsPerPage).keys()].map((index) => {
+    const countingNumber = index + 1;
+    return (currentPage - 1) * resultsPerPage + countingNumber;
+  });
+
+  const paginatedItems = paginatedData.map((num) => (
+    <AActivityTimelineItem
+      data-testid={`mock-content-${num}`}
+      key={num}
+      title={`Mock title #${num}`}
+      time={`${num} days ago`}
+      withConnector={num < TOTAL_ITEMS}
+      itemNum={num}
+    />
+  ));
+
+  const TOTAL_ITEMS = 30;
+  return (
+    <>
+      <AActivityTimeline {...props}>{paginatedItems}</AActivityTimeline>
+      <APagination
+        className="mt-4"
+        onPageChange={(value) => setCurrentPage(value)}
+        onResultsPerPageChange={(value) => setResultsPerPage(value)}
+        page={currentPage}
+        resultsPerPage={resultsPerPage}
+        total={TOTAL_ITEMS}
+      />
+    </>
   );
 }

--- a/framework/components/AActivityTimeline/AActivityTimeline.cy.js
+++ b/framework/components/AActivityTimeline/AActivityTimeline.cy.js
@@ -1,7 +1,7 @@
-import React, {useState} from "react";
+import React, {useState, useMemo} from "react";
 import AActivityTimeline from "./AActivityTimeline";
 import AActivityTimelineItem from "./AActivityTimelineItem";
-import APagination from "../APagination/APagination";
+import APaginator from "../APaginator";
 
 const DEFAULT_BORDER_STYLE = "2px solid rgb(225, 228, 232)";
 const COMPLETE_STATUS_BORDER_STYLE = "2px solid rgb(29, 105, 204)";
@@ -36,8 +36,8 @@ describe("<AActivityTimeline />", () => {
 
     cy.get("[aria-label='Next']").click();
     cy.get(
-      "[data-testid='mock-content-5'] .a-activity-timeline__list-item--num"
-    ).contains("5)");
+      "[data-testid='mock-content-15'] .a-activity-timeline__list-item--num"
+    ).contains("15)");
   });
 
   it("should always render a timeline item connector if the prop for it is passed", () => {
@@ -344,36 +344,35 @@ function ControlledTimelineTest({children, itemCount = 1}) {
 }
 
 function PaginatedTimelineTest(...props) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const [resultsPerPage, setResultsPerPage] = useState(3);
-
-  const paginatedData = [...new Array(resultsPerPage).keys()].map((index) => {
-    const countingNumber = index + 1;
-    return (currentPage - 1) * resultsPerPage + countingNumber;
-  });
-
+  const [currentPage, setCurrentPage] = useState(0);
+  const [resultsPerPage, setResultsPerPage] = useState(10);
+  const startIndex = currentPage * resultsPerPage;
+  const endIndex = currentPage * resultsPerPage + resultsPerPage;
+  const numbers = useMemo(() => Array.from({length: 100}, (_, i) => i + 1), []);
+  const paginatedData = numbers.slice(startIndex, endIndex);
   const paginatedItems = paginatedData.map((num) => (
     <AActivityTimelineItem
       data-testid={`mock-content-${num}`}
       key={num}
       title={`Mock title #${num}`}
       time={`${num} days ago`}
-      withConnector={num < TOTAL_ITEMS}
+      withConnector={num < numbers.length}
       itemNum={num}
     />
   ));
 
-  const TOTAL_ITEMS = 30;
   return (
     <>
       <AActivityTimeline {...props}>{paginatedItems}</AActivityTimeline>
-      <APagination
-        className="mt-4"
-        onPageChange={(value) => setCurrentPage(value)}
+      <br />
+      <APaginator
+        onPageChange={(value) => {
+          setCurrentPage(value);
+        }}
         onResultsPerPageChange={(value) => setResultsPerPage(value)}
-        page={currentPage}
         resultsPerPage={resultsPerPage}
-        total={TOTAL_ITEMS}
+        page={currentPage}
+        total={numbers.length}
       />
     </>
   );

--- a/framework/components/AActivityTimeline/AActivityTimeline.js
+++ b/framework/components/AActivityTimeline/AActivityTimeline.js
@@ -5,13 +5,23 @@ import "./AActivityTimeline.scss";
 
 const AActivityTimeline = forwardRef(
   (
-    {children, className: propsClassName, hasUnorderedItems = false, ...rest},
+    {
+      children,
+      className: propsClassName,
+      hasUnorderedItems = false,
+      numbered = false,
+      ...rest
+    },
     ref
   ) => {
     let className = "a-activity-timeline";
 
     if (propsClassName) {
       className += ` ${propsClassName}`;
+    }
+
+    if (numbered && !hasUnorderedItems) {
+      className += " a-activity-timeline--numbered";
     }
 
     const ListTag = hasUnorderedItems ? "ul" : "ol";

--- a/framework/components/AActivityTimeline/AActivityTimeline.mdx
+++ b/framework/components/AActivityTimeline/AActivityTimeline.mdx
@@ -34,6 +34,26 @@ sourceCodeLink: https://github.com/cisco-sbg-ui/magna-react/tree/main/framework/
 `}
 />
 
+##### Numbered
+
+<Playground
+  code={`<AActivityTimeline numbered>
+  <AActivityTimelineItem
+    time="2022-02-12 21:11:10 UTC"
+    title="Account Created"
+  />
+  <AActivityTimelineItem
+    time="2022-02-14 21:12:10 UTC"
+    title="Tutorial Island Completed"
+  />
+  <AActivityTimelineItem
+    time="2022-02-14 22:11:10 UTC"
+    title="Cook's Assistant Started"
+  />
+</AActivityTimeline>
+`}
+/>
+
 #### Paginated List (`withConnector` prop)
 
 When rendering a timeline from a paginated source of data, the last item in the _visible_ slice of data may not actually be the very last item in the entirety of the list. As such, the connector on the last timeline item in the slice should still exist to indicate to the user that the timeline is ongoing. In such situations, you can explicitly pass the `withConnector` prop to control its presence.

--- a/framework/components/AActivityTimeline/AActivityTimeline.mdx
+++ b/framework/components/AActivityTimeline/AActivityTimeline.mdx
@@ -60,33 +60,34 @@ When rendering a timeline from a paginated source of data, the last item in the 
 
 <Playground
   code={`() => {
-  const [currentPage, setCurrentPage] = useState(1);
-  const [resultsPerPage, setResultsPerPage] = useState(3);
-  const paginatedData = [...new Array(resultsPerPage).keys()].map((index) => {
-    const countingNumber = index + 1;
-    return (currentPage - 1) * resultsPerPage + countingNumber;
-  });
-  const TOTAL_ITEMS = 30;
+  const [currentPage, setCurrentPage] = useState(0);
+  const [resultsPerPage, setResultsPerPage] = useState(10);
+  const startIndex = currentPage * resultsPerPage;
+  const endIndex = currentPage * resultsPerPage + resultsPerPage;
+  const numbers = useMemo(() => Array.from({ length: 100 }, (_, i) => i + 1), []);
+  const paginatedData = numbers.slice(startIndex, endIndex);
   return (
     <>
-      <AActivityTimeline numbered>
+    <AActivityTimeline numbered>
         {paginatedData.map((num) => (
           <AActivityTimelineItem
             key={num}
             title={\`Item #\${num}\`}
             time={\`\${num} days ago\`}
-            withConnector={num < TOTAL_ITEMS}
+            withConnector={num < numbers.length}
             itemNum={num}
           />
         ))}
       </AActivityTimeline>
-      <APagination
-        className="mt-4"
-        onPageChange={(value) => setCurrentPage(value)}
+      <br/>
+      <APaginator
+        onPageChange={(value) => {
+          setCurrentPage(value);
+        }}
         onResultsPerPageChange={(value) => setResultsPerPage(value)}
-        page={currentPage}
         resultsPerPage={resultsPerPage}
-        total={TOTAL_ITEMS}
+        page={currentPage}
+        total={numbers.length}
       />
     </>
   );

--- a/framework/components/AActivityTimeline/AActivityTimeline.mdx
+++ b/framework/components/AActivityTimeline/AActivityTimeline.mdx
@@ -69,13 +69,14 @@ When rendering a timeline from a paginated source of data, the last item in the 
   const TOTAL_ITEMS = 30;
   return (
     <>
-      <AActivityTimeline>
+      <AActivityTimeline numbered>
         {paginatedData.map((num) => (
           <AActivityTimelineItem
             key={num}
             title={\`Item #\${num}\`}
             time={\`\${num} days ago\`}
             withConnector={num < TOTAL_ITEMS}
+            itemNum={num}
           />
         ))}
       </AActivityTimeline>

--- a/framework/components/AActivityTimeline/AActivityTimeline.scss
+++ b/framework/components/AActivityTimeline/AActivityTimeline.scss
@@ -5,12 +5,17 @@
 
   &--numbered {
     counter-reset: list-number;
-    .a-activity-timeline__list-item__header::before {
-      counter-increment: list-number;
-      content: counter(list-number) ")";
-      margin-right: 14px;
-      font-weight: 600;
-      color: var(--base-text-strong-default);
+    .a-activity-timeline__list-item {
+      &__title::before {
+        counter-increment: list-number;
+        content: counter(list-number) ")";
+        margin-right: 14px;
+        font-weight: 600;
+        color: var(--base-text-strong-default);
+      }
+      &__time {
+        padding-left: 28px;
+      }
     }
   }
 

--- a/framework/components/AActivityTimeline/AActivityTimeline.scss
+++ b/framework/components/AActivityTimeline/AActivityTimeline.scss
@@ -2,7 +2,17 @@
   list-style-type: none;
   margin: 0;
   padding-left: 0 !important;
-  color: var(--base-text-medium-default);
+
+  &--numbered {
+    counter-reset: list-number;
+    .a-activity-timeline__list-item__header::before {
+      counter-increment: list-number;
+      content: counter(list-number) ")";
+      margin-right: 14px;
+      font-weight: 600;
+      color: var(--base-text-strong-default);
+    }
+  }
 
   &__list-item {
     width: 100%;
@@ -10,7 +20,7 @@
     display: flex;
 
     &:not(:last-child) {
-      padding-bottom: 16px;
+      padding-bottom: 12px;
     }
 
     &:last-child .a-activity-timeline__list-item__divider {
@@ -28,6 +38,7 @@
       left: 12px;
       height: 100%;
       width: 2px;
+      margin-top: 1px;
       border-left: 2px solid var(--base-border-default);
     }
 
@@ -45,12 +56,14 @@
       grid-template-columns: auto auto minmax(0, 1fr);
       align-items: center;
       row-gap: 4px;
+      padding-bottom: 12px;
     }
 
     &__title {
       grid-area: title;
       font-weight: 600;
       color: var(--base-text-strong-default);
+      align-items: center;
     }
 
     &__divider {
@@ -74,6 +87,7 @@
       flex-shrink: 0;
       z-index: 1;
       margin-right: 16px;
+      margin-top: 1px;
     }
 
     &__button {

--- a/framework/components/AActivityTimeline/AActivityTimeline.scss
+++ b/framework/components/AActivityTimeline/AActivityTimeline.scss
@@ -10,7 +10,6 @@
         counter-increment: list-number;
         content: counter(list-number) ")";
         margin-right: 14px;
-        color: var(--base-text-strong-default);
       }
       &__time {
         padding-left: 28px;
@@ -36,9 +35,14 @@
     width: 100%;
     position: relative;
     display: flex;
-
     &:not(:last-child) {
       padding-bottom: 12px;
+      .a-activity-timeline__list-item__header {
+        padding-bottom: 12px;
+      }
+      .a-activity-timeline__list-item__body {
+        margin-bottom: 16px;
+      }
     }
 
     &:last-child .a-activity-timeline__list-item__divider {
@@ -75,13 +79,12 @@
       align-items: center;
       row-gap: 4px;
       font-weight: 600;
-      padding-bottom: 12px;
+      color: var(--base-text-strong-default);
     }
 
     &__title {
       grid-area: title;
       font-weight: 600;
-      color: var(--base-text-strong-default);
       align-items: center;
     }
 
@@ -90,7 +93,7 @@
       border-top: none;
       border-left: none;
       border-right: none;
-      padding-top: 16px;
+      padding-top: 12px;
       border-bottom-width: 2px;
       border-color: var(--base-border-default);
     }
@@ -126,7 +129,7 @@
     &__body {
       grid-area: body;
       display: block;
-      margin-top: 12px;
+      color: var(--base-text-medium-default);
 
       &--collapsed {
         display: none;

--- a/framework/components/AActivityTimeline/AActivityTimeline.scss
+++ b/framework/components/AActivityTimeline/AActivityTimeline.scss
@@ -10,11 +10,24 @@
         counter-increment: list-number;
         content: counter(list-number) ")";
         margin-right: 14px;
-        font-weight: 600;
         color: var(--base-text-strong-default);
       }
       &__time {
         padding-left: 28px;
+      }
+      //If using numbered paginated list, hide content and apply styling.
+      &:has(.a-activity-timeline__list-item--num) {
+        .a-activity-timeline__list-item {
+          &__title {
+            &::before {
+              content: none;
+            }
+            padding-left: 15px;
+          }
+          &__time {
+            padding-left: 15px;
+          }
+        }
       }
     }
   }
@@ -61,6 +74,7 @@
       grid-template-columns: auto auto minmax(0, 1fr);
       align-items: center;
       row-gap: 4px;
+      font-weight: 600;
       padding-bottom: 12px;
     }
 

--- a/framework/components/AActivityTimeline/AActivityTimelineItem.js
+++ b/framework/components/AActivityTimeline/AActivityTimelineItem.js
@@ -37,6 +37,7 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
     title,
     withConnector,
     withDivider,
+    itemNum,
     ...rest
   } = props;
 
@@ -73,6 +74,10 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
     </AActivityTimelineItemHeaderContent>
   );
 
+  const numberedPaginatedList = itemNum ? (
+    <span className="a-activity-timeline__list-item--num">{itemNum})</span>
+  ) : null; //Null as safety for edge case of 0
+
   return (
     <AActivityTimelineListItem
       icon={statusIcon}
@@ -99,6 +104,7 @@ const AActivityTimelineItem = forwardRef((props, ref) => {
         </AActivityTimelineItemHeaderToggleButton>
       ) : (
         <AActivityTimelineItemHeader>
+          {numberedPaginatedList}
           {headerContent}
         </AActivityTimelineItemHeader>
       )}

--- a/framework/components/AActivityTimeline/types.ts
+++ b/framework/components/AActivityTimeline/types.ts
@@ -19,7 +19,7 @@ export type AActivityTimelineProps = Override<
     /**
      * Adds numbered timeline and associated positioning to content.
      * If `hasUnorderedItems` is set to `true`, this prop is ignored.
-     * For paginated lists, utilize the accurate number provided in paginated data list rather than `numbered` prop.
+     * For paginated lists, pass the number provided in paginated data to `itemNum` in `AActivityTimelineItem`
      */
     numbered?: boolean;
   }
@@ -100,6 +100,8 @@ export type AActivityTimelineItemProps = Override<
      * for collapsible items (unless it is the last one in the list.)
      */
     withDivider?: boolean;
+    /** Option to pass number to numbered list. Useful for paginated data. */
+    itemNum?: number | string;
   }
 >;
 

--- a/framework/components/AActivityTimeline/types.ts
+++ b/framework/components/AActivityTimeline/types.ts
@@ -1,4 +1,4 @@
-import {Override} from "../../types";
+import type {Override} from "../../types";
 
 export type AActivityTimelineProps = Override<
   React.ComponentPropsWithRef<"div">,
@@ -16,6 +16,11 @@ export type AActivityTimelineProps = Override<
      * @defaultValue `false`
      */
     hasUnorderedItems?: boolean;
+    /**
+     * Adds numbered timeline and associated positioning to content.
+     * If `hasUnorderedItems` is set to `true`, this prop is ignored.
+     */
+    numbered?: boolean;
   }
 >;
 
@@ -64,7 +69,7 @@ export type AActivityTimelineItemProps = Override<
      * the state of the component (i.e. passing `isCollapsed`), then
      * this is the right place to toggle said state.
      */
-    onToggle?: (...args: any[]) => unknown;
+    onToggle?: (...args: unknown[]) => unknown;
 
     /**
      * Determines which icon to render in the timeline item's bullet.

--- a/framework/components/AActivityTimeline/types.ts
+++ b/framework/components/AActivityTimeline/types.ts
@@ -19,6 +19,7 @@ export type AActivityTimelineProps = Override<
     /**
      * Adds numbered timeline and associated positioning to content.
      * If `hasUnorderedItems` is set to `true`, this prop is ignored.
+     * For paginated lists, utilize the accurate number provided in paginated data list rather than `numbered` prop.
      */
     numbered?: boolean;
   }


### PR DESCRIPTION
** #978 - Touch up activity timeline and add numbered lists**

**Please check if the PR fulfills these requirements**

- [x] This change has been run and tested against at least 2 typescript applications _**(tested in IM)**_
- [ ] This change passed unit tests in the applications the build was tested against _**(was not able to run unit test against IM due to unrelated failures)**_
- [x] The changes are documented in component docs and changelog
- [x] Test have been added or modified, if appropriate
- [ ] Convert component to tsx, if reasonable **_(Will revisit in follow up PR)_**
  

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->


**Other information**:

![Screenshot 2024-12-05 at 2 59 28 PM](https://github.com/user-attachments/assets/36720dd5-76c1-44be-ba95-65e09a6300fa)


**Numbered Pagination Lists**
CSS will only increment what is on the viewport as seen below in first image.  I was going to leave the option off for paginated lists since they can just add the number and override the styles, but that wouldn't have been very nice. This update also allows a developer to pass `numList` to `AActivityTimelineItem` if using a numbered paginated list to take advantage of same styling.


Before
![Screenshot 2024-12-06 at 9 22 59 AM](https://github.com/user-attachments/assets/6c87d9c9-e6d1-4ff7-b9f4-c232a3f8e729)

After
![Screenshot 2024-12-06 at 9 18 23 AM](https://github.com/user-attachments/assets/f983988a-42f3-4916-a9b3-581868d5e145)

