### PR TITLE
build/commonjs-as-module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     // Search under node_modules for non-relative imports.
     "moduleResolution": "node",
+    "module": "commonjs",
     // Process & infer types from .js files.
     "allowJs": true,
     // Don't emit; allow Babel to transform files.


### PR DESCRIPTION
This makes monorepo stop yelling about us for some reason (I'm guessing it accepts our cjs and moves on).  No idea how this impacts other groups so we should do some thorough testing and run their unit tests