### PR TITLE
fix: reduce useEffect call back to 1

### DIFF
--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -96,7 +96,7 @@ const ATheme = forwardRef(
 
     // persist currentTheme on change
     useIsomorphicLayoutEffect(() => {
-      if (shouldUseThemeStorage) {
+      if (shouldUseThemeStorage && currentTheme !== theme) {
         ThemeStorage.saveTheme(currentTheme);
       }
     }, [currentTheme]);


### PR DESCRIPTION
**Resolves #986 - React strict mode changes**

**Problem**

In react StrictMode, `useEffect`'s purposefully run twice to catch flakiness.  In this case, the theme was getting set properly, and then RESET with a bad state conflict of the newly set theme and the rerun of another "initial onload" set theme.

This check just ensures that we resave only when there's been a true onchange event.  This avoids the redundant reloads which cause the ripple effect of mismatching values which ultimately lead to a resetting of "default".

**To recreate issue in x__-components**

1) Go to `withAAppDecorator.jsx` and add:
``` jsx
const withAAppDecorator = (Story, props) => {
  return (
    <React.StrictMode>
      <div style={{minWidth: "95%", height: "70vh"}}>
        <AApp style={{height: "100%"}} persistTheme withNewWrappingContext>
          <ACardContainer
            style={{minHeight: "200px", textAlign: "center", margin: "20px"}}>
            <ACardContent>
              <Story />
            </ACardContent>
          </ACardContainer>
        </AApp>
      </div>
    </React.StrictMode>
  );
};
```

2) Open Application tab and localStorage in dev tools
3) Change `persist-magna-react-theme` to `dusk`.
4) Refresh page and it will flash dark mode, until going back to default.


**To validate fix**

1) In magna `npm run build`, `npm pack`
2) `npm i` this in `x__-components package.json`
3) Repeat steps above and theme `dusk` should stay put


**Please check if the PR fulfills these requirements**

- [x] This change has been run and tested against at least 1 typescript application.  (If extensive change, 2 is best)
- [x] This change passed unit tests in the applications the build was tested against
- [ ] The changes are documented in component docs and changelog
- [ ] Test have been added or modified, if appropriate
- [ ] Convert component to tsx, if reasonable
  
