### PR TITLE
Bugfix ADrawer Responsive width array based prop type 

### DIFF
--- a/framework/components/ADrawer/ADrawer.js
+++ b/framework/components/ADrawer/ADrawer.js
@@ -239,7 +239,7 @@ ADrawer.propTypes = {
    * defined breakpoints.
    */
   responsiveWidth: PropTypes.oneOfType([
-    PropTypes.arrayOf(["sm", "md", "lg", "xl"]),
+    PropTypes.arrayOf(PropTypes.oneOf(["sm", "md", "lg", "xl"])),
     PropTypes.string
   ]),
 


### PR DESCRIPTION
Bugfix prompted by a discussion in UI dev channel.

![image](https://github.com/user-attachments/assets/6210a8ae-05b3-4570-a4c1-70a31b311e65)

The existing PropType definition for `ADrawers`s `responsiveWidth` is not quite correct. The Typescript type is correct, but if the build falls back to using proptypes, it may flag the issue.