### PR TITLE
fix(APageAlert): refine prop types

### DIFF
--- a/framework/components/APageLayout/APageAlert.d.ts
+++ b/framework/components/APageLayout/APageAlert.d.ts
@@ -1,0 +1,9 @@
+import React from "react";
+
+import {type APageAlertProps} from "./types";
+
+declare const APageAlert: (
+  props: React.PropsWithChildren<APageAlertProps>
+) => JSX.Element;
+
+export default APageAlert;

--- a/framework/components/APageLayout/APageAlert.js
+++ b/framework/components/APageLayout/APageAlert.js
@@ -17,7 +17,10 @@ APageAlert.propTypes = {
   /**
    * String representing class names to be passed `AToast` component.
    */
-  className: PropTypes.string
+  className: PropTypes.string,
+
+  /** Node children */
+  children: PropTypes.node
 };
 
 APageAlert.displayName = "APageAlert";

--- a/framework/components/APageLayout/types.ts
+++ b/framework/components/APageLayout/types.ts
@@ -1,5 +1,7 @@
 import {Override} from "../../types";
 
+export type APageAlertProps = React.ComponentPropsWithRef<"div">;
+
 export type APageContainerProps = React.ComponentPropsWithRef<"div">;
 
 export type APageDescriptionProps = React.ComponentPropsWithRef<"div">;


### PR DESCRIPTION
## Context

When rendering `APageAlert` with React children in a TypeScript project, the following warning is shown:

![Screenshot 2025-01-07 at 3 07 02 PM](https://github.com/user-attachments/assets/882c3443-93c9-47cf-8017-f43700104c6c)

This seems to be because of a combination of two things:

1. The prop types do not define `children`
2. There are no explicitly defined TypeScript types for the `APageAlert` props

Because of (2), I'm assuming something in this repo defaults to generating the TypeScript types from prop types. However, since `children` is missing in the prop types, the TypeScript type also excludes the `children` prop.

## This PR

* Defines TypeScript types for the `APageAlert` component
* Adds `children` to the `APageAlert` prop types