### PR TITLE
fix(AActivityTimeline): add space between header and body

### DIFF
--- a/framework/components/AActivityTimeline/AActivityTimeline.scss
+++ b/framework/components/AActivityTimeline/AActivityTimeline.scss
@@ -45,6 +45,12 @@
       }
     }
 
+    &:has(.a-activity-timeline__list-item__body) {
+      .a-activity-timeline__list-item__header {
+        padding-bottom: 12px;
+      }
+    }
+
     &:last-child .a-activity-timeline__list-item__divider {
       display: none;
     }


### PR DESCRIPTION
## Context

When rendering `AActivityTimeline` with a single `AActivityTimelineItem` component, there is no space between the timeline's header and body:

![Screenshot 2025-01-08 at 10 36 57 AM](https://github.com/user-attachments/assets/d04f3225-80fc-43b0-bdb9-32e4ab2dc033)

Similarly, the last item in a list of timeline items doesn't render space between the header and body:

![Screenshot 2025-01-08 at 10 39 00 AM](https://github.com/user-attachments/assets/3dd8b6b0-c3eb-4045-8791-102ed1373a4b)

## This PR

* Always adds padding between timeline item headers and body
    * Done via `:has()` pseudo-class

## Test Plan

### Case 1: Only one timeline item

1. Navigate to the Magna React docs site
2. Paste this into a sandbox:
    ```jsx
    <AActivityTimeline>
      <AActivityTimelineItem time="2022-02-12 21:11:10 UTC" title="Account Created">
        You created your account. You can start playing!
      </AActivityTimelineItem>
    </AActivityTimeline>
    ```
3. **Verify that there is space between the timeline item header and body**

### Case 2: Multiple timeline items

1. Navigate to the Magna React docs site
2. Paste this into a sandbox:
    ```jsx
    <AActivityTimeline>
      <AActivityTimelineItem time="2022-02-12 21:11:10 UTC" title="Account Created">
        You created your account. You can start playing!
      </AActivityTimelineItem>
      <AActivityTimelineItem
        time="2022-02-14 21:12:10 UTC"
        title="Tutorial Island Completed"
      >
        You completed Tutorial Island. You are now in Lumbridge.
      </AActivityTimelineItem>
      <AActivityTimelineItem
        time="2022-02-14 22:11:10 UTC"
        title="Cook's Assistant Started"
      >
        You started the Cook's Assistant quest.
      </AActivityTimelineItem>
    </AActivityTimeline>
    ````
3. **Verify that there is space between every timeline item header and body**