### PR TITLE
Allow defaultValue for string arrays in ASelect

### DIFF
--- a/framework/components/ASelect/ASelect.cy.js
+++ b/framework/components/ASelect/ASelect.cy.js
@@ -57,6 +57,16 @@ describe("<ASelect />", () => {
       cy.get('[role="option"]').eq(2).enterKeydown();
       getSelectedItem().contains("2");
     });
+
+    it("should respect the default value", () => {
+      cy.mount(<StringItemsTest defaultValue="5" />);
+      openSelect();
+      cy.get('[role="option"]').eq(5).enterKeydown();
+      getSelectedItem().contains("5");
+
+      openSelect().downArrowKeydown();
+      getSelectedItem().contains("6");
+    });
   });
 
   describe("when passing an array of objects as items", () => {

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -36,6 +36,7 @@ const ASelect = forwardRef(
       label,
       maxHeight,
       onSelected,
+      defaultValue,
       placeholder: propsPlaceholder,
       prependContent,
       readOnly,
@@ -58,12 +59,15 @@ const ASelect = forwardRef(
     const surfaceRef = useRef(null);
     const selectedItemRef = useRef(null);
     const [selectId] = useState(selectCounter++);
+    const checkSelected = (x) => {
+      return typeof x === "string" ? x === defaultValue : x[itemSelected];
+    };
+
     const [originalSelectedItem, setOriginalSelectedItem] = useState(
-      items.find((x) => x[itemSelected])
+      items.find((x) => checkSelected(x))
     );
-    const [selectedItem, setSelectedItem] = useState(
-      items.find((x) => x[itemSelected])
-    );
+
+    const [selectedItem, setSelectedItem] = useState(originalSelectedItem);
     const [isFocused, setIsFocused] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
     const [error, setError] = useState("");
@@ -85,7 +89,7 @@ const ASelect = forwardRef(
     }, [validationState]);
 
     useEffect(() => {
-      const newSelectedItem = items.find((x) => x[itemSelected]);
+      const newSelectedItem = items.find((x) => checkSelected(x));
 
       if (
         (!["string", "object"].includes(typeof originalSelectedItem) &&
@@ -601,6 +605,10 @@ ASelect.propTypes = {
    * Handles the `selected` event.
    */
   onSelected: PropTypes.func,
+  /**
+   * Sets a default initial value for string array `items`
+   */
+  defaultValue: PropTypes.string,
   /**
    * Sets the text when no option is selected.
    */

--- a/framework/components/ASelect/ASelect.scss
+++ b/framework/components/ASelect/ASelect.scss
@@ -12,6 +12,7 @@ $select-padding: 6px;
     &--selected {
       &::after {
         color: var(--control-icon-default);
+        top: calc(50% - 6px) !important;
       }
     }
 
@@ -138,6 +139,7 @@ $select-padding: 6px;
   max-height: 400px;
   overflow-y: auto;
   .a-list-item.a-select__menu-item {
+    height: unset;
     white-space: normal;
     text-indent: unset;
     /* preserve the original 4px padding and add the negated text-indent */

--- a/framework/components/ASelect/types.ts
+++ b/framework/components/ASelect/types.ts
@@ -1,6 +1,6 @@
-import {Override} from "../../types";
-import {AHintsType} from "../AFieldBase/types";
-import {AInputBaseProps} from "../AInputBase/types";
+import type {Override} from "../../types";
+import type {AHintsType} from "../AFieldBase/types";
+import type {AInputBaseProps} from "../AInputBase/types";
 
 export type ASelectItem = string | Record<string, unknown>;
 
@@ -105,6 +105,10 @@ export type ASelectProps<T extends ASelectItem> = Override<
      * Handles the `selected` event.
      */
     onSelected?: (item: T) => void;
+    /**
+     * Sets a default initial value for string array `items`
+     */
+    defaultValue: string;
     /**
      * Sets the text when no option is selected.
      */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] This change has been run and tested against at least 1 typescript application.  (If extensive change, 2 is best)
- [ ] This change passed unit tests in the applications the build was tested against
- [x] The changes are documented in component docs and changelog
- [x] Test have been added or modified, if appropriate
- [ ] Convert component to tsx, if reasonable
  
For new components
- [ ] The component should be in typescript
- [ ] The component should accept a class name as a prop, if appropriate
- [ ] The component should accept a forward ref, if appropriate
- [ ] Add tests in typescript, cypress/tests/*, if reasonable



**Other information**:

Not sure if we want to use this or not, as it's easy enough for the consuming side to map strings to objects. But the component itself supports string arrays


