### PR TITLE
feat(APageAlert): add "AToast" props to types

### DIFF
--- a/framework/components/APageLayout/APageAlert.js
+++ b/framework/components/APageLayout/APageAlert.js
@@ -19,6 +19,11 @@ APageAlert.propTypes = {
    */
   className: PropTypes.string,
 
+  /**
+   * Determines if the alert can be dismissed.
+   */
+  dismissible: PropTypes.bool,
+
   /** Node children */
   children: PropTypes.node
 };

--- a/framework/components/APageLayout/types.ts
+++ b/framework/components/APageLayout/types.ts
@@ -1,6 +1,7 @@
 import {Override} from "../../types";
+import type AToast from "../AToast";
 
-export type APageAlertProps = React.ComponentPropsWithRef<"div">;
+export type APageAlertProps = React.ComponentPropsWithRef<typeof AToast>;
 
 export type APageContainerProps = React.ComponentPropsWithRef<"div">;
 


### PR DESCRIPTION
## Context

Although I fixed the `children` prop issue mentioned in https://github.com/cisco-sbg-ui/magna-react/pull/993, I forgot to add the props that are passed through to the `AToast` component:

![Screenshot 2025-01-14 at 2 59 59 PM](https://github.com/user-attachments/assets/7f6e5355-04fd-494f-9c74-2b4031cc80bb)

## This PR

* Has the `APageAlert` component extend the `AToast` component's props

## Test Plan

N/A